### PR TITLE
Update program ids to new deployment addr

### DIFF
--- a/assertions/src/lib.rs
+++ b/assertions/src/lib.rs
@@ -9,7 +9,7 @@ use pinocchio::{
 use pinocchio_pubkey::declare_id;
 use pinocchio_system::ID as SYSTEM_ID;
 
-declare_id!("swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC");
+declare_id!("swigDk8JezhiAVde8k6NMwxpZfgGm2NNuMe1KYCmUjP");
 
 #[allow(unused_imports)]
 use std::mem::MaybeUninit;

--- a/docs/program_diagrams.md
+++ b/docs/program_diagrams.md
@@ -4,7 +4,7 @@
 ┌───────────────────────────────────────────────────────────────────────┐
 │                           SWIG SOLANA PROGRAM                         │
 │                                                                       │
-│   Program ID: swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC             │
+│   Program ID: swigDk8JezhiAVde8k6NMwxpZfgGm2NNuMe1KYCmUjP             │
 └───────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -27,7 +27,7 @@ use swig_state_x::{
 };
 use util::ProgramScopeCache;
 
-declare_id!("swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC");
+declare_id!("swigDk8JezhiAVde8k6NMwxpZfgGm2NNuMe1KYCmUjP");
 const SPL_TOKEN_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 const SPL_TOKEN_2022_ID: Pubkey = pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 const STAKING_ID: Pubkey = pubkey!("Stake11111111111111111111111111111111111111");

--- a/validator.sh
+++ b/validator.sh
@@ -5,5 +5,5 @@ cargo --version
 cargo build-sbf && solana-test-validator \
    --limit-ledger-size 0 \
    --bind-address 0.0.0.0 \
-   --bpf-program Swig111111111111111111111111111111111111111 target/deploy/swig.so  \
+   --bpf-program swigDk8JezhiAVde8k6NMwxpZfgGm2NNuMe1KYCmUjP target/deploy/swig.so  \
     -r


### PR DESCRIPTION
move from `swigNmWhy8RvUYXBKV5TSU8Hh3f4o5EczHouzBzEsLC` to `swigDk8JezhiAVde8k6NMwxpZfgGm2NNuMe1KYCmUjP` for target program id. 

Supersedes #14 after a discussion between myself and @austbot where we made the executive decision to use `swigD...` as the new target program id for both devnet and mainnet to keep things consistent with all other tooling.