### PR TITLE
feat: Adds mainnet and devnet feature gate for program ids

### DIFF
--- a/assertions/Cargo.toml
+++ b/assertions/Cargo.toml
@@ -6,12 +6,14 @@ description = "Solana program assertion utilities"
 license = "AGPL-3.0"
 
 [dependencies]
-pinocchio = { version = "0.8.1"}
+pinocchio = { version = "0.8.1" }
 pinocchio-system = { version = "0.2.3" }
 pinocchio-pubkey = { version = "0.2.4" }
 
 [features]
-default = []
+default = ["mainnet"]
+devnet = []
+mainnet = []
 
 [lints]
 workspace = true

--- a/assertions/src/lib.rs
+++ b/assertions/src/lib.rs
@@ -9,7 +9,13 @@ use pinocchio::{
 use pinocchio_pubkey::declare_id;
 use pinocchio_system::ID as SYSTEM_ID;
 
-declare_id!("swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC");
+#[cfg(feature = "devnet")]
+const PROGRAM_ID: &str = "swigDk8JezhiAVde8k6NMwxpZfgGm2NNuMe1KYCmUjP";
+#[cfg(not(feature = "devnet"))]
+#[cfg(feature = "mainnet")]
+const PROGRAM_ID: &str = "swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC";
+
+declare_id!(PROGRAM_ID);
 
 #[allow(unused_imports)]
 use std::mem::MaybeUninit;

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -16,7 +16,7 @@ pinocchio-system = { version = "0.2.3" }
 shank = { version = "0.4.2", git = "https://github.com/anagrambuild/shank.git" }
 swig-compact-instructions = { path = "../instructions" }
 swig-state-x = { path = "../state-x" }
-swig-assertions = { path = "../assertions" }
+swig-assertions = { path = "../assertions", features = ["mainnet"] }
 static_assertions = "1.1.0"
 bs58 = "*"
 num_enum = "0.7.3"
@@ -39,6 +39,9 @@ alloy-signer-local = { version = "0.14.0" }
 test-bpf = []
 no-entrypoint = []
 program_scope_test = []
+devnet = ["swig-assertions/devnet"]
+mainnet = ["swig-assertions/mainnet"]
+default = ["mainnet"]
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -27,7 +27,14 @@ use swig_state_x::{
 };
 use util::ProgramScopeCache;
 
-declare_id!("swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC");
+#[cfg(feature = "devnet")]
+const PROGRAM_ID: &str = "swigDk8JezhiAVde8k6NMwxpZfgGm2NNuMe1KYCmUjP";
+#[cfg(not(feature = "devnet"))]
+#[cfg(feature = "mainnet")]
+const PROGRAM_ID: &str = "swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC";
+
+declare_id!(PROGRAM_ID);
+
 const SPL_TOKEN_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 const SPL_TOKEN_2022_ID: Pubkey = pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 const STAKING_ID: Pubkey = pubkey!("Stake11111111111111111111111111111111111111");


### PR DESCRIPTION
By default, will use `mainnet`.

- Mainnet program id: `swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC`
- Devnet program id: `swigDk8JezhiAVde8k6NMwxpZfgGm2NNuMe1KYCmUjP`