### PR TITLE
CLI enhancements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ members = [
   "assertions",
   "no-padding",
   "rust-sdk",
-  "cli"
-  ]
+  "cli",
+  "cli-x",
+]
 
 [workspace.lints.rust]
 unused_imports = "allow"

--- a/cli-x/Cargo.toml
+++ b/cli-x/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "cli-x"
+version = "0.1.0"
+edition = "2021"
+description = "SWIG CLI - A command-line interface for the SWIG wallet"
+authors = ["SWIG Team"]
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.4", features = ["derive"] }
+colored = "2.1"
+console = "0.15"
+dialoguer = "0.11"
+indicatif = "0.17"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+directories = "5.0"
+dirs = "5.0"
+rand = "0.8"
+tokio = { version = "1.0", features = ["full"] }
+bs58 = "0.5.1"
+hex = "0.4.3"
+swig-sdk = { path = "../rust-sdk" }
+secp256k1 = "0.30.0"
+solana-sdk = "2.0"
+
+alloy-primitives = { version = "1.0.0", features = ["k256"] }
+alloy-signer = { version = "0.14.0" }
+alloy-signer-local = { version = "0.14.0" }
+
+[lints]
+workspace = true

--- a/cli-x/README.md
+++ b/cli-x/README.md
@@ -1,0 +1,183 @@
+# SWIG CLI
+
+A command-line interface for interacting with SWIG wallets on Solana.
+
+## Features
+
+- Interactive mode with guided prompts
+- Command mode for scripting and automation
+- Rich terminal output with colors and progress indicators
+- Support for Ed25519 and Secp256k1 authorities
+- Comprehensive wallet management commands
+- Integration with Solana CLI config
+
+## Installation
+
+1. Make sure you have Rust and Cargo installed
+2. Clone the repository
+3. Build the CLI:
+
+```bash
+cargo build --release
+```
+
+4. The binary will be available at `target/release/swig`
+
+## Usage
+
+The CLI can be used in two modes:
+
+### Interactive Mode
+
+Run the CLI in interactive mode:
+
+```bash
+swig -i
+```
+
+This will present a menu-driven interface with the following options:
+
+- Create New Wallet
+- Add Authority
+- Remove Authority
+- View Wallet
+- List Authorities
+- Check Balance
+
+### Command Mode
+
+For scripting and automation, use the command mode:
+
+#### Create a New Wallet
+
+```bash
+swig create --root ed25519 --authority <PUBKEY> [--swig-id <ID>]
+```
+
+#### Add an Authority
+
+```bash
+swig add-authority \
+    --authority-type ed25519 \
+    --authority <PUBKEY> \
+    --swig-id <ID> \
+    --permissions all,sol
+```
+
+#### Remove an Authority
+
+```bash
+swig remove-authority --swig-id <ID> --authority <PUBKEY>
+```
+
+#### View Wallet Details
+
+```bash
+swig view --swig-id <ID>
+```
+
+#### List Authorities
+
+```bash
+swig list-authorities --swig-id <ID>
+```
+
+#### Check Balance
+
+```bash
+swig balance --swig-id <ID>
+```
+
+### Global Options
+
+These options can be used with any command:
+
+- `-c, --config <PATH>` - Path to Solana config file
+- `-k, --keypair <PATH>` - Path to keypair file
+- `-u, --rpc-url <URL>` - RPC URL
+- `-i, --interactive` - Use interactive mode
+
+You must provide either:
+
+1. `--rpc-url` and `--keypair`, or
+2. `--config` pointing to a Solana CLI config file
+
+## Authority Types
+
+The CLI supports multiple authority types:
+
+- `ed25519` - Standard Ed25519 keypairs (recommended)
+- `secp256k1` - Secp256k1 keypairs for Ethereum/Bitcoin compatibility
+- `ed25519-session` - Temporary session-based Ed25519 authorities
+- `secp256k1-session` - Temporary session-based Secp256k1 authorities
+
+## Permissions
+
+When adding authorities, you can specify their permissions:
+
+- `all` - Full access to all operations
+- `sol` - Permission to transfer SOL (with optional limits)
+
+Multiple permissions can be specified using commas:
+
+```bash
+--permissions all,sol
+```
+
+## Examples
+
+1. Create a new wallet with Ed25519 authority:
+
+```bash
+swig create \
+    --root ed25519 \
+    --authority 5KL2xJ6nTxgqxcp5HpZCKPsG9QYhYdqyPKxE8BqPFh1h
+```
+
+2. Add a Secp256k1 authority with SOL transfer permission:
+
+```bash
+swig add-authority \
+    --authority-type secp256k1 \
+    --authority 0x742d35Cc6634C0532925a3b844Bc454e4438f44e \
+    --swig-id my-wallet \
+    --permissions sol
+```
+
+3. View wallet details in interactive mode:
+
+```bash
+swig -i
+# Then select "View Wallet" from the menu
+```
+
+## Development
+
+### Project Structure
+
+```
+cli-x/
+├── src/
+│   └── main.rs    # Main CLI implementation
+├── Cargo.toml     # Dependencies and package info
+└── README.md      # This file
+```
+
+### Adding New Commands
+
+1. Add a new variant to the `Command` enum in `main.rs`
+2. Implement the command's execution logic
+3. Add the command to both interactive and command modes
+4. Update the documentation
+
+### Testing
+
+Run the tests:
+
+```bash
+cargo test
+```
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/cli-x/config-example.json
+++ b/cli-x/config-example.json
@@ -1,0 +1,10 @@
+{
+  "default_authority": {
+    "authority_type": "<authority_type>",
+    "authority": "<authority>",
+    "authority_kp": "<authority_keypair>",
+    "fee_payer": "<fee_payer_keypair>"
+  },
+  "rpc_url": "<rpc_url>"
+}
+

--- a/cli-x/src/commands.rs
+++ b/cli-x/src/commands.rs
@@ -1,0 +1,290 @@
+use alloy_primitives::{Address, B256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use anyhow::{anyhow, Result};
+use colored::*;
+use solana_sdk::{pubkey::Pubkey, signature::Keypair};
+use std::str::FromStr;
+use swig_sdk::{authority::AuthorityType, AuthorityManager, Permission, SwigError, SwigWallet};
+
+use crate::{format_authority, Command, SwigCliContext};
+
+pub fn create_swig_instance(
+    ctx: &mut SwigCliContext,
+    swig_id: [u8; 32],
+    authority_type: AuthorityType,
+    authority: String,
+    authority_kp: String,
+) -> Result<Box<SwigWallet<'static>>> {
+    let (authority_manager, signing_authority) = match authority_type {
+        AuthorityType::Ed25519 => {
+            let authority_kp = Keypair::from_base58_string(&authority_kp);
+            let authority = Pubkey::from_str(&authority)?;
+
+            (AuthorityManager::Ed25519(authority), Some(authority_kp))
+        },
+        AuthorityType::Secp256k1 => {
+            let wallet = LocalSigner::from_str(&authority_kp)?;
+            let eth_pubkey = wallet
+                .credential()
+                .verifying_key()
+                .to_encoded_point(false)
+                .to_bytes();
+
+            let eth_address = Address::from_raw_public_key(&eth_pubkey[1..]);
+
+            let sign_fn = move |payload: &[u8]| -> [u8; 65] {
+                let mut hash = [0u8; 32];
+                hash.copy_from_slice(&payload[..32]);
+                let hash = B256::from(hash);
+                let tsig = wallet
+                    .sign_hash_sync(&hash)
+                    .map_err(|_| SwigError::InvalidSecp256k1)
+                    .unwrap()
+                    .as_bytes();
+                let mut sig = [0u8; 65];
+                sig.copy_from_slice(&tsig);
+                sig
+            };
+
+            (
+                AuthorityManager::Secp256k1(eth_pubkey, Box::new(sign_fn)),
+                None,
+            )
+        },
+        _ => return Err(anyhow!("Unsupported authority type")),
+    };
+
+    // Create a static reference to avoid lifetime issues
+    let payer = Box::new(ctx.payer.insecure_clone());
+    let auth_for_wallet = Box::new(signing_authority.unwrap_or_else(|| ctx.payer.insecure_clone()));
+
+    // Convert to static references
+    let payer_static = Box::leak(payer);
+    let auth_static = Box::leak(auth_for_wallet);
+
+    SwigWallet::new(
+        swig_id,
+        authority_manager,
+        payer_static,
+        auth_static,
+        ctx.rpc_url.clone(),
+    )
+    .map(Box::new)
+    .map_err(|e| anyhow!("Failed to create SWIG wallet: {}", e))
+}
+
+pub fn run_command_mode(ctx: &mut SwigCliContext, cmd: Command) -> Result<()> {
+    match cmd {
+        Command::Create {
+            authority_type,
+            authority,
+            authority_kp,
+            fee_payer,
+            id,
+        } => {
+            let swig_id = id
+                .map(|i| format!("{:0<32}", i))
+                .unwrap_or_else(|| {
+                    format!(
+                        "{:0<32}",
+                        bs58::encode(rand::random::<[u8; 32]>()).into_string()
+                    )
+                })
+                .as_bytes()[..32]
+                .try_into()
+                .unwrap();
+
+            // Set the fee payer from command args or config
+            let fee_payer_str =
+                fee_payer.unwrap_or_else(|| ctx.config.default_authority.fee_payer.clone());
+            ctx.payer = Keypair::from_base58_string(&fee_payer_str);
+
+            let mut wallet = create_swig_instance(
+                ctx,
+                swig_id,
+                parse_authority_type(
+                    authority_type
+                        .unwrap_or_else(|| ctx.config.default_authority.authority_type.clone()),
+                )?,
+                authority.unwrap_or_else(|| ctx.config.default_authority.authority.clone()),
+                authority_kp.unwrap_or_else(|| ctx.config.default_authority.authority_kp.clone()),
+            )?;
+
+            ctx.wallet = Some(wallet);
+
+            Ok(())
+        },
+        Command::AddAuthority {
+            authority_type,
+            authority,
+            authority_kp,
+            fee_payer,
+            id,
+            new_authority,
+            new_authority_type,
+            permissions,
+        } => {
+            let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+
+            // Set the fee payer from command args or config
+            let fee_payer_str =
+                fee_payer.unwrap_or_else(|| ctx.config.default_authority.fee_payer.clone());
+            ctx.payer = Keypair::from_base58_string(&fee_payer_str);
+
+            // Parse permissions
+            if permissions.is_empty() {
+                return Err(anyhow!("Permissions are required"));
+            }
+            let parsed_permissions = permissions
+                .iter()
+                .map(|p| match p.to_lowercase().as_str() {
+                    "all" => Ok(Permission::All),
+                    "sol" => Ok(Permission::Sol {
+                        amount: 1_000_000_000,
+                        recurring: None,
+                    }),
+                    _ => Err(anyhow!("Invalid permission: {}", p)),
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let mut wallet = create_swig_instance(
+                ctx,
+                swig_id,
+                parse_authority_type(
+                    authority_type
+                        .unwrap_or_else(|| ctx.config.default_authority.authority_type.clone()),
+                )?,
+                authority.unwrap_or_else(|| ctx.config.default_authority.authority.clone()),
+                authority_kp.unwrap_or_else(|| ctx.config.default_authority.authority_kp.clone()),
+            )?;
+
+            let new_authority =
+                new_authority.ok_or_else(|| anyhow!("New authority is required"))?;
+            let new_authority_type =
+                new_authority_type.ok_or_else(|| anyhow!("New authority type is required"))?;
+
+            let new_authority_type = parse_authority_type(new_authority_type)?;
+            let authority_bytes = format_authority(&new_authority, &new_authority_type)?;
+
+            wallet.add_authority(new_authority_type, &authority_bytes, parsed_permissions)?;
+
+            println!("Authority added successfully!");
+            Ok(())
+        },
+        Command::RemoveAuthority {
+            authority_type,
+            authority,
+            authority_kp,
+            fee_payer,
+            id,
+            remove_authority,
+        } => {
+            let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+
+            // Set the fee payer from command args or config
+            let fee_payer_str =
+                fee_payer.unwrap_or_else(|| ctx.config.default_authority.fee_payer.clone());
+            ctx.payer = Keypair::from_base58_string(&fee_payer_str);
+
+            let mut wallet = create_swig_instance(
+                ctx,
+                swig_id,
+                parse_authority_type(
+                    authority_type
+                        .unwrap_or_else(|| ctx.config.default_authority.authority_type.clone()),
+                )?,
+                authority.unwrap_or_else(|| ctx.config.default_authority.authority.clone()),
+                authority_kp.unwrap_or_else(|| ctx.config.default_authority.authority_kp.clone()),
+            )?;
+
+            let remove_authority =
+                remove_authority.ok_or_else(|| anyhow!("Remove authority is required"))?;
+            wallet.remove_authority(remove_authority.as_bytes())?;
+            println!("Authority removed successfully!");
+            Ok(())
+        },
+        Command::View {
+            authority_type,
+            authority,
+            authority_kp,
+            id,
+        } => {
+            let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+
+            let wallet = create_swig_instance(
+                ctx,
+                swig_id,
+                parse_authority_type(
+                    authority_type
+                        .unwrap_or_else(|| ctx.config.default_authority.authority_type.clone()),
+                )?,
+                authority.unwrap_or_else(|| ctx.config.default_authority.authority.clone()),
+                authority_kp.unwrap_or_else(|| ctx.config.default_authority.authority_kp.clone()),
+            )?;
+
+            wallet.display_swig()?;
+            Ok(())
+        },
+        Command::GetRoleId {
+            authority_type,
+            authority,
+            authority_kp,
+            id,
+            authority_to_fetch,
+            authority_type_to_fetch,
+        } => {
+            let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+
+            let fetch_authority_type = parse_authority_type(authority_type_to_fetch)?;
+            let fetch_authority_bytes =
+                format_authority(&authority_to_fetch, &fetch_authority_type)?;
+
+            let wallet = create_swig_instance(
+                ctx,
+                swig_id,
+                parse_authority_type(
+                    authority_type
+                        .unwrap_or_else(|| ctx.config.default_authority.authority_type.clone()),
+                )?,
+                authority.unwrap_or_else(|| ctx.config.default_authority.authority.clone()),
+                authority_kp.unwrap_or_else(|| ctx.config.default_authority.authority_kp.clone()),
+            )?;
+
+            let role_id = wallet.get_role_id(&fetch_authority_bytes)?;
+            println!("Role ID: {}", role_id);
+            Ok(())
+        },
+        Command::Balance {
+            authority_type,
+            authority,
+            authority_kp,
+            id,
+        } => {
+            let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+
+            let wallet = create_swig_instance(
+                ctx,
+                swig_id,
+                parse_authority_type(
+                    authority_type
+                        .unwrap_or_else(|| ctx.config.default_authority.authority_type.clone()),
+                )?,
+                authority.unwrap_or_else(|| ctx.config.default_authority.authority.clone()),
+                authority_kp.unwrap_or_else(|| ctx.config.default_authority.authority_kp.clone()),
+            )?;
+
+            let balance = wallet.get_balance()?;
+            println!("Balance: {} SOL", balance as f64 / 1_000_000_000.0);
+            Ok(())
+        },
+    }
+}
+
+pub fn parse_authority_type(authority_type: String) -> Result<AuthorityType> {
+    match authority_type.as_str() {
+        "Ed25519" => Ok(AuthorityType::Ed25519),
+        "Secp256k1" => Ok(AuthorityType::Secp256k1),
+        _ => Err(anyhow!("Invalid authority type: {}", authority_type)),
+    }
+}

--- a/cli-x/src/config.rs
+++ b/cli-x/src/config.rs
@@ -1,0 +1,75 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SigningAuthority {
+    pub authority_type: String,
+    pub authority: String,
+    pub authority_kp: String,
+    pub fee_payer: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SwigConfig {
+    pub default_authority: SigningAuthority,
+    pub rpc_url: Option<String>,
+}
+
+impl Default for SwigConfig {
+    fn default() -> Self {
+        Self {
+            default_authority: SigningAuthority {
+                authority_type: "Ed25519".to_string(),
+                authority: String::new(),
+                authority_kp: String::new(),
+                fee_payer: String::new(),
+            },
+            rpc_url: Some("http://localhost:8899".to_string()),
+        }
+    }
+}
+
+impl SwigConfig {
+    pub fn load(config_dir: &PathBuf) -> Result<Self> {
+        let config_path = config_dir.join("config.json");
+        if !config_path.exists() {
+            return Ok(Self::default());
+        }
+
+        let config_str = fs::read_to_string(config_path)?;
+        serde_json::from_str(&config_str).map_err(|e| anyhow!("Failed to parse config: {}", e))
+    }
+
+    pub fn save(&self, config_dir: &PathBuf) -> Result<()> {
+        let config_path = config_dir.join("config.json");
+        let config_str = serde_json::to_string_pretty(self)?;
+        fs::write(config_path, config_str)?;
+        Ok(())
+    }
+
+    pub fn update_from_cli_args(
+        &mut self,
+        authority_type: Option<String>,
+        authority: Option<String>,
+        authority_kp: Option<String>,
+        fee_payer: Option<String>,
+        rpc_url: Option<String>,
+    ) {
+        if let Some(authority_type) = authority_type {
+            self.default_authority.authority_type = authority_type;
+        }
+        if let Some(authority) = authority {
+            self.default_authority.authority = authority;
+        }
+        if let Some(authority_kp) = authority_kp {
+            self.default_authority.authority_kp = authority_kp;
+        }
+        if let Some(fee_payer) = fee_payer {
+            self.default_authority.fee_payer = fee_payer;
+        }
+        if let Some(rpc_url) = rpc_url {
+            self.rpc_url = Some(rpc_url);
+        }
+    }
+}

--- a/cli-x/src/interactive.rs
+++ b/cli-x/src/interactive.rs
@@ -1,0 +1,550 @@
+use alloy_primitives::{Address, B256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use anyhow::{anyhow, Result};
+use colored::*;
+use dialoguer::{theme::ColorfulTheme, Confirm, Input, Password, Select};
+use solana_sdk::{
+    pubkey::Pubkey, signature::Keypair, signer::Signer, system_instruction::transfer,
+};
+use std::{collections::HashMap, str::FromStr};
+use swig_sdk::{
+    authority::{ed25519::CreateEd25519SessionAuthority, AuthorityType},
+    swig::SwigWithRoles,
+    AuthorityManager, Permission, RecurringConfig, SwigError, SwigWallet,
+};
+
+use crate::SwigCliContext;
+
+pub fn run_interactive_mode(ctx: &mut SwigCliContext) -> Result<()> {
+    println!(
+        "\n{}",
+        "Welcome to SWIG CLI Interactive Mode".bright_blue().bold()
+    );
+
+    loop {
+        let mut actions = if ctx.wallet.is_none() {
+            vec!["Create New Wallet", "Exit"]
+        } else {
+            vec![
+                "Add Authority",
+                "Remove Authority",
+                "View Wallet",
+                "Transfer",
+                "Switch Authority",
+                "Exit",
+            ]
+        };
+
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Choose an action")
+            .items(&actions)
+            .default(0)
+            .interact()?;
+
+        if ctx.wallet.is_none() {
+            match selection {
+                0 => create_wallet_interactive(ctx)?,
+                1 => break,
+                _ => unreachable!(),
+            }
+        } else {
+            match selection {
+                0 => add_authority_interactive(ctx)?,
+                1 => remove_authority_interactive(ctx)?,
+                2 => view_wallet_interactive(ctx)?,
+                3 => transfer_interactive(ctx)?,
+                4 => switch_authority_interactive(ctx)?,
+                5 => break,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn create_wallet_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Creating new SWIG wallet...".bright_blue().bold());
+
+    let use_random_id = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Use random SWIG ID?")
+        .default(true)
+        .interact()?;
+
+    let swig_id = if use_random_id {
+        None
+    } else {
+        Some(
+            Input::<String>::with_theme(&ColorfulTheme::default())
+                .with_prompt("Enter SWIG ID")
+                .interact_text()?,
+        )
+    }
+    .map(|i| format!("{:0<32}", i).as_bytes()[..32].try_into().unwrap())
+    .unwrap_or_else(rand::random);
+
+    println!("SWIG ID: {}", bs58::encode(swig_id).into_string());
+
+    let authority_type = get_authority_type()?;
+
+    let (authority_manager, fee_payer) = match authority_type {
+        AuthorityType::Ed25519 => {
+            let authority_keypair = Password::with_theme(&ColorfulTheme::default())
+                .with_prompt("Enter authority keypair")
+                .interact()?;
+
+            let authority = Keypair::from_base58_string(&authority_keypair);
+            let authority_pubkey = authority.pubkey();
+            println!("Authority public key: {}", authority_pubkey);
+            (
+                AuthorityManager::Ed25519(authority_pubkey),
+                authority.insecure_clone(),
+            )
+        },
+        AuthorityType::Secp256k1 => {
+            let authority_keypair = Password::with_theme(&ColorfulTheme::default())
+                .with_prompt("Enter Secp256k1 authority keypair")
+                .interact()?;
+
+            let wallet = LocalSigner::from_str(&authority_keypair)?;
+
+            let eth_pubkey = wallet
+                .credential()
+                .verifying_key()
+                .to_encoded_point(false)
+                .to_bytes();
+
+            let eth_address = Address::from_raw_public_key(&eth_pubkey[1..]);
+
+            println!("Wallet: {:?}", wallet);
+            println!("Eth pubkey: {:?}", eth_pubkey);
+            println!("Eth address: {:?}", eth_address);
+            let secp_pubkey = wallet.address().to_checksum_buffer(None);
+
+            let sign_fn = move |payload: &[u8]| -> [u8; 65] {
+                let mut hash = [0u8; 32];
+                hash.copy_from_slice(&payload[..32]);
+                let hash = B256::from(hash);
+                let tsig = wallet
+                    .sign_hash_sync(&hash)
+                    .map_err(|_| SwigError::InvalidSecp256k1)
+                    .unwrap()
+                    .as_bytes();
+                let mut sig = [0u8; 65];
+                sig.copy_from_slice(&tsig);
+                sig
+            };
+
+            let fee_payer_kp_str = Password::with_theme(&ColorfulTheme::default())
+                .with_prompt("Enter Fee payer keypair")
+                .interact()?;
+            let fee_payer_keypair = Keypair::from_base58_string(&fee_payer_kp_str);
+
+            (
+                AuthorityManager::Secp256k1(eth_pubkey, Box::new(sign_fn)),
+                fee_payer_keypair,
+            )
+        },
+        _ => todo!(),
+    };
+
+    let fee_payer = Box::leak(Box::new(fee_payer));
+    let wallet = SwigWallet::new(
+        swig_id,
+        authority_manager,
+        fee_payer,
+        fee_payer,
+        "http://localhost:8899".to_string(),
+    )
+    .unwrap();
+
+    wallet.display_swig()?;
+
+    ctx.wallet = Some(Box::new(wallet));
+    ctx.payer = fee_payer.insecure_clone();
+
+    Ok(())
+}
+
+fn add_authority_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Adding new authority...".bright_blue().bold());
+
+    if ctx.wallet.is_none() {
+        return Err(anyhow!(
+            "No wallet loaded. Please create or load a wallet first."
+        ));
+    }
+
+    let authority_type = get_authority_type()?;
+
+    let authority = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter authority public key")
+        .interact_text()?;
+
+    let authority = format_authority(&authority, &authority_type)?;
+
+    let permissions = get_permissions_interactive()?;
+
+    let signature =
+        ctx.wallet
+            .as_mut()
+            .unwrap()
+            .add_authority(authority_type, &authority, permissions);
+
+    if let Ok(signature) = signature {
+        println!("\n{}", "Authority added successfully!".bright_green());
+        println!("Signature: {}", signature);
+    } else {
+        println!("\n{}", "Failed to add authority".bright_red());
+        println!("Error: {}", signature.err().unwrap());
+    }
+
+    Ok(())
+}
+
+fn remove_authority_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Removing authority...".bright_blue().bold());
+
+    if ctx.wallet.is_none() {
+        return Err(anyhow!(
+            "No wallet loaded. Please create or load a wallet first."
+        ));
+    }
+
+    let authorities = get_authorities(ctx)?;
+    println!("\nAvailable authorities:");
+
+    let authority_keys: Vec<String> = authorities.keys().cloned().collect();
+    if authority_keys.is_empty() {
+        return Err(anyhow!("No authorities found to remove"));
+    }
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choose authority to remove")
+        .items(&authority_keys)
+        .default(0)
+        .interact()?;
+
+    let authority = &authority_keys[selection];
+
+    println!("Removing authority: {:?}", authority);
+
+    ctx.wallet
+        .as_mut()
+        .unwrap()
+        .remove_authority(authorities.get(authority).unwrap())?;
+
+    println!("\n{}", "Authority removed successfully!".bright_green());
+    Ok(())
+}
+
+fn switch_authority_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Switching authority...".bright_blue().bold());
+
+    let role_id = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter authority role ID")
+        .interact_text()?;
+
+    let authority_keypair = Password::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter authority keypair")
+        .interact()?;
+
+    let authority_types = vec![
+        "Ed25519 (Recommended for standard usage)",
+        "Secp256k1 (For Ethereum/Bitcoin compatibility)",
+        "Ed25519Session (For temporary session-based auth)",
+        "Secp256k1Session (For temporary session-based auth with Ethereum/Bitcoin)",
+    ];
+
+    let authority_type_idx = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choose authority type")
+        .items(&authority_types)
+        .default(0)
+        .interact()?;
+
+    let authority_type = match authority_type_idx {
+        0 => AuthorityType::Ed25519,
+        1 => AuthorityType::Secp256k1,
+        2 => AuthorityType::Ed25519Session,
+        3 => AuthorityType::Secp256k1Session,
+        _ => unreachable!(),
+    };
+
+    let role_id = u32::from_str(&role_id)?;
+
+    let authority = Keypair::from_base58_string(&authority_keypair);
+    let authority_pubkey = authority.pubkey();
+
+    let authority_manager = match authority_type {
+        AuthorityType::Ed25519 => {
+            let pubkey = authority_pubkey;
+            println!("Authority: {}", authority_pubkey);
+            println!("Authority type: {:?}", authority_type);
+            println!("Authority pubkey: {}", pubkey);
+            AuthorityManager::Ed25519(pubkey)
+        },
+        AuthorityType::Ed25519Session => {
+            let create_session_authority = CreateEd25519SessionAuthority::new(
+                authority_pubkey.to_bytes(),
+                authority_pubkey.to_bytes(),
+                100,
+            );
+            AuthorityManager::Ed25519Session(create_session_authority)
+        },
+        _ => {
+            return Err(anyhow!("Session-based authorities not supported for root"));
+        },
+    };
+
+    // Store the authority keypair in the context
+    ctx.authority = Some(authority.insecure_clone());
+
+    ctx.wallet
+        .as_mut()
+        .unwrap()
+        .switch_authority(role_id, authority_manager)?;
+    Ok(())
+}
+
+fn view_wallet_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Viewing wallet details...".bright_blue().bold());
+
+    if ctx.wallet.is_none() {
+        return Err(anyhow!("Wallet not found"));
+    }
+
+    ctx.wallet.as_ref().unwrap().display_swig()?;
+
+    Ok(())
+}
+
+fn transfer_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Transferring...".bright_blue().bold());
+
+    let recipient = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter recipient address")
+        .interact_text()?;
+
+    let amount = Input::<u64>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter amount")
+        .interact_text()?;
+
+    let transfer_instruction = transfer(
+        &ctx.wallet.as_ref().unwrap().get_swig_account()?,
+        &Pubkey::from_str(&recipient)?,
+        amount,
+    );
+
+    let signature = ctx
+        .wallet
+        .as_mut()
+        .unwrap()
+        .sign(vec![transfer_instruction], None)?;
+
+    println!("Signature: {}", signature);
+
+    Ok(())
+}
+
+pub fn get_authority_type() -> Result<AuthorityType> {
+    let authority_types = vec![
+        "Ed25519 (Recommended for standard usage)",
+        "Secp256k1 (For Ethereum/Bitcoin compatibility)",
+        "Ed25519Session (For temporary session-based auth)",
+        "Secp256k1Session (For temporary session-based auth with Ethereum/Bitcoin)",
+    ];
+
+    let authority_type_idx = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choose authority type")
+        .items(&authority_types)
+        .default(0)
+        .interact()?;
+
+    let authority_type = match authority_type_idx {
+        0 => AuthorityType::Ed25519,
+        1 => AuthorityType::Secp256k1,
+        2 => AuthorityType::Ed25519Session,
+        3 => AuthorityType::Secp256k1Session,
+        _ => unreachable!(),
+    };
+
+    Ok(authority_type)
+}
+
+pub fn get_permissions_interactive() -> Result<Vec<Permission>> {
+    let permission_types = vec![
+        "All (Full access to all operations)",
+        "Manage Authority (Add/remove authorities)",
+        "Token (Token-specific permissions)",
+        "SOL (SOL transfer permissions)",
+        "Program (Program interaction permissions)",
+        "Sub Account (Sub-account management)",
+    ];
+
+    let mut permissions = Vec::new();
+
+    loop {
+        let permission_type_idx = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Choose permission type")
+            .items(&permission_types)
+            .default(0)
+            .interact()?;
+
+        let permission = match permission_type_idx {
+            0 => Permission::All,
+            1 => Permission::ManageAuthority,
+            2 => {
+                // Get token mint address
+                let mint_str: String = Input::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Enter token mint address")
+                    .interact_text()?;
+                let mint = Pubkey::from_str(&mint_str)?;
+
+                // Get amount
+                let amount: u64 = Input::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Enter token amount limit")
+                    .interact_text()?;
+
+                // Check if recurring
+                let is_recurring = Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Make this a recurring limit?")
+                    .default(false)
+                    .interact()?;
+
+                let recurring = if is_recurring {
+                    let window: u64 = Input::with_theme(&ColorfulTheme::default())
+                        .with_prompt("Enter time window in slots")
+                        .interact_text()?;
+                    Some(RecurringConfig::new(window))
+                } else {
+                    None
+                };
+
+                Permission::Token {
+                    mint,
+                    amount,
+                    recurring,
+                }
+            },
+            3 => {
+                // Get SOL amount
+                let amount: u64 = Input::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Enter SOL amount limit (in lamports)")
+                    .interact_text()?;
+
+                // Check if recurring
+                let is_recurring = Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Make this a recurring limit?")
+                    .default(false)
+                    .interact()?;
+
+                let recurring = if is_recurring {
+                    let window: u64 = Input::with_theme(&ColorfulTheme::default())
+                        .with_prompt("Enter time window in slots")
+                        .interact_text()?;
+                    Some(RecurringConfig::new(window))
+                } else {
+                    None
+                };
+
+                Permission::Sol { amount, recurring }
+            },
+            4 => {
+                // Get program ID
+                let program_id_str: String = Input::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Enter program ID")
+                    .interact_text()?;
+                let program_id = Pubkey::from_str(&program_id_str)?;
+
+                Permission::Program { program_id }
+            },
+            5 => {
+                // Get sub-account address
+                let sub_account_str: String = Input::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Enter sub-account address")
+                    .interact_text()?;
+                let sub_account = Pubkey::from_str(&sub_account_str)?;
+
+                Permission::SubAccount { sub_account }
+            },
+            _ => unreachable!(),
+        };
+
+        permissions.push(permission);
+
+        // Ask if user wants to add more permissions
+        let add_more = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Add more permissions?")
+            .default(false)
+            .interact()?;
+
+        if !add_more {
+            break;
+        }
+    }
+
+    Ok(permissions)
+}
+
+pub fn format_authority(authority: &str, authority_type: &AuthorityType) -> Result<Vec<u8>> {
+    match authority_type {
+        AuthorityType::Ed25519 | AuthorityType::Ed25519Session => {
+            let authority = Pubkey::from_str(authority)?;
+            Ok(authority.to_bytes().to_vec())
+        },
+        AuthorityType::Secp256k1 | AuthorityType::Secp256k1Session => {
+            let wallet = LocalSigner::random();
+
+            let secp_pubkey = wallet
+                .credential()
+                .verifying_key()
+                .to_encoded_point(false)
+                .to_bytes();
+
+            println!("Secp256k1 public key: {:?}", wallet.address());
+            Ok(secp_pubkey.as_ref()[1..].to_vec())
+        },
+        _ => Err(anyhow!("Unsupported authority type")),
+    }
+}
+
+pub fn get_authorities(ctx: &mut SwigCliContext) -> Result<HashMap<String, Vec<u8>>> {
+    let swig_pubkey = ctx.wallet.as_ref().unwrap().get_swig_account()?;
+
+    let swig_account = ctx
+        .wallet
+        .as_ref()
+        .unwrap()
+        .rpc_client
+        .get_account(&swig_pubkey)?;
+
+    let swig_data = swig_account.data;
+
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data).unwrap();
+
+    let mut authorities = HashMap::new();
+
+    for i in 0..swig_with_roles.state.role_counter {
+        let role = swig_with_roles
+            .get_role(i)
+            .map_err(|e| SwigError::AuthorityNotFound)?;
+
+        if let Some(role) = role {
+            match role.authority.authority_type() {
+                AuthorityType::Ed25519 | AuthorityType::Ed25519Session => {
+                    let authority = role.authority.identity().unwrap();
+                    let authority = bs58::encode(authority).into_string();
+                    let authority_pubkey = Pubkey::from_str(&authority)?;
+                    authorities.insert(authority, authority_pubkey.to_bytes().to_vec());
+                },
+                AuthorityType::Secp256k1 | AuthorityType::Secp256k1Session => {
+                    // Implementation for Secp256k1 authorities
+                },
+                _ => todo!(),
+            }
+        }
+    }
+
+    Ok(authorities)
+}

--- a/cli-x/src/main.rs
+++ b/cli-x/src/main.rs
@@ -1,0 +1,617 @@
+use alloy_primitives::B256;
+use alloy_signer_local::LocalSigner;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+    time::Duration,
+};
+
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use colored::*;
+use console::Term;
+use dialoguer::{theme::ColorfulTheme, Confirm, Input, Password, Select};
+use directories::BaseDirs;
+use indicatif::{ProgressBar, ProgressStyle};
+use secp256k1::{PublicKey as Secp256k1PublicKey, Secp256k1, SecretKey as Secp256k1SecretKey};
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{read_keypair_file, Keypair, Signer},
+};
+use swig_sdk::{
+    authority::{ed25519::CreateEd25519SessionAuthority, AuthorityType},
+    AuthorityManager, Permission, SwigWallet,
+};
+
+const LOGO: &str = r#"
+   _____ _    _ _____ ______    _____ _      _____ 
+  / ____| |  | |_   _|  ____|  / ____| |    |_   _|
+ | (___ | |  | | | | | |   __ | |    | |      | |  
+  \___ \| |  | | | | |  __ __ | |    | |      | |  
+  ____) | |__| |_| |_| |  |   | |____| |____ _| |_ 
+ |_____/ \____/|_____|_|_____  \_____|______|_____|
+"#;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "swig",
+    about = "SWIG CLI - A command-line interface for the SWIG wallet",
+    version
+)]
+pub struct SwigCli {
+    #[arg(short = 'c', long, help = "Path to Solana config file")]
+    pub config: Option<String>,
+
+    #[arg(short = 'k', long, help = "Path to keypair file")]
+    pub keypair: Option<String>,
+
+    #[arg(short = 'u', long, help = "RPC URL")]
+    pub rpc_url: Option<String>,
+
+    #[arg(short = 'i', long, help = "Use interactive mode")]
+    pub interactive: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum Command {
+    /// Create a new SWIG wallet
+    Create {
+        #[arg(short, long)]
+        authority_type: String,
+        #[arg(short, long)]
+        authority: String,
+        #[arg(short, long)]
+        authority_kp: String,
+        #[arg(short, long = "swig-id")]
+        id: Option<String>,
+    },
+    /// Add a new authority to a wallet
+    AddAuthority {
+        #[arg(short = 't', long)]
+        authority_type: String,
+        #[arg(short, long)]
+        authority: String,
+        #[arg(short, long = "swig-id")]
+        id: String,
+        #[arg(short, long, value_parser, num_args = 1.., value_delimiter = ',')]
+        permissions: Vec<String>,
+    },
+    /// Remove an authority from a wallet
+    RemoveAuthority {
+        #[arg(short, long = "swig-id")]
+        id: String,
+        #[arg(short, long)]
+        authority: String,
+    },
+    /// View wallet details
+    View {
+        #[arg(short, long = "swig-id")]
+        id: String,
+    },
+    /// List all authorities in a wallet
+    ListAuthorities {
+        #[arg(short, long = "swig-id")]
+        id: String,
+    },
+    /// Check wallet balance
+    Balance {
+        #[arg(short, long = "swig-id")]
+        id: String,
+    },
+}
+
+pub struct SwigCliContext {
+    pub payer: Keypair,
+    pub config_dir: PathBuf,
+    pub rpc_url: String,
+    pub authority: Option<Keypair>,
+    pub wallet: Option<Box<SwigWallet<'static>>>,
+}
+
+fn main() -> Result<()> {
+    // Print the logo
+    println!("{}", LOGO.bright_cyan());
+
+    let cli = SwigCli::parse();
+    let mut ctx = setup(&cli)?;
+
+    if cli.interactive {
+        run_interactive_mode(&mut ctx)
+    } else if let Some(ref cmd) = cli.command {
+        run_command_mode(&mut ctx, cmd.clone())
+    } else {
+        println!("Please specify either --interactive or a command");
+        Ok(())
+    }
+}
+
+fn run_interactive_mode(ctx: &mut SwigCliContext) -> Result<()> {
+    println!(
+        "\n{}",
+        "Welcome to SWIG CLI Interactive Mode".bright_blue().bold()
+    );
+
+    loop {
+        let actions = vec![
+            "Create New Wallet",
+            "Add Authority",
+            "Remove Authority",
+            "View Wallet",
+            "List Authorities",
+            "Check Balance",
+            "Exit",
+        ];
+
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Choose an action")
+            .items(&actions)
+            .default(0)
+            .interact()?;
+
+        match selection {
+            0 => create_wallet_interactive(ctx)?,
+            1 => add_authority_interactive(ctx)?,
+            2 => remove_authority_interactive(ctx)?,
+            3 => view_wallet_interactive(ctx)?,
+            4 => list_authorities_interactive(ctx)?,
+            5 => check_balance_interactive(ctx)?,
+            6 => break,
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(())
+}
+
+fn create_wallet_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Creating new SWIG wallet...".bright_blue().bold());
+
+    let authority_types = vec![
+        "Ed25519 (Recommended for standard usage)",
+        "Secp256k1 (For Ethereum/Bitcoin compatibility)",
+        "Ed25519Session (For temporary session-based auth)",
+        "Secp256k1Session (For temporary session-based auth with Ethereum/Bitcoin)",
+    ];
+
+    let authority_type_idx = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choose authority type")
+        .items(&authority_types)
+        .default(0)
+        .interact()?;
+
+    let authority_keypair = Password::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter authority keypair")
+        .interact()?;
+
+    let authority_type = match authority_type_idx {
+        0 => AuthorityType::Ed25519,
+        1 => AuthorityType::Secp256k1,
+        2 => AuthorityType::Ed25519Session,
+        3 => AuthorityType::Secp256k1Session,
+        _ => unreachable!(),
+    };
+
+    let authority = Keypair::from_base58_string(&authority_keypair);
+    let authority_pubkey = authority.pubkey();
+    println!("Authority public key: {}", authority_pubkey);
+
+    let use_random_id = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Use random SWIG ID?")
+        .default(true)
+        .interact()?;
+
+    let id = if use_random_id {
+        None
+    } else {
+        Some(
+            Input::<String>::with_theme(&ColorfulTheme::default())
+                .with_prompt("Enter SWIG ID")
+                .interact_text()?,
+        )
+    };
+
+    execute_create(
+        ctx,
+        authority_type,
+        authority_pubkey.to_string(),
+        authority,
+        id,
+    )?;
+
+    Ok(())
+}
+
+fn add_authority_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Adding new authority...".bright_blue().bold());
+
+    let id = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter SWIG ID")
+        .interact_text()?;
+
+    let authority_types = vec![
+        "Ed25519 (Recommended for standard usage)",
+        "Secp256k1 (For Ethereum/Bitcoin compatibility)",
+        "Ed25519Session (For temporary session-based auth)",
+        "Secp256k1Session (For temporary session-based auth with Ethereum/Bitcoin)",
+    ];
+
+    let authority_type_idx = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choose authority type")
+        .items(&authority_types)
+        .default(0)
+        .interact()?;
+
+    let authority = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter authority public key")
+        .interact_text()?;
+
+    let permissions = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter permissions (comma-separated)")
+        .interact_text()?;
+
+    let permissions = permissions
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect();
+
+    let authority_type = match authority_type_idx {
+        0 => AuthorityType::Ed25519,
+        1 => AuthorityType::Secp256k1,
+        2 => AuthorityType::Ed25519Session,
+        3 => AuthorityType::Secp256k1Session,
+        _ => unreachable!(),
+    };
+
+    execute_add_authority(ctx, authority_type, authority, id, permissions)
+}
+
+fn remove_authority_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Removing authority...".bright_blue().bold());
+
+    let id = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter SWIG ID")
+        .interact_text()?;
+
+    let authority = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter authority to remove")
+        .interact_text()?;
+
+    execute_remove_authority(ctx, id, authority)
+}
+
+fn view_wallet_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Viewing wallet details...".bright_blue().bold());
+
+    if ctx.wallet.is_none() {
+        return Err(anyhow!("Wallet not found"));
+    }
+
+    ctx.wallet.as_ref().unwrap().display_swig()?;
+
+    Ok(())
+}
+
+fn list_authorities_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Listing authorities...".bright_blue().bold());
+
+    let id = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter SWIG ID")
+        .interact_text()?;
+
+    execute_list_authorities(ctx, id)
+}
+
+fn check_balance_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Checking balance...".bright_blue().bold());
+
+    let id = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter SWIG ID")
+        .interact_text()?;
+
+    execute_balance(ctx, id)
+}
+
+fn run_command_mode(ctx: &mut SwigCliContext, cmd: Command) -> Result<()> {
+    match cmd {
+        Command::Create {
+            authority_type,
+            authority,
+            id,
+            authority_kp,
+        } => {
+            let authority_kp = Keypair::from_base58_string(&authority_kp);
+            let wallet = execute_create(
+                ctx,
+                parse_authority_type(authority_type)?,
+                authority,
+                authority_kp,
+                id,
+            )?;
+
+            // Store the wallet in the context
+            Ok(())
+        },
+        Command::AddAuthority {
+            authority_type,
+            authority,
+            id,
+            permissions,
+        } => execute_add_authority(
+            ctx,
+            parse_authority_type(authority_type)?,
+            authority,
+            id,
+            permissions,
+        ),
+        Command::RemoveAuthority { id, authority } => execute_remove_authority(ctx, id, authority),
+        Command::View { id } => execute_view(ctx, id),
+        Command::ListAuthorities { id } => execute_list_authorities(ctx, id),
+        Command::Balance { id } => execute_balance(ctx, id),
+    }
+}
+
+fn parse_authority_type(authority_type: String) -> Result<AuthorityType> {
+    match authority_type.as_str() {
+        "Ed25519" => Ok(AuthorityType::Ed25519),
+        "Secp256k1" => Ok(AuthorityType::Secp256k1),
+        _ => Err(anyhow!("Invalid authority type: {}", authority_type)),
+    }
+}
+
+fn execute_create(
+    ctx: &mut SwigCliContext,
+    authority_type: AuthorityType,
+    authority: String,
+    authority_kp: Keypair,
+    id: Option<String>,
+) -> Result<()> {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_message("Creating SWIG wallet...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    let swig_id = id
+        .map(|i| format!("{:0<32}", i).as_bytes()[..32].try_into().unwrap())
+        .unwrap_or_else(rand::random);
+
+    let authority_manager = match authority_type {
+        AuthorityType::Ed25519 => {
+            let pubkey = Pubkey::from_str(&authority)?;
+            println!("Authority: {}", authority);
+            println!("Authority type: {:?}", authority_type);
+            println!("Authority pubkey: {}", pubkey);
+            AuthorityManager::Ed25519(pubkey)
+        },
+        AuthorityType::Ed25519Session => {
+            let create_session_authority = CreateEd25519SessionAuthority::new(
+                Pubkey::from_str(&authority)?.to_bytes(),
+                Pubkey::from_str(&authority)?.to_bytes(),
+                100,
+            );
+            AuthorityManager::Ed25519Session(create_session_authority)
+        },
+        _ => {
+            spinner.finish_with_message("Error: Session-based authorities not supported for root");
+            return Err(anyhow!("Session-based authorities not supported for root"));
+        },
+    };
+
+    // Store the authority keypair in the context
+    ctx.authority = Some(authority_kp.insecure_clone());
+
+    // Create a static copy of the authority for the wallet
+    let auth_for_wallet = Box::leak(Box::new(authority_kp));
+
+    let wallet = SwigWallet::new(
+        swig_id,
+        authority_manager,
+        auth_for_wallet,
+        auth_for_wallet,
+        ctx.rpc_url.clone(),
+    )?;
+
+    spinner.finish_with_message("SWIG wallet created successfully!");
+    wallet.display_swig()?;
+    ctx.wallet = Some(Box::new(wallet));
+    Ok(())
+}
+
+fn execute_add_authority(
+    ctx: &mut SwigCliContext,
+    authority_type: AuthorityType,
+    authority: String,
+    id: String,
+    permissions: Vec<String>,
+) -> Result<()> {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_message("Adding authority...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+    let authority_manager = match authority_type {
+        AuthorityType::Ed25519 => {
+            let pubkey = Pubkey::from_str(&authority)?;
+            AuthorityManager::Ed25519(pubkey)
+        },
+        AuthorityType::Ed25519Session => {
+            let create_session_authority = CreateEd25519SessionAuthority::new(
+                Pubkey::from_str(&authority)?.to_bytes(),
+                Pubkey::from_str(&authority)?.to_bytes(),
+                100,
+            );
+            AuthorityManager::Ed25519Session(create_session_authority)
+        },
+        _ => {
+            spinner.finish_with_message("Error: Session-based authorities not implemented yet");
+            return Err(anyhow!("Session-based authorities not implemented yet"));
+        },
+    };
+
+    let mut wallet = SwigWallet::new(
+        swig_id,
+        authority_manager,
+        &ctx.payer,
+        &ctx.payer,
+        ctx.rpc_url.clone(),
+    )?;
+
+    // Convert string permissions to Permission enum
+    let parsed_permissions = permissions
+        .iter()
+        .map(|p| match p.to_lowercase().as_str() {
+            "all" => Ok(Permission::All),
+            "sol" => Ok(Permission::Sol {
+                amount: 1_000_000_000, // 1 SOL default
+                recurring: None,
+            }),
+            _ => Err(anyhow!("Invalid permission: {}", p)),
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    wallet.add_authority(
+        authority_type.into(),
+        authority.as_bytes(),
+        parsed_permissions,
+    )?;
+
+    spinner.finish_with_message("Authority added successfully!");
+    Ok(())
+}
+
+fn execute_remove_authority(ctx: &mut SwigCliContext, id: String, authority: String) -> Result<()> {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_message("Removing authority...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+    let authority_pubkey = Pubkey::from_str(&authority)?;
+    let authority_manager = AuthorityManager::Ed25519(authority_pubkey);
+
+    let mut wallet = SwigWallet::new(
+        swig_id,
+        authority_manager,
+        &ctx.payer,
+        &ctx.payer,
+        ctx.rpc_url.clone(),
+    )?;
+
+    wallet.remove_authority(authority.as_bytes())?;
+
+    spinner.finish_with_message("Authority removed successfully!");
+    Ok(())
+}
+
+fn execute_view(ctx: &mut SwigCliContext, id: String) -> Result<()> {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_message("Loading wallet details...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    if ctx.wallet.is_none() {
+        return Err(anyhow!("Wallet not found"));
+    }
+
+    spinner.finish_and_clear();
+
+    ctx.wallet.as_ref().unwrap().display_swig()?;
+
+    Ok(())
+}
+
+fn execute_list_authorities(ctx: &mut SwigCliContext, id: String) -> Result<()> {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_message("Loading authorities...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+    let authority_manager = AuthorityManager::Ed25519(ctx.payer.pubkey());
+
+    let wallet = SwigWallet::new(
+        swig_id,
+        authority_manager,
+        &ctx.payer,
+        &ctx.payer,
+        ctx.rpc_url.clone(),
+    )?;
+
+    spinner.finish_and_clear();
+    wallet.display_swig()?;
+    Ok(())
+}
+
+fn execute_balance(ctx: &mut SwigCliContext, id: String) -> Result<()> {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_message("Fetching balance...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    let swig_id = format!("{:0<32}", id).as_bytes()[..32].try_into().unwrap();
+    let authority_manager = AuthorityManager::Ed25519(ctx.payer.pubkey());
+
+    let wallet = SwigWallet::new(
+        swig_id,
+        authority_manager,
+        &ctx.payer,
+        &ctx.payer,
+        ctx.rpc_url.clone(),
+    )?;
+
+    let balance = wallet.get_balance()?;
+    spinner.finish_with_message(format!("Balance: {} SOL", balance as f64 / 1_000_000_000.0));
+    Ok(())
+}
+
+fn setup(cli: &SwigCli) -> Result<SwigCliContext> {
+    let config_dir = ensure_config_dir()?;
+
+    // Default values
+    let default_rpc_url = "http://localhost:8899".to_string();
+    let default_keypair_path = dirs::home_dir()
+        .map(|mut p| {
+            p.push(".config");
+            p.push("solana");
+            p.push("id.json");
+            p.to_string_lossy().to_string()
+        })
+        .unwrap_or_else(|| "./.config/solana/id.json".to_string());
+
+    let (rpc_url, keypair_path) = match (&cli.rpc_url, &cli.keypair, &cli.config) {
+        (Some(rpc), Some(kp), None) => (rpc.clone(), kp.clone()),
+        (Some(rpc), None, None) => (rpc.clone(), default_keypair_path),
+        (None, Some(kp), None) => (default_rpc_url, kp.clone()),
+        (None, None, None) => (default_rpc_url, default_keypair_path),
+        _ => {
+            return Err(anyhow!(
+                "Please provide either:\n\
+                 1. --rpc-url and/or --keypair\n\
+                 2. --config <path-to-solana-config>"
+            ));
+        },
+    };
+
+    let payer = read_keypair_file(&keypair_path)
+        .map_err(|e| anyhow!("Failed to read keypair file: {}", e))?;
+
+    Ok(SwigCliContext {
+        payer,
+        rpc_url,
+        config_dir,
+        authority: None,
+        wallet: None,
+    })
+}
+
+fn get_config_path() -> PathBuf {
+    if let Some(base_dirs) = BaseDirs::new() {
+        base_dirs.data_dir().join("swig-cli")
+    } else {
+        PathBuf::from(".")
+    }
+}
+
+fn ensure_config_dir() -> std::io::Result<PathBuf> {
+    let config_path = get_config_path();
+    std::fs::create_dir_all(&config_path)?;
+    Ok(config_path)
+}

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -14,14 +14,16 @@ bs58 = "0.5.1"
 hex = "0.4.3"
 thiserror = "2.0.12"
 anyhow = "1.0.75"
+alloy-primitives = { version = "1.0.0", features = ["k256"] }
+alloy-signer = { version = "0.14.0" }
+alloy-signer-local = { version = "0.14.0" }
+secp256k1 = "0.21"
 
 [dev-dependencies]
 test-log = "0.2"
 rand = "0.8"
 litesvm = { git = "https://github.com/litesvm/litesvm" }
-alloy-primitives = { version = "1.0.0", features = ["k256"] }
-alloy-signer = { version = "0.14.0" }
-alloy-signer-local = { version = "0.14.0" }
+
 
 [features]
 rust_sdk_test = []

--- a/rust-sdk/src/error.rs
+++ b/rust-sdk/src/error.rs
@@ -65,6 +65,10 @@ pub enum SwigError {
     /// Transaction compilation failed
     #[error("Transaction compilation failed")]
     TransactionCompilationFailed,
+
+    /// Transaction failed with logs
+    #[error("Transaction failed: {error}\nLogs:\n{}", logs.join("\n"))]
+    TransactionFailedWithLogs { error: String, logs: Vec<String> },
 }
 
 impl From<anyhow::Error> for SwigError {

--- a/rust-sdk/src/lib.rs
+++ b/rust-sdk/src/lib.rs
@@ -7,6 +7,8 @@ pub mod wallet;
 // Re-exports for convenient public API
 pub use error::SwigError;
 pub use instruction_builder::{AuthorityManager, SwigInstructionBuilder};
+
+pub use swig_state_x::authority;
 pub use types::{Permission, RecurringConfig};
 pub use wallet::SwigWallet;
 

--- a/rust-sdk/src/lib.rs
+++ b/rust-sdk/src/lib.rs
@@ -8,7 +8,7 @@ pub mod wallet;
 pub use error::SwigError;
 pub use instruction_builder::{AuthorityManager, SwigInstructionBuilder};
 
-pub use swig_state_x::authority;
+pub use swig_state_x::{authority, swig};
 pub use types::{Permission, RecurringConfig};
 pub use wallet::SwigWallet;
 

--- a/rust-sdk/src/tests/wallet_tests.rs
+++ b/rust-sdk/src/tests/wallet_tests.rs
@@ -242,12 +242,30 @@ mod authority_management_tests {
         let wallet = LocalSigner::random();
         println!("wallet: {:?}", wallet.address());
 
+        let wallet2 = wallet.clone();
         let secp_pubkey = wallet
             .credential()
             .verifying_key()
             .to_encoded_point(false)
             .to_bytes();
 
+        let sec1_bytes = wallet2.credential().verifying_key().to_sec1_bytes();
+        let secp1_pubkey = sec1_bytes.as_ref();
+
+        let authority_hex = hex::encode([&[0x4].as_slice(), secp1_pubkey].concat());
+        //get eth address from public key
+        let mut hasher = solana_sdk::keccak::Hasher::default();
+        hasher.hash(authority_hex.as_bytes());
+        let hash = hasher.result();
+        let address = format!("0x{}", hex::encode(&hash.0[12..32]));
+        println!("address: {:?}", address);
+
+        println!(
+            "\t\tAuthority Public Key: 0x{} address {}",
+            authority_hex, address
+        );
+        println!("secp_pubkey length: {:?}", secp_pubkey);
+        println!("secp1_pubkey length: {:?}", secp1_pubkey);
         // Add secondary authority with SOL permission
         swig_wallet
             .add_authority(

--- a/rust-sdk/src/tests/wallet_tests.rs
+++ b/rust-sdk/src/tests/wallet_tests.rs
@@ -483,4 +483,42 @@ mod transfer_tests {
 
         assert!(swig_wallet.sign(vec![transfer_ix], None).is_err());
     }
+
+    #[test_log::test]
+    fn should_get_role_id() {
+        let (mut litesvm, main_authority) = setup_test_environment();
+        let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+        let authority_2 = Keypair::new();
+        let authority_3 = Keypair::new();
+
+        swig_wallet
+            .add_authority(
+                AuthorityType::Ed25519,
+                &authority_2.pubkey().to_bytes(),
+                vec![Permission::Sol {
+                    amount: 10_000_000_000,
+                    recurring: None,
+                }],
+            )
+            .unwrap();
+
+        swig_wallet
+            .add_authority(
+                AuthorityType::Ed25519,
+                &authority_3.pubkey().to_bytes(),
+                vec![Permission::Sol {
+                    amount: 10_000_000_000,
+                    recurring: None,
+                }],
+            )
+            .unwrap();
+
+        swig_wallet.display_swig().unwrap();
+        let role_id = swig_wallet
+            .get_role_id(&authority_3.pubkey().to_bytes())
+            .unwrap();
+        println!("role_id: {:?}", role_id);
+        assert_eq!(role_id, 2);
+    }
 }

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -196,7 +196,7 @@ impl<'c> SwigWallet<'c> {
             new_authority_type,
             new_authority,
             permissions,
-            None,
+            Some(self.get_current_slot()?),
         )?;
         let msg = v0::Message::try_compile(
             &self.fee_payer.pubkey(),
@@ -236,7 +236,7 @@ impl<'c> SwigWallet<'c> {
         if let Some(authority_id) = authority_id {
             let instruction = self
                 .instruction_builder
-                .remove_authority(authority_id, None)?;
+                .remove_authority(authority_id, Some(self.get_current_slot()?))?;
 
             let msg = v0::Message::try_compile(
                 &self.fee_payer.pubkey(),


### PR DESCRIPTION
CLI has been divided into interactive and command mode. 

1. Interactive will have the context of previous interactions and can be used without repeating yourself. 
2. The command mode can be used to run independently as single command, used for various applications

This change also contains test cases for verifying the Secp bug which was identified.

get Role Id is a new function added to the wallet to get the current role of the authority of the swig wallet