### PR TITLE
Rust SDK sub accounts and program scope

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,6 +76,12 @@ jobs:
           cargo nextest run --config-file nextest.toml --profile ci --all --workspace --no-fail-fast --features=program_scope_test
           mkdir -p target/nextest/reports
           cp target/nextest/ci/output.xml target/nextest/reports/program-scope-tests.xml
+      
+      - name: Run Rust SDK Tests with nextest
+        run: |
+          cargo nextest run --config-file nextest.toml --profile ci --all --workspace --no-fail-fast --features=rust_sdk_test,program_scope_test
+          mkdir -p target/nextest/reports
+          cp target/nextest/ci/output.xml target/nextest/reports/rust-sdk-tests.xml
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,8 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-sdk",
+ "spl-associated-token-account 7.0.0",
+ "spl-token 8.0.0",
  "swig-sdk",
  "tokio",
 ]
@@ -8979,6 +8981,7 @@ dependencies = [
  "litesvm-token",
  "rand 0.8.5",
  "secp256k1 0.21.3",
+ "solana-account-decoder-client-types",
  "solana-client",
  "solana-program",
  "solana-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,10 +1371,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cli-x"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "anyhow",
+ "bs58",
+ "clap 4.5.36",
+ "colored",
+ "console",
+ "dialoguer 0.11.0",
+ "directories 5.0.1",
+ "dirs",
+ "hex",
+ "indicatif",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "solana-sdk",
+ "swig-sdk",
+ "tokio",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "combine"
@@ -1839,6 +1875,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,11 +1910,29 @@ dependencies = [
 
 [[package]]
 name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1876,6 +1943,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3423,74 +3502,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "litesvm"
-version = "0.6.1"
-source = "git+https://github.com/litesvm/litesvm#c572f9091827692bb8776a8f54b82f1d02014e6e"
-dependencies = [
- "ansi_term",
- "bincode",
- "indexmap 2.9.0",
- "itertools 0.14.0",
- "log",
- "solana-account",
- "solana-address-lookup-table-interface",
- "solana-bpf-loader-program",
- "solana-builtins",
- "solana-clock",
- "solana-compute-budget",
- "solana-compute-budget-instruction",
- "solana-config-program",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-feature-set",
- "solana-fee",
- "solana-fee-structure",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-keypair",
- "solana-last-restart-slot",
- "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-log-collector",
- "solana-measure",
- "solana-message",
- "solana-native-token",
- "solana-nonce",
- "solana-nonce-account",
- "solana-precompiles",
- "solana-program-error",
- "solana-program-runtime",
- "solana-pubkey",
- "solana-rent",
- "solana-reserved-account-keys",
- "solana-sdk-ids",
- "solana-sha256-hasher",
- "solana-signature",
- "solana-signer",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-svm-transaction",
- "solana-system-interface",
- "solana-system-program",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-timings",
- "solana-transaction",
- "solana-transaction-context",
- "solana-transaction-error",
- "solana-vote-program",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "litesvm-token"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e86e6be8c00c17755cbcdef6e35f18051725239e0e6eba61a021d84378693df"
 dependencies = [
- "litesvm 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "litesvm",
  "smallvec",
  "solana-keypair",
  "solana-program-pack",
@@ -3500,7 +3517,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "spl-associated-token-account-client",
- "spl-token",
+ "spl-token 7.0.0",
 ]
 
 [[package]]
@@ -5106,13 +5123,31 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
+dependencies = [
+ "secp256k1-sys 0.4.2",
+]
+
+[[package]]
+name = "secp256k1"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -5552,10 +5587,10 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-sysvar",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 7.0.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
  "thiserror 2.0.12",
  "zstd",
 ]
@@ -7013,7 +7048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e71f9dfc6f2a5df04c3fed2b90b0fbf0da3939f3383a9bf24a5c0bcf994f2b10"
 dependencies = [
  "console",
- "dialoguer",
+ "dialoguer 0.10.4",
  "hidapi",
  "log",
  "num-derive",
@@ -7898,12 +7933,12 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
- "spl-associated-token-account",
+ "spl-associated-token-account 6.0.0",
  "spl-memo",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 7.0.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
  "thiserror 2.0.12",
 ]
 
@@ -8170,9 +8205,25 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-associated-token-account-client",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 6.0.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-associated-token-account"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae179d4a26b3c7a20c839898e6aed84cb4477adf108a366c95532f058aea041b"
+dependencies = [
+ "borsh 1.5.7",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-associated-token-account-client",
+ "spl-token 8.0.0",
+ "spl-token-2022 8.0.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8231,7 +8282,30 @@ dependencies = [
  "solana-program",
  "solana-zk-sdk",
  "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-extraction 0.2.1",
+]
+
+[[package]]
+name = "spl-elgamal-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
+dependencies = [
+ "bytemuck",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-zk-sdk",
+ "spl-pod",
+ "spl-token-confidential-transfer-proof-extraction 0.3.0",
 ]
 
 [[package]]
@@ -8277,8 +8351,23 @@ dependencies = [
  "num-derive",
  "num-traits",
  "solana-program",
- "spl-program-error-derive",
+ "spl-program-error-derive 0.4.1",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "solana-decode-error",
+ "solana-msg",
+ "solana-program-error",
+ "spl-program-error-derive 0.5.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8286,6 +8375,18 @@ name = "spl-program-error-derive"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d375dd76c517836353e093c2dbb490938ff72821ab568b545fd30ab3256b3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.8",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8310,9 +8411,31 @@ dependencies = [
  "solana-pubkey",
  "spl-discriminator",
  "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
+ "spl-program-error 0.6.0",
+ "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error 0.7.0",
+ "spl-type-length-value 0.8.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8331,6 +8454,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053067c6a82c705004f91dae058b11b4780407e9ccd6799dc9e7d0fab5f242da"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sysvar",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "spl-token-2022"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8344,17 +8495,17 @@ dependencies = [
  "solana-program",
  "solana-security-txt",
  "solana-zk-sdk",
- "spl-elgamal-registry",
+ "spl-elgamal-registry 0.1.1",
  "spl-memo",
  "spl-pod",
- "spl-token",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
- "spl-token-confidential-transfer-proof-extraction",
+ "spl-token 7.0.0",
+ "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1",
+ "spl-token-confidential-transfer-proof-extraction 0.2.1",
  "spl-token-confidential-transfer-proof-generation 0.2.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "spl-type-length-value",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
 ]
 
@@ -8372,17 +8523,61 @@ dependencies = [
  "solana-program",
  "solana-security-txt",
  "solana-zk-sdk",
- "spl-elgamal-registry",
+ "spl-elgamal-registry 0.1.1",
  "spl-memo",
  "spl-pod",
- "spl-token",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
- "spl-token-confidential-transfer-proof-extraction",
+ "spl-token 7.0.0",
+ "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1",
+ "spl-token-confidential-transfer-proof-extraction 0.2.1",
  "spl-token-confidential-transfer-proof-generation 0.3.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "spl-type-length-value",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "spl-type-length-value 0.7.0",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-clock",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-native-token",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-security-txt",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-zk-sdk",
+ "spl-elgamal-registry 0.2.0",
+ "spl-memo",
+ "spl-pod",
+ "spl-token 8.0.0",
+ "spl-token-confidential-transfer-ciphertext-arithmetic 0.3.0",
+ "spl-token-confidential-transfer-proof-extraction 0.3.0",
+ "spl-token-confidential-transfer-proof-generation 0.4.0",
+ "spl-token-group-interface 0.6.0",
+ "spl-token-metadata-interface 0.7.0",
+ "spl-transfer-hook-interface 0.10.0",
+ "spl-type-length-value 0.8.0",
  "thiserror 2.0.12",
 ]
 
@@ -8399,6 +8594,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-confidential-transfer-ciphertext-arithmetic"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ab20faf7b5edaa79acd240e0f21d5a2ef936aa99ed98f698573a2825b299c4"
+dependencies = [
+ "base64 0.22.1",
+ "bytemuck",
+ "solana-curve25519",
+ "solana-zk-sdk",
+]
+
+[[package]]
 name = "spl-token-confidential-transfer-proof-extraction"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8407,6 +8614,26 @@ dependencies = [
  "bytemuck",
  "solana-curve25519",
  "solana-program",
+ "solana-zk-sdk",
+ "spl-pod",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-extraction"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
+dependencies = [
+ "bytemuck",
+ "solana-account-info",
+ "solana-curve25519",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sdk-ids",
  "solana-zk-sdk",
  "spl-pod",
  "thiserror 2.0.12",
@@ -8435,6 +8662,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-confidential-transfer-proof-generation"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "solana-zk-sdk",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "spl-token-group-interface"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8454,6 +8692,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-group-interface"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5597b4cd76f85ce7cd206045b7dc22da8c25516573d42d267c8d1fd128db5129"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "spl-token-metadata-interface"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8470,8 +8727,29 @@ dependencies = [
  "solana-pubkey",
  "spl-discriminator",
  "spl-pod",
- "spl-type-length-value",
+ "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304d6e06f0de0c13a621464b1fd5d4b1bebf60d15ca71a44d3839958e0da16ee"
+dependencies = [
+ "borsh 1.5.7",
+ "num-derive",
+ "num-traits",
+ "solana-borsh",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-type-length-value 0.8.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8493,10 +8771,35 @@ dependencies = [
  "solana-pubkey",
  "spl-discriminator",
  "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
- "spl-type-length-value",
+ "spl-program-error 0.6.0",
+ "spl-tlv-account-resolution 0.9.0",
+ "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error 0.7.0",
+ "spl-tlv-account-resolution 0.10.0",
+ "spl-type-length-value 0.8.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8515,6 +8818,24 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d417eb548214fa822d93f84444024b4e57c13ed6719d4dcc68eec24fb481e9f5"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-decode-error",
+ "solana-msg",
+ "solana-program-error",
+ "spl-discriminator",
+ "spl-pod",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8559,7 +8880,7 @@ dependencies = [
  "bs58",
  "bytemuck",
  "ecdsa",
- "litesvm 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "litesvm",
  "litesvm-token",
  "no-padding",
  "num_enum",
@@ -8600,13 +8921,13 @@ dependencies = [
  "borsh 1.5.7",
  "bs58",
  "clap 4.5.36",
- "directories",
+ "directories 6.0.0",
  "hex",
  "jupiter-swap-api-client",
  "libsecp256k1 0.7.2",
  "macro_rules_attribute",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "solana-account-decoder-client-types",
@@ -8615,8 +8936,8 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk",
  "solana-transaction-status",
- "spl-associated-token-account",
- "spl-token",
+ "spl-associated-token-account 6.0.0",
+ "spl-token 7.0.0",
  "swig-interface",
  "swig-state-x",
  "tokio",
@@ -8654,11 +8975,15 @@ dependencies = [
  "anyhow",
  "bs58",
  "hex",
- "litesvm 0.6.1 (git+https://github.com/litesvm/litesvm)",
+ "litesvm",
+ "litesvm-token",
  "rand 0.8.5",
+ "secp256k1 0.21.3",
  "solana-client",
  "solana-program",
  "solana-sdk",
+ "spl-associated-token-account 7.0.0",
+ "spl-token 8.0.0",
  "swig-interface",
  "swig-state-x",
  "test-log",

--- a/cli-x/Cargo.toml
+++ b/cli-x/Cargo.toml
@@ -28,6 +28,8 @@ solana-sdk = "2.0"
 alloy-primitives = { version = "1.0.0", features = ["k256"] }
 alloy-signer = { version = "0.14.0" }
 alloy-signer-local = { version = "0.14.0" }
+spl-token = "8.0.0"
+spl-associated-token-account = "7.0.0"
 
 [lints]
 workspace = true

--- a/cli-x/src/commands.rs
+++ b/cli-x/src/commands.rs
@@ -127,7 +127,7 @@ pub fn parse_permission_from_json(permission_json: &Value) -> Result<Permission>
                 .as_str()
                 .ok_or_else(|| anyhow!("Sub-account is required for sub-account permission"))?;
             Ok(Permission::SubAccount {
-                sub_account: Pubkey::from_str(sub_account)?,
+                sub_account: sub_account.as_bytes().try_into().unwrap(),
             })
         },
         Some(unknown) => Err(anyhow!("Invalid permission type: {}", unknown)),

--- a/cli-x/src/commands.rs
+++ b/cli-x/src/commands.rs
@@ -3,9 +3,12 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::LocalSigner;
 use anyhow::{anyhow, Result};
 use colored::*;
+use serde_json::Value;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
 use std::str::FromStr;
-use swig_sdk::{authority::AuthorityType, AuthorityManager, Permission, SwigError, SwigWallet};
+use swig_sdk::{
+    authority::AuthorityType, AuthorityManager, Permission, RecurringConfig, SwigError, SwigWallet,
+};
 
 use crate::{format_authority, Command, SwigCliContext};
 
@@ -74,6 +77,64 @@ pub fn create_swig_instance(
     .map_err(|e| anyhow!("Failed to create SWIG wallet: {}", e))
 }
 
+pub fn parse_permission_from_json(permission_json: &Value) -> Result<Permission> {
+    match permission_json["type"].as_str() {
+        Some("all") => Ok(Permission::All),
+        Some("sol") => {
+            let amount = permission_json["amount"].as_u64().unwrap_or(1_000_000_000);
+            let recurring = if let Some(recurring) = permission_json.get("recurring") {
+                let window = recurring["window"].as_u64().unwrap_or(86400);
+                Some(swig_sdk::RecurringConfig::new(window))
+            } else {
+                None
+            };
+            Ok(Permission::Sol { amount, recurring })
+        },
+        Some("manageAuthority") => Ok(Permission::ManageAuthority),
+        Some("program") => {
+            let program_id = permission_json["programId"]
+                .as_str()
+                .ok_or_else(|| anyhow!("Program ID is required for program permission"))?;
+            Ok(Permission::Program {
+                program_id: Pubkey::from_str(program_id)?,
+            })
+        },
+        Some("programScope") => {
+            let program_id = permission_json["programId"]
+                .as_str()
+                .ok_or_else(|| anyhow!("Program ID is required for program scope permission"))?;
+            let target_account = permission_json["targetAccount"].as_str().ok_or_else(|| {
+                anyhow!("Target account is required for program scope permission")
+            })?;
+            let numeric_type = permission_json["numericType"].as_u64().unwrap_or(0);
+            let limit = permission_json["limit"].as_u64();
+            let window = permission_json["window"].as_u64();
+            let balance_field_start = permission_json["balanceFieldStart"].as_u64();
+            let balance_field_end = permission_json["balanceFieldEnd"].as_u64();
+
+            Ok(Permission::ProgramScope {
+                program_id: Pubkey::from_str(program_id)?,
+                target_account: Pubkey::from_str(target_account)?,
+                numeric_type,
+                limit,
+                window,
+                balance_field_start,
+                balance_field_end,
+            })
+        },
+        Some("subAccount") => {
+            let sub_account = permission_json["subAccount"]
+                .as_str()
+                .ok_or_else(|| anyhow!("Sub-account is required for sub-account permission"))?;
+            Ok(Permission::SubAccount {
+                sub_account: Pubkey::from_str(sub_account)?,
+            })
+        },
+        Some(unknown) => Err(anyhow!("Invalid permission type: {}", unknown)),
+        None => Err(anyhow!("Permission type is required")),
+    }
+}
+
 pub fn run_command_mode(ctx: &mut SwigCliContext, cmd: Command) -> Result<()> {
     match cmd {
         Command::Create {
@@ -132,19 +193,17 @@ pub fn run_command_mode(ctx: &mut SwigCliContext, cmd: Command) -> Result<()> {
                 fee_payer.unwrap_or_else(|| ctx.config.default_authority.fee_payer.clone());
             ctx.payer = Keypair::from_base58_string(&fee_payer_str);
 
-            // Parse permissions
+            // Parse permissions from JSON
             if permissions.is_empty() {
                 return Err(anyhow!("Permissions are required"));
             }
+
             let parsed_permissions = permissions
                 .iter()
-                .map(|p| match p.to_lowercase().as_str() {
-                    "all" => Ok(Permission::All),
-                    "sol" => Ok(Permission::Sol {
-                        amount: 1_000_000_000,
-                        recurring: None,
-                    }),
-                    _ => Err(anyhow!("Invalid permission: {}", p)),
+                .map(|p| {
+                    let permission_value: Value = serde_json::from_str(p)
+                        .map_err(|e| anyhow!("Invalid permission JSON: {}", e))?;
+                    parse_permission_from_json(&permission_value)
                 })
                 .collect::<Result<Vec<_>>>()?;
 

--- a/cli-x/src/interactive.rs
+++ b/cli-x/src/interactive.rs
@@ -5,7 +5,10 @@ use anyhow::{anyhow, Result};
 use colored::*;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Password, Select};
 use solana_sdk::{
-    pubkey::Pubkey, signature::Keypair, signer::Signer, system_instruction::transfer,
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    system_instruction::{self, transfer},
 };
 use std::{collections::HashMap, str::FromStr};
 use swig_sdk::{
@@ -32,6 +35,7 @@ pub fn run_interactive_mode(ctx: &mut SwigCliContext) -> Result<()> {
                 "View Wallet",
                 "Transfer",
                 "Switch Authority",
+                "Sub Accounts",
                 "Exit",
             ]
         };
@@ -55,7 +59,8 @@ pub fn run_interactive_mode(ctx: &mut SwigCliContext) -> Result<()> {
                 2 => view_wallet_interactive(ctx)?,
                 3 => transfer_interactive(ctx)?,
                 4 => switch_authority_interactive(ctx)?,
-                5 => break,
+                5 => sub_accounts_interactive(ctx)?,
+                6 => break,
                 _ => unreachable!(),
             }
         }
@@ -246,10 +251,6 @@ fn switch_authority_interactive(ctx: &mut SwigCliContext) -> Result<()> {
         .with_prompt("Enter authority role ID")
         .interact_text()?;
 
-    let authority_keypair = Password::with_theme(&ColorfulTheme::default())
-        .with_prompt("Enter authority keypair")
-        .interact()?;
-
     let authority_types = vec![
         "Ed25519 (Recommended for standard usage)",
         "Secp256k1 (For Ethereum/Bitcoin compatibility)",
@@ -270,6 +271,10 @@ fn switch_authority_interactive(ctx: &mut SwigCliContext) -> Result<()> {
         3 => AuthorityType::Secp256k1Session,
         _ => unreachable!(),
     };
+
+    let authority_keypair = Password::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter authority keypair")
+        .interact()?;
 
     let role_id = u32::from_str(&role_id)?;
 
@@ -511,16 +516,8 @@ pub fn get_permissions_interactive() -> Result<Vec<Permission>> {
                     balance_field_end: Some(72),   // Fixed for SPL token accounts
                 }
             },
-            6 => {
-                // Get sub-account address
-                let sub_account_str: String = Input::with_theme(&ColorfulTheme::default())
-                    .with_prompt("Enter sub-account address")
-                    .interact_text()?;
-                let sub_account = Pubkey::from_str(&sub_account_str)?;
-
-                Permission::SubAccount {
-                    sub_account: sub_account.to_bytes(),
-                }
+            6 => Permission::SubAccount {
+                sub_account: [0; 32],
             },
             _ => unreachable!(),
         };
@@ -539,6 +536,116 @@ pub fn get_permissions_interactive() -> Result<Vec<Permission>> {
     }
 
     Ok(permissions)
+}
+
+pub fn sub_accounts_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Sub Accounts...".bright_blue().bold());
+
+    let actions = vec![
+        "Create sub-account",
+        "Transfer from sub-account",
+        "Toggle sub-account",
+        "Withdraw from sub-account to Swig wallet",
+        "Exit",
+    ];
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choose an action")
+        .items(&actions)
+        .default(0)
+        .interact()?;
+
+    match selection {
+        0 => create_sub_account_interactive(ctx)?,
+        1 => transfer_from_sub_account_interactive(ctx)?,
+        2 => toggle_sub_account_interactive(ctx)?,
+        3 => withdraw_from_sub_account_interactive(ctx)?,
+        _ => unreachable!(),
+    }
+    Ok(())
+}
+
+fn create_sub_account_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Checking for sub-account...".bright_blue().bold());
+
+    let sub_account = ctx.wallet.as_mut().unwrap().get_sub_account()?;
+    if let Some(sub_account) = sub_account {
+        println!("Sub-account already exists: {}", sub_account);
+    } else {
+        println!("Sub-account does not exist, creating...");
+        let signature = ctx.wallet.as_mut().unwrap().create_sub_account()?;
+        println!("Sub-account created: {}", signature);
+    }
+
+    Ok(())
+}
+
+fn transfer_from_sub_account_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!(
+        "\n{}",
+        "Transferring from sub-account...".bright_blue().bold()
+    );
+    let recipient = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter recipient address")
+        .interact_text()?;
+    let recipient = Pubkey::from_str(&recipient)?;
+    let amount = Input::<u64>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter amount")
+        .interact_text()?;
+    let sub_account = ctx.wallet.as_mut().unwrap().get_sub_account()?;
+    if let Some(sub_account) = sub_account {
+        let transfer_ix = system_instruction::transfer(&sub_account, &recipient, amount);
+
+        let signature = ctx
+            .wallet
+            .as_mut()
+            .unwrap()
+            .sign_with_sub_account(vec![transfer_ix], None)
+            .unwrap();
+
+        println!("Signature: {}", signature);
+    } else {
+        println!("Sub-account does not exist!");
+    }
+
+    Ok(())
+}
+
+pub fn withdraw_from_sub_account_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!(
+        "\n{}",
+        "Withdrawing from sub-account...".bright_blue().bold()
+    );
+
+    let sub_account = Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter Sub account address")
+        .interact_text()?;
+    let sub_account = Pubkey::from_str(&sub_account)?;
+
+    let amount = Input::<u64>::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter amount")
+        .interact_text()?;
+
+    ctx.wallet
+        .as_mut()
+        .unwrap()
+        .withdraw_from_sub_account(sub_account, amount)?;
+
+    Ok(())
+}
+
+fn toggle_sub_account_interactive(ctx: &mut SwigCliContext) -> Result<()> {
+    println!("\n{}", "Toggling sub-account...".bright_blue().bold());
+
+    let sub_account = ctx.wallet.as_mut().unwrap().get_sub_account()?;
+    if let Some(sub_account) = sub_account {
+        ctx.wallet
+            .as_mut()
+            .unwrap()
+            .toggle_sub_account(sub_account, true)?;
+    }
+
+    Ok(())
 }
 
 pub fn format_authority(authority: &str, authority_type: &AuthorityType) -> Result<Vec<u8>> {

--- a/cli-x/src/interactive.rs
+++ b/cli-x/src/interactive.rs
@@ -518,7 +518,9 @@ pub fn get_permissions_interactive() -> Result<Vec<Permission>> {
                     .interact_text()?;
                 let sub_account = Pubkey::from_str(&sub_account_str)?;
 
-                Permission::SubAccount { sub_account }
+                Permission::SubAccount {
+                    sub_account: sub_account.to_bytes(),
+                }
             },
             _ => unreachable!(),
         };

--- a/cli-x/src/interactive.rs
+++ b/cli-x/src/interactive.rs
@@ -303,7 +303,7 @@ fn switch_authority_interactive(ctx: &mut SwigCliContext) -> Result<()> {
     ctx.wallet
         .as_mut()
         .unwrap()
-        .switch_authority(role_id, authority_manager)?;
+        .switch_authority(role_id, authority_manager, None)?;
     Ok(())
 }
 

--- a/cli-x/src/main.rs
+++ b/cli-x/src/main.rs
@@ -170,6 +170,60 @@ pub enum Command {
         #[arg(short, long)]
         authority_type_to_fetch: String,
     },
+    /// Create a sub-account for the wallet
+    CreateSubAccount {
+        #[arg(short, long)]
+        authority_type: Option<String>,
+        #[arg(short, long)]
+        authority: Option<String>,
+        #[arg(short, long)]
+        authority_kp: Option<String>,
+        #[arg(short, long = "swig-id")]
+        id: String,
+    },
+    /// Transfer from a sub-account
+    TransferFromSubAccount {
+        #[arg(short, long)]
+        authority_type: Option<String>,
+        #[arg(short, long)]
+        authority: Option<String>,
+        #[arg(short, long)]
+        authority_kp: Option<String>,
+        #[arg(short, long = "swig-id")]
+        id: String,
+        #[arg(short, long)]
+        recipient: String,
+        #[arg(short, long)]
+        amount: u64,
+    },
+    /// Toggle a sub-account
+    ToggleSubAccount {
+        #[arg(short, long)]
+        authority_type: Option<String>,
+        #[arg(short, long)]
+        authority: Option<String>,
+        #[arg(short, long)]
+        authority_kp: Option<String>,
+        #[arg(short, long = "swig-id")]
+        id: String,
+        #[arg(short, long)]
+        enabled: bool,
+    },
+    /// Withdraw from a sub-account to the SWIG wallet
+    WithdrawFromSubAccount {
+        #[arg(short, long)]
+        authority_type: Option<String>,
+        #[arg(short, long)]
+        authority: Option<String>,
+        #[arg(short, long)]
+        authority_kp: Option<String>,
+        #[arg(short, long = "swig-id")]
+        id: String,
+        #[arg(short, long)]
+        sub_account: String,
+        #[arg(short, long)]
+        amount: u64,
+    },
 }
 
 pub struct SwigCliContext {

--- a/cli-x/src/main.rs
+++ b/cli-x/src/main.rs
@@ -412,7 +412,7 @@ fn get_permissions_interactive() -> Result<Vec<Permission>> {
                 let sub_account = Pubkey::from_str(&sub_account_str)?;
 
                 Permission::SubAccount {
-                    sub_account: sub_account.to_bytes(),
+                    sub_account: [0; 32],
                 }
             },
             _ => unreachable!(),

--- a/cli-x/src/main.rs
+++ b/cli-x/src/main.rs
@@ -411,7 +411,9 @@ fn get_permissions_interactive() -> Result<Vec<Permission>> {
                     .interact_text()?;
                 let sub_account = Pubkey::from_str(&sub_account_str)?;
 
-                Permission::SubAccount { sub_account }
+                Permission::SubAccount {
+                    sub_account: sub_account.to_bytes(),
+                }
             },
             _ => unreachable!(),
         };

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -19,6 +19,8 @@ alloy-signer = { version = "0.14.0" }
 alloy-signer-local = { version = "0.14.0" }
 secp256k1 = "0.21"
 litesvm-token = "0.6.1"
+spl-associated-token-account = "7.0.0"
+spl-token = "8.0.0"
 
 [dev-dependencies]
 test-log = "0.2"

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -18,11 +18,12 @@ alloy-primitives = { version = "1.0.0", features = ["k256"] }
 alloy-signer = { version = "0.14.0" }
 alloy-signer-local = { version = "0.14.0" }
 secp256k1 = "0.21"
+litesvm-token = "0.6.1"
 
 [dev-dependencies]
 test-log = "0.2"
 rand = "0.8"
-litesvm = { git = "https://github.com/litesvm/litesvm" }
+litesvm = { version = "0.6.1" }
 
 
 [features]

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -21,6 +21,7 @@ secp256k1 = "0.21"
 litesvm-token = "0.6.1"
 spl-associated-token-account = "7.0.0"
 spl-token = "8.0.0"
+solana-account-decoder-client-types = "2.0"
 
 [dev-dependencies]
 test-log = "0.2"

--- a/rust-sdk/src/error.rs
+++ b/rust-sdk/src/error.rs
@@ -69,6 +69,10 @@ pub enum SwigError {
     /// Transaction failed with logs
     #[error("Transaction failed: {error}\nLogs:\n{}", logs.join("\n"))]
     TransactionFailedWithLogs { error: String, logs: Vec<String> },
+
+    /// Invalid program scope
+    #[error("Invalid program scope")]
+    InvalidProgramScope,
 }
 
 impl From<anyhow::Error> for SwigError {

--- a/rust-sdk/src/error.rs
+++ b/rust-sdk/src/error.rs
@@ -43,8 +43,8 @@ pub enum SwigError {
     InvalidSecp256k1,
 
     /// Transaction error
-    #[error("Transaction error")]
-    TransactionError,
+    #[error("Transaction error: {0}")]
+    TransactionError(String),
 
     /// Current slot not set
     #[error("Current slot not set")]
@@ -89,7 +89,7 @@ impl From<solana_sdk::message::CompileError> for SwigError {
 
 impl From<solana_sdk::signature::SignerError> for SwigError {
     fn from(error: solana_sdk::signature::SignerError) -> Self {
-        SwigError::TransactionError
+        SwigError::TransactionError(error.to_string())
     }
 }
 

--- a/rust-sdk/src/instruction_builder.rs
+++ b/rust-sdk/src/instruction_builder.rs
@@ -518,6 +518,15 @@ impl SwigInstructionBuilder {
         Ok(self.swig_account)
     }
 
+    /// Returns the swig id
+    ///
+    /// # Returns
+    ///
+    /// Returns the swig id as a `[u8; 32]`
+    pub fn get_swig_id(&self) -> &[u8; 32] {
+        &self.swig_id
+    }
+
     /// Derives the Swig account public key from an ID
     ///
     /// # Arguments

--- a/rust-sdk/src/instruction_builder.rs
+++ b/rust-sdk/src/instruction_builder.rs
@@ -1,14 +1,16 @@
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use swig_interface::{
     program_id, AddAuthorityInstruction, AuthorityConfig, ClientAction, CreateInstruction,
-    CreateSessionInstruction, RemoveAuthorityInstruction, SignInstruction,
+    CreateSessionInstruction, CreateSubAccountInstruction, RemoveAuthorityInstruction,
+    SignInstruction, SubAccountSignInstruction, ToggleSubAccountInstruction,
+    WithdrawFromSubAccountInstruction,
 };
 use swig_state_x::{
     authority::{
         ed25519::CreateEd25519SessionAuthority, secp256k1::CreateSecp256k1SessionAuthority,
         AuthorityType,
     },
-    swig::swig_account_seeds,
+    swig::{sub_account_seeds, swig_account_seeds},
     IntoBytes,
 };
 
@@ -570,6 +572,266 @@ impl SwigInstructionBuilder {
     pub fn switch_payer(&mut self, payer: Pubkey) -> Result<(), SwigError> {
         self.payer = payer;
         Ok(())
+    }
+
+    /// Creates a Subaccount for the Swig account
+    ///
+    /// # Arguments
+    ///
+    /// * `subaccount_id` - The ID of the subaccount to create
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the subaccount's public key or a `SwigError`
+    pub fn create_sub_account(&self, current_slot: Option<u64>) -> Result<Instruction, SwigError> {
+        let role_id_bytes = self.role_id.to_le_bytes();
+        let swig_id_bytes = self.swig_id;
+        let (sub_account, sub_account_bump) = Pubkey::find_program_address(
+            &sub_account_seeds(&swig_id_bytes, &role_id_bytes),
+            &swig_interface::program_id(),
+        );
+
+        match &self.authority_manager {
+            AuthorityManager::Ed25519(authority) => {
+                Ok(CreateSubAccountInstruction::new_with_ed25519_authority(
+                    self.swig_account,
+                    *authority,
+                    self.payer,
+                    sub_account,
+                    self.role_id,
+                    sub_account_bump,
+                )?)
+            },
+            AuthorityManager::Secp256k1(authority, signing_fn) => {
+                let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+                Ok(CreateSubAccountInstruction::new_with_secp256k1_authority(
+                    self.swig_account,
+                    self.payer,
+                    signing_fn,
+                    current_slot,
+                    sub_account,
+                    self.role_id,
+                    sub_account_bump,
+                )?)
+            },
+            _ => todo!(),
+        }
+    }
+
+    /// Signs a instruction with sub-account
+    ///
+    /// # Arguments
+    ///
+    /// * `instructions` - The instructions to sign
+    /// * `current_slot` - Optional current slot number (required for Secp256k1)
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the signed instruction or a `SwigError`
+    pub fn sign_instruction_with_sub_account(
+        &self,
+        instructions: Vec<Instruction>,
+        current_slot: Option<u64>,
+    ) -> Result<Instruction, SwigError> {
+        println!("Signing instruction with sub-account");
+        println!("Swig account: {}", self.swig_account);
+        println!("Payer: {}", self.payer);
+        println!("Role ID: {}", self.role_id);
+        println!("Swig ID: {:?}", self.swig_id);
+        println!("Program ID: {:?}", program_id());
+        let role_id_bytes = self.role_id.to_le_bytes();
+        let swig_id_bytes = self.swig_id;
+        let (sub_account, sub_account_bump) = Pubkey::find_program_address(
+            &sub_account_seeds(&swig_id_bytes, &role_id_bytes),
+            &swig_interface::program_id(),
+        );
+        println!("Sub-account: {}", sub_account);
+
+        match &self.authority_manager {
+            AuthorityManager::Ed25519(authority) => {
+                println!("authority: {:?}", &authority);
+
+                Ok(SubAccountSignInstruction::new_with_ed25519_authority(
+                    self.swig_account,
+                    sub_account,
+                    *authority,
+                    self.payer,
+                    self.role_id,
+                    instructions,
+                )?)
+            },
+            AuthorityManager::Secp256k1(authority, signing_fn) => {
+                let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+                Ok(SubAccountSignInstruction::new_with_secp256k1_authority(
+                    self.swig_account,
+                    sub_account,
+                    self.payer,
+                    signing_fn,
+                    current_slot,
+                    self.role_id,
+                    instructions,
+                )?)
+            },
+            _ => todo!(),
+        }
+    }
+
+    /// Withdraws funds from a sub-account
+    ///
+    /// # Arguments
+    ///
+    /// * `sub_account` - The public key of the sub-account
+    /// * `amount` - The amount to withdraw
+    /// * `current_slot` - Optional current slot number (required for Secp256k1)
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the withdraw instruction or a `SwigError`
+    pub fn withdraw_from_sub_account(
+        &self,
+        sub_account: Pubkey,
+        amount: u64,
+        current_slot: Option<u64>,
+    ) -> Result<Instruction, SwigError> {
+        match &self.authority_manager {
+            AuthorityManager::Ed25519(authority) => {
+                WithdrawFromSubAccountInstruction::new_with_ed25519_authority(
+                    self.swig_account,
+                    *authority,
+                    self.payer,
+                    sub_account,
+                    self.role_id,
+                    amount,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to create withdraw instruction: {:?}", e).into()
+                })
+            },
+            AuthorityManager::Secp256k1(authority, signing_fn) => {
+                let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+                WithdrawFromSubAccountInstruction::new_with_secp256k1_authority(
+                    self.swig_account,
+                    self.payer,
+                    signing_fn,
+                    current_slot,
+                    sub_account,
+                    self.role_id,
+                    amount,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to create withdraw instruction: {:?}", e).into()
+                })
+            },
+            _ => todo!(),
+        }
+    }
+
+    /// Withdraws tokens from a sub-account
+    ///
+    /// # Arguments
+    ///
+    /// * `sub_account` - The public key of the sub-account
+    /// * `sub_account_token` - The token account of the sub-account
+    /// * `swig_token` - The token account of the Swig account
+    /// * `token_program` - The token program ID
+    /// * `amount` - The amount of tokens to withdraw
+    /// * `current_slot` - Optional current slot number (required for Secp256k1)
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the withdraw token instruction or a `SwigError`
+    pub fn withdraw_token_from_sub_account(
+        &self,
+        sub_account: Pubkey,
+        sub_account_token: Pubkey,
+        swig_token: Pubkey,
+        token_program: Pubkey,
+        amount: u64,
+        current_slot: Option<u64>,
+    ) -> Result<Instruction, SwigError> {
+        match &self.authority_manager {
+            AuthorityManager::Ed25519(authority) => {
+                WithdrawFromSubAccountInstruction::new_token_with_ed25519_authority(
+                    self.swig_account,
+                    *authority,
+                    self.payer,
+                    sub_account,
+                    sub_account_token,
+                    swig_token,
+                    token_program,
+                    self.role_id,
+                    amount,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to create withdraw token instruction: {:?}", e).into()
+                })
+            },
+            AuthorityManager::Secp256k1(authority, signing_fn) => {
+                let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+                WithdrawFromSubAccountInstruction::new_token_with_secp256k1_authority(
+                    self.swig_account,
+                    self.payer,
+                    signing_fn,
+                    current_slot,
+                    sub_account,
+                    sub_account_token,
+                    swig_token,
+                    token_program,
+                    self.role_id,
+                    amount,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to create withdraw token instruction: {:?}", e).into()
+                })
+            },
+            _ => todo!(),
+        }
+    }
+
+    /// Toggles a sub-account's enabled state
+    ///
+    /// # Arguments
+    ///
+    /// * `sub_account` - The public key of the sub-account
+    /// * `enabled` - Whether to enable or disable the sub-account
+    /// * `current_slot` - Optional current slot number (required for Secp256k1)
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the toggle instruction or a `SwigError`
+    pub fn toggle_sub_account(
+        &self,
+        sub_account: Pubkey,
+        enabled: bool,
+        current_slot: Option<u64>,
+    ) -> Result<Instruction, SwigError> {
+        match &self.authority_manager {
+            AuthorityManager::Ed25519(authority) => {
+                ToggleSubAccountInstruction::new_with_ed25519_authority(
+                    self.swig_account,
+                    *authority,
+                    self.payer,
+                    sub_account,
+                    self.role_id,
+                    enabled,
+                )
+                .map_err(|e| anyhow::anyhow!("Failed to create toggle instruction: {:?}", e).into())
+            },
+            AuthorityManager::Secp256k1(authority, signing_fn) => {
+                let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+                ToggleSubAccountInstruction::new_with_secp256k1_authority(
+                    self.swig_account,
+                    self.payer,
+                    signing_fn,
+                    current_slot,
+                    sub_account,
+                    self.role_id,
+                    enabled,
+                )
+                .map_err(|e| anyhow::anyhow!("Failed to create toggle instruction: {:?}", e).into())
+            },
+            _ => todo!(),
+        }
     }
 
     /// Returns the current authority's public key as bytes

--- a/rust-sdk/src/tests/ix_builder/authority_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/authority_tests.rs
@@ -1,0 +1,274 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    signature::{Keypair, Signer},
+    transaction::VersionedTransaction,
+};
+use swig_interface::program_id;
+use swig_state_x::{
+    authority::AuthorityType,
+    swig::{swig_account_seeds, SwigWithRoles},
+};
+
+use super::*;
+
+#[test_log::test]
+fn test_add_authority_with_ed25519_root() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [3u8; 32];
+    let authority = Keypair::new();
+    let role_id = 0;
+
+    // First create the Swig account
+    let (swig_key, _) = create_swig_ed25519(&mut context, &authority, swig_id).unwrap();
+
+    let mut builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(authority.pubkey()),
+        context.default_payer.pubkey(),
+        role_id,
+    );
+
+    let new_authority = Keypair::new();
+    let new_authority_bytes = new_authority.pubkey().to_bytes();
+    let permissions = vec![Permission::Sol {
+        amount: 100000 / 2,
+        recurring: None,
+    }];
+
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+
+    let add_auth_ix = builder
+        .add_authority_instruction(
+            AuthorityType::Ed25519,
+            &new_authority_bytes,
+            permissions,
+            Some(current_slot),
+        )
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[add_auth_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &authority],
+    )
+    .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to add authority: {:?}",
+        result.err()
+    );
+
+    // Verify the new authority was added
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig_data.state.roles, 2); // Root authority + new authority
+}
+
+#[test_log::test]
+fn test_add_authority_with_secp256k1_root() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [7u8; 32];
+    let payer = &context.default_payer;
+    let role_id = 0;
+
+    let wallet = LocalSigner::random();
+    let secp_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let wallet = wallet.clone();
+    let signing_fn = move |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        let hash = B256::from(hash);
+        wallet.sign_hash_sync(&hash).unwrap().as_bytes()
+    };
+
+    let mut builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Secp256k1(secp_pubkey, Box::new(signing_fn)),
+        payer.pubkey(),
+        role_id,
+    );
+
+    let ix = builder.build_swig_account().unwrap();
+    let msg = v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+        .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[payer]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create Swig account: {:?}",
+        result.err()
+    );
+
+    let swig_key = builder.get_swig_account().unwrap();
+
+    let new_authority = LocalSigner::random();
+    let secp_pubkey_bytes = new_authority
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let permissions = vec![Permission::Sol {
+        amount: 1_000_000_000,
+        recurring: None,
+    }];
+
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+
+    let add_auth_ix = builder
+        .add_authority_instruction(
+            AuthorityType::Secp256k1,
+            &secp_pubkey_bytes,
+            permissions,
+            Some(current_slot),
+        )
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[add_auth_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&context.default_payer])
+        .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to add authority: {:?}",
+        result.err()
+    );
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig_data.state.roles, 2); // Root authority + new authority
+}
+
+#[test_log::test]
+fn test_remove_authority_with_ed25519_root() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [8u8; 32];
+    let authority = Keypair::new();
+    let authority_pubkey = authority.pubkey();
+    let role_id = 0;
+
+    let (swig_key, _) = create_swig_ed25519(&mut context, &authority, swig_id).unwrap();
+
+    let new_authority = Keypair::new();
+    let permissions = vec![Permission::Sol {
+        amount: 1_000_000_000,
+        recurring: None,
+    }];
+
+    let payer = &context.default_payer;
+
+    let mut builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(authority.pubkey()),
+        payer.pubkey(),
+        role_id,
+    );
+
+    let add_auth_ix = builder
+        .add_authority_instruction(
+            AuthorityType::Ed25519,
+            &authority_pubkey.to_bytes(),
+            permissions,
+            None,
+        )
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &payer.pubkey(),
+        &[add_auth_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to add authority: {:?}",
+        result.err()
+    );
+
+    let remove_auth_ix = builder.remove_authority(1, None).unwrap();
+    let msg = v0::Message::try_compile(
+        &payer.pubkey(),
+        &[remove_auth_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to remove authority: {:?}",
+        result.err()
+    );
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig_data.state.roles, 1); // Only root authority remains
+}
+
+#[test_log::test]
+fn test_switch_authority_and_payer() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [9u8; 32];
+    let authority = Keypair::new();
+    let payer = &context.default_payer;
+    let role_id = 0;
+
+    let mut builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(authority.pubkey()),
+        payer.pubkey(),
+        role_id,
+    );
+
+    let new_authority = Keypair::new();
+    let new_payer = Keypair::new();
+
+    builder
+        .switch_authority(1, AuthorityManager::Ed25519(new_authority.pubkey()))
+        .unwrap();
+    assert_eq!(builder.get_role_id(), 1);
+    assert_eq!(
+        builder.get_current_authority().unwrap(),
+        new_authority.pubkey().to_bytes()
+    );
+
+    builder.switch_payer(new_payer.pubkey()).unwrap();
+    let ix = builder.build_swig_account().unwrap();
+    assert_eq!(ix.accounts[1].pubkey, new_payer.pubkey());
+}

--- a/rust-sdk/src/tests/ix_builder/mod.rs
+++ b/rust-sdk/src/tests/ix_builder/mod.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use common::*;
+use litesvm::{types::TransactionMetadata, LiteSVM};
+use litesvm_token::spl_token;
+use solana_program::{pubkey::Pubkey, system_program};
+use solana_sdk::{
+    account::ReadableAccount,
+    clock::Clock,
+    message::{v0, VersionedMessage},
+    signature::Keypair,
+    signer::Signer,
+    system_instruction,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{
+    program_id, AuthorityConfig, ClientAction, CreateInstruction, CreateSessionInstruction,
+    SignInstruction,
+};
+use swig_state_x::{
+    action::{
+        all::All, manage_authority::ManageAuthority, program_scope::ProgramScope,
+        sol_limit::SolLimit, sol_recurring_limit::SolRecurringLimit,
+    },
+    authority::{
+        ed25519::{CreateEd25519SessionAuthority, ED25519Authority, Ed25519SessionAuthority},
+        secp256k1::{
+            CreateSecp256k1SessionAuthority, Secp256k1Authority, Secp256k1SessionAuthority,
+        },
+        AuthorityType,
+    },
+    role::Role,
+    swig::{swig_account_seeds, SwigWithRoles},
+    IntoBytes,
+};
+
+use super::*;
+use crate::{
+    error::SwigError, instruction_builder::AuthorityManager, types::Permission, RecurringConfig,
+    SwigInstructionBuilder, SwigWallet,
+};
+
+pub mod authority_tests;
+pub mod program_scope_tests;
+pub mod session_tests;
+pub mod swig_account_tests;
+pub mod transfer_tests;

--- a/rust-sdk/src/tests/ix_builder/mod.rs
+++ b/rust-sdk/src/tests/ix_builder/mod.rs
@@ -46,5 +46,6 @@ use crate::{
 pub mod authority_tests;
 pub mod program_scope_tests;
 pub mod session_tests;
+pub mod sub_account_test;
 pub mod swig_account_tests;
 pub mod transfer_tests;

--- a/rust-sdk/src/tests/ix_builder/program_scope_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/program_scope_tests.rs
@@ -1,0 +1,556 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use litesvm::{types::TransactionMetadata, LiteSVM};
+use litesvm_token::spl_token;
+use solana_program::{pubkey::Pubkey, system_program};
+use solana_sdk::{
+    account::ReadableAccount,
+    clock::Clock,
+    message::{v0, VersionedMessage},
+    signature::{Keypair, Signer},
+    transaction::VersionedTransaction,
+};
+use swig_interface::{program_id, AuthorityConfig};
+use swig_state_x::{
+    action::program_scope::ProgramScope,
+    authority::AuthorityType,
+    swig::{swig_account_seeds, SwigWithRoles},
+};
+
+use super::*;
+
+#[test_log::test]
+fn test_token_transfer_with_program_scope() {
+    let mut context = setup_test_context().unwrap();
+
+    // Setup swig authority
+    let swig_authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    // Airdrop to participants
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    // Setup token mint
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+
+    // Setup swig account
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
+    let swig_create_result = create_swig_ed25519(&mut context, &swig_authority, id);
+    assert!(swig_create_result.is_ok());
+
+    // Setup token accounts
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig,
+        &context.default_payer,
+    )
+    .unwrap();
+
+    let recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+
+    // Define program scope permissions
+    let permissions = vec![Permission::ProgramScope {
+        program_id: spl_token::ID,
+        target_account: swig_ata,
+        numeric_type: 2,
+        limit: Some(1000),
+        window: Some(0),
+        balance_field_start: Some(64),
+        balance_field_end: Some(72),
+    }];
+
+    let mut ix_builder = SwigInstructionBuilder::new(
+        id,
+        AuthorityManager::Ed25519(swig_authority.pubkey()),
+        context.default_payer.pubkey(),
+        0,
+    );
+
+    let new_authority = Keypair::new();
+
+    // Add new authority with program scope permissions
+    let add_auth_ix = ix_builder
+        .add_authority_instruction(
+            AuthorityType::Ed25519,
+            &new_authority.pubkey().to_bytes(),
+            permissions,
+            None,
+        )
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[add_auth_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &swig_authority],
+    )
+    .unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to add authority: {:?}",
+        result.err()
+    );
+
+    // Mint initial tokens to swig account
+    let initial_token_amount = 1000;
+    mint_to(
+        &mut context.svm,
+        &mint_pubkey,
+        &context.default_payer,
+        &swig_ata,
+        initial_token_amount,
+    )
+    .unwrap();
+
+    // Perform token transfer through swig
+    let transfer_amount = 100;
+    let swig_transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &recipient_ata,
+        &swig,
+        &[],
+        transfer_amount,
+    )
+    .unwrap();
+
+    let mut new_authority_ix = SwigInstructionBuilder::new(
+        id,
+        AuthorityManager::Ed25519(new_authority.pubkey()),
+        context.default_payer.pubkey(),
+        1,
+    );
+
+    let sign_ix = ix_builder
+        .sign_instruction(
+            vec![swig_transfer_ix],
+            Some(context.svm.get_sysvar::<Clock>().slot),
+        )
+        .unwrap();
+
+    let transfer_message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &sign_ix,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let transfer_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message),
+        &[&context.default_payer, &swig_authority],
+    )
+    .unwrap();
+
+    let transfer_result = context.svm.send_transaction(transfer_tx);
+    assert!(
+        transfer_result.is_ok(),
+        "Token transfer failed: {:?}",
+        transfer_result.err()
+    );
+}
+
+#[test_log::test]
+fn test_recurring_limit_program_scope() {
+    let mut context = setup_test_context().unwrap();
+
+    // Setup swig authority
+    let swig_authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    // Airdrop to participants
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    // Setup token mint
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+
+    // Setup swig account
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
+    let swig_create_result = create_swig_ed25519(&mut context, &swig_authority, id);
+    assert!(swig_create_result.is_ok());
+
+    // Setup token accounts
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig,
+        &context.default_payer,
+    )
+    .unwrap();
+
+    let recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+
+    // Setup a RecurringLimit program scope
+    // Set a limit of 500 tokens per 100 slots
+    let window_size = 100;
+    let transfer_limit = 500_u64;
+
+    let permissions = vec![Permission::ProgramScope {
+        program_id: spl_token::ID,
+        target_account: swig_ata,
+        numeric_type: 2, // U64
+        limit: Some(transfer_limit),
+        window: Some(window_size),
+        balance_field_start: Some(64),
+        balance_field_end: Some(72),
+    }];
+
+    let mut ix_builder = SwigInstructionBuilder::new(
+        id,
+        AuthorityManager::Ed25519(swig_authority.pubkey()),
+        context.default_payer.pubkey(),
+        0,
+    );
+
+    let new_authority = Keypair::new();
+    // Add authority with program scope permissions
+    let add_auth_ix = ix_builder
+        .add_authority_instruction(
+            AuthorityType::Ed25519,
+            &new_authority.pubkey().to_bytes(),
+            permissions,
+            None,
+        )
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[add_auth_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &swig_authority],
+    )
+    .unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to add authority: {:?}",
+        result.err()
+    );
+
+    // Mint initial tokens to swig account
+    let initial_token_amount = 1000;
+    mint_to(
+        &mut context.svm,
+        &mint_pubkey,
+        &context.default_payer,
+        &swig_ata,
+        initial_token_amount,
+    )
+    .unwrap();
+
+    // First batch of transfers - should succeed up to the limit
+    let transfer_batch = 100;
+    let mut transferred = 0;
+
+    let mut new_ix_builder = SwigInstructionBuilder::new(
+        id,
+        AuthorityManager::Ed25519(new_authority.pubkey()),
+        context.default_payer.pubkey(),
+        1,
+    );
+
+    let transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &recipient_ata,
+        &swig,
+        &[],
+        transfer_batch,
+    )
+    .unwrap();
+
+    // Transfer in batches of 100 tokens up to limit (should succeed)
+    while transferred + transfer_batch <= transfer_limit {
+        let current_slot = context.svm.get_sysvar::<Clock>().slot;
+
+        let sign_ix = new_ix_builder
+            .sign_instruction(vec![transfer_ix.clone()], Some(current_slot))
+            .unwrap();
+
+        let transfer_message = v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &sign_ix,
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap();
+
+        let transfer_tx = VersionedTransaction::try_new(
+            VersionedMessage::V0(transfer_message),
+            &[&context.default_payer, &new_authority],
+        )
+        .unwrap();
+
+        let transfer_result = context.svm.send_transaction(transfer_tx);
+        assert!(
+            transfer_result.is_ok(),
+            "Token transfer failed: {:?}",
+            transfer_result.err()
+        );
+        transferred += transfer_batch;
+        context.svm.expire_blockhash();
+    }
+
+    // Try to transfer one more batch (should fail)
+    let sign_ix = new_ix_builder
+        .sign_instruction(
+            vec![transfer_ix],
+            Some(context.svm.get_sysvar::<Clock>().slot),
+        )
+        .unwrap();
+
+    let transfer_message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &sign_ix,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let transfer_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message),
+        &[&context.default_payer, &new_authority],
+    )
+    .unwrap();
+
+    let transfer_result = context.svm.send_transaction(transfer_tx);
+    assert!(
+        transfer_result.is_err(),
+        "Transfer should have failed due to limit"
+    );
+
+    // Advance the clock past the window to trigger a reset
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    context.svm.warp_to_slot(current_slot + window_size + 1);
+    context.svm.expire_blockhash();
+
+    // After resetting the clock, we should be able to transfer again
+    let transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &recipient_ata,
+        &swig,
+        &[],
+        transfer_batch,
+    )
+    .unwrap();
+
+    let sign_ix = new_ix_builder
+        .sign_instruction(
+            vec![transfer_ix],
+            Some(context.svm.get_sysvar::<Clock>().slot),
+        )
+        .unwrap();
+
+    let transfer_message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &sign_ix,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let transfer_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message),
+        &[&context.default_payer, &new_authority],
+    )
+    .unwrap();
+
+    let transfer_result = context.svm.send_transaction(transfer_tx);
+    assert!(
+        transfer_result.is_ok(),
+        "Token transfer after window reset failed: {:?}",
+        transfer_result.err()
+    );
+}
+
+use solana_sdk::account::Account;
+pub fn display_swig(swig_pubkey: Pubkey, swig_account: &Account) -> Result<(), SwigError> {
+    let swig_with_roles =
+        SwigWithRoles::from_bytes(&swig_account.data).map_err(|e| SwigError::InvalidSwigData)?;
+
+    println!("╔══════════════════════════════════════════════════════════════════");
+    println!("║ SWIG WALLET DETAILS");
+    println!("╠══════════════════════════════════════════════════════════════════");
+    println!("║ Account Address: {}", swig_pubkey);
+    println!("║ Total Roles: {}", swig_with_roles.state.role_counter);
+    println!(
+        "║ Balance: {} SOL",
+        swig_account.lamports() as f64 / 1_000_000_000.0
+    );
+
+    println!("╠══════════════════════════════════════════════════════════════════");
+    println!("║ ROLES & PERMISSIONS");
+    println!("╠══════════════════════════════════════════════════════════════════");
+
+    for i in 0..swig_with_roles.state.role_counter {
+        let role = swig_with_roles
+            .get_role(i)
+            .map_err(|e| SwigError::AuthorityNotFound)?;
+
+        if let Some(role) = role {
+            println!("║");
+            println!("║ Role ID: {}", i);
+            println!(
+                "║ ├─ Type: {}",
+                if role.authority.session_based() {
+                    "Session-based Authority"
+                } else {
+                    "Permanent Authority"
+                }
+            );
+            println!("║ ├─ Authority Type: {:?}", role.authority.authority_type());
+            println!(
+                "║ ├─ Authority: {}",
+                match role.authority.authority_type() {
+                    AuthorityType::Ed25519 | AuthorityType::Ed25519Session => {
+                        let authority = role.authority.identity().unwrap();
+                        let authority = bs58::encode(authority).into_string();
+                        authority
+                    },
+                    AuthorityType::Secp256k1 | AuthorityType::Secp256k1Session => {
+                        let authority = role.authority.identity().unwrap();
+                        let authority_hex = hex::encode([&[0x4].as_slice(), authority].concat());
+                        // get eth address from public key
+                        let mut hasher = solana_sdk::keccak::Hasher::default();
+                        hasher.hash(authority_hex.as_bytes());
+                        let hash = hasher.result();
+                        let address = format!("0x{}", hex::encode(&hash.0[12..32]));
+                        address
+                    },
+                    _ => todo!(),
+                }
+            );
+
+            println!("║ ├─ Permissions:");
+
+            // Check All permission
+            if (Role::get_action::<All>(&role, &[]).map_err(|_| SwigError::AuthorityNotFound)?)
+                .is_some()
+            {
+                println!("║ │  ├─ Full Access (All Permissions)");
+            }
+
+            // Check Manage Authority permission
+            if (Role::get_action::<ManageAuthority>(&role, &[])
+                .map_err(|_| SwigError::AuthorityNotFound)?)
+            .is_some()
+            {
+                println!("║ │  ├─ Manage Authority");
+            }
+
+            // Check Sol Limit
+            if let Some(action) = Role::get_action::<SolLimit>(&role, &[])
+                .map_err(|_| SwigError::AuthorityNotFound)?
+            {
+                println!(
+                    "║ │  ├─ SOL Limit: {} SOL",
+                    action.amount as f64 / 1_000_000_000.0
+                );
+            }
+
+            // Check Sol Recurring Limit
+            if let Some(action) = Role::get_action::<SolRecurringLimit>(&role, &[])
+                .map_err(|_| SwigError::AuthorityNotFound)?
+            {
+                println!("║ │  ├─ Recurring SOL Limit:");
+                println!(
+                    "║ │  │  ├─ Amount: {} SOL",
+                    action.recurring_amount as f64 / 1_000_000_000.0
+                );
+                println!("║ │  │  ├─ Window: {} slots", action.window);
+                println!(
+                    "║ │  │  ├─ Current Usage: {} SOL",
+                    action.current_amount as f64 / 1_000_000_000.0
+                );
+                println!("║ │  │  └─ Last Reset: Slot {}", action.last_reset);
+            }
+
+            // Check Program Scope
+            if let Some(action) = Role::get_action::<ProgramScope>(&role, &spl_token::ID.to_bytes())
+                .map_err(|_| SwigError::AuthorityNotFound)?
+            {
+                let program_id = Pubkey::from(action.program_id);
+                let target_account = Pubkey::from(action.target_account);
+                println!("║ │  ├─ Program Scope");
+                println!("║ │  │  ├─ Program ID: {}", program_id);
+                println!("║ │  │  ├─ Target Account: {}", target_account);
+                println!(
+                    "║ │  │  ├─ Scope Type: {}",
+                    match action.scope_type {
+                        0 => "Basic",
+                        1 => "Limit",
+                        2 => "Recurring Limit",
+                        _ => "Unknown",
+                    }
+                );
+                println!(
+                    "║ │  │  ├─ Numeric Type: {}",
+                    match action.numeric_type {
+                        0 => "U64",
+                        1 => "U128",
+                        2 => "F64",
+                        _ => "Unknown",
+                    }
+                );
+                if action.scope_type > 0 {
+                    println!("║ │  │  ├─ Limit: {} ", action.limit);
+                    println!("║ │  │  ├─ Current Usage: {} ", action.current_amount);
+                }
+                if action.scope_type == 2 {
+                    println!("║ │  │  ├─ Window: {} slots", action.window);
+                    println!("║ │  │  ├─ Last Reset: Slot {}", action.last_reset);
+                }
+                println!("║ │  │  ");
+            }
+            println!("║ │  ");
+        }
+    }
+
+    println!("╚══════════════════════════════════════════════════════════════════");
+
+    Ok(())
+}

--- a/rust-sdk/src/tests/ix_builder/session_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/session_tests.rs
@@ -1,0 +1,236 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    signature::{Keypair, Signer},
+    transaction::VersionedTransaction,
+};
+use swig_interface::program_id;
+use swig_state_x::{
+    authority::{
+        ed25519::{CreateEd25519SessionAuthority, Ed25519SessionAuthority},
+        secp256k1::{CreateSecp256k1SessionAuthority, Secp256k1SessionAuthority},
+        AuthorityType,
+    },
+    swig::{swig_account_seeds, SwigWithRoles},
+};
+
+use super::*;
+
+#[test_log::test]
+fn test_create_ed25519_session() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = [0; 32];
+
+    let mut swig_ix_builder = SwigInstructionBuilder::new(
+        id,
+        AuthorityManager::Ed25519Session(CreateEd25519SessionAuthority::new(
+            swig_authority.pubkey().to_bytes(),
+            [0; 32],
+            100,
+        )),
+        context.default_payer.pubkey(),
+        0,
+    );
+
+    let create_ix = swig_ix_builder.build_swig_account().unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[create_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&context.default_payer])
+        .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create Swig account: {:?}",
+        result.err()
+    );
+
+    let swig_key = swig_ix_builder.get_swig_account().unwrap();
+
+    context.svm.airdrop(&swig_key, 50_000_000_000).unwrap();
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig.state.roles, 1);
+    let role = swig.get_role(0).unwrap().unwrap();
+
+    assert_eq!(
+        role.authority.authority_type(),
+        AuthorityType::Ed25519Session
+    );
+    assert!(role.authority.session_based());
+    let auth: &Ed25519SessionAuthority = role.authority.as_any().downcast_ref().unwrap();
+    assert_eq!(auth.max_session_length, 100);
+    assert_eq!(auth.public_key, swig_authority.pubkey().to_bytes());
+    assert_eq!(auth.current_session_expiration, 0);
+    assert_eq!(auth.session_key, [0; 32]);
+
+    // Create a session
+    let session_authority = Keypair::new();
+    let create_session_ix = swig_ix_builder
+        .create_session_instruction(session_authority.pubkey(), 100, None)
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[create_session_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &swig_authority],
+    )
+    .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create session: {:?}",
+        result.err()
+    );
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_data = swig_account.data;
+
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data)
+        .map_err(|e| SwigError::InvalidSwigData)
+        .unwrap();
+
+    let role = swig_with_roles.get_role(0).unwrap().unwrap();
+    let auth: &Ed25519SessionAuthority = role.authority.as_any().downcast_ref().unwrap();
+}
+
+#[test_log::test]
+fn test_create_secp256k1_session() {
+    let mut context = setup_test_context().unwrap();
+
+    let wallet = LocalSigner::random();
+
+    let id = [0; 32];
+
+    let secp_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let wallet = wallet.clone();
+    let payer = &context.default_payer;
+
+    let signing_fn = move |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        let hash = B256::from(hash);
+        wallet.sign_hash_sync(&hash).unwrap().as_bytes()
+    };
+
+    let mut swig_ix_builder = SwigInstructionBuilder::new(
+        id,
+        AuthorityManager::Secp256k1Session(
+            CreateSecp256k1SessionAuthority::new(
+                secp_pubkey[1..].try_into().unwrap(),
+                [0; 32],
+                100,
+            ),
+            Box::new(signing_fn),
+        ),
+        context.default_payer.pubkey(),
+        0,
+    );
+
+    let create_ix = swig_ix_builder.build_swig_account().unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[create_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&context.default_payer])
+        .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create Swig account: {:?}",
+        result.err()
+    );
+
+    let swig_key = swig_ix_builder.get_swig_account().unwrap();
+
+    context.svm.airdrop(&swig_key, 50_000_000_000).unwrap();
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig.state.roles, 1);
+    let role = swig.get_role(0).unwrap().unwrap();
+
+    assert_eq!(
+        role.authority.authority_type(),
+        AuthorityType::Secp256k1Session
+    );
+    assert!(role.authority.session_based());
+    let auth: &Secp256k1SessionAuthority = role.authority.as_any().downcast_ref().unwrap();
+
+    assert_eq!(auth.max_session_age, 100);
+    assert_eq!(auth.current_session_expiration, 0);
+    assert_eq!(auth.session_key, [0; 32]);
+
+    // Create a session
+    let session_authority = Keypair::new();
+
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let create_session_ix = swig_ix_builder
+        .create_session_instruction(session_authority.pubkey(), 100, Some(current_slot))
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[create_session_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&context.default_payer])
+        .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create session: {:?}",
+        result.err()
+    );
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_data = swig_account.data;
+
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data)
+        .map_err(|e| SwigError::InvalidSwigData)
+        .unwrap();
+
+    let role = swig_with_roles.get_role(0).unwrap().unwrap();
+    let auth: &Secp256k1SessionAuthority = role.authority.as_any().downcast_ref().unwrap();
+}

--- a/rust-sdk/src/tests/ix_builder/sub_account.rs
+++ b/rust-sdk/src/tests/ix_builder/sub_account.rs
@@ -1,0 +1,63 @@
+use super::*;
+use crate::tests::common::*;
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use litesvm_token::spl_token;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::{clock::Clock, signature::Keypair, transaction::VersionedTransaction};
+
+#[test_log::test]
+fn test_create_sub_account() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [3u8; 32];
+    let authority = Keypair::new();
+    let role_id = 0;
+
+    // First create the Swig account
+    let (swig_key, _) = create_swig_ed25519(&mut context, &authority, swig_id).unwrap();
+
+    let mut builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(authority.pubkey()),
+        context.default_payer.pubkey(),
+        role_id,
+    );
+
+    // Add a new authority to the Swig account with SubAccount permission
+    let new_authority = Keypair::new();
+    let ix = builder
+        .add_authority_instruction(
+            AuthorityType::Ed25519,
+            &new_authority.pubkey().to_bytes(),
+            vec![Permission::SubAccount],
+        )
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&context.default_payer])
+        .unwrap();
+
+    context.svm.process_transaction(&tx).unwrap();
+
+    // Create a sub account
+
+    let ix = builder.create_subaccount(role_id).unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&context.default_payer])
+        .unwrap();
+}

--- a/rust-sdk/src/tests/ix_builder/sub_account_test.rs
+++ b/rust-sdk/src/tests/ix_builder/sub_account_test.rs
@@ -1,0 +1,305 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    signature::{Keypair, Signer},
+    system_instruction,
+    transaction::VersionedTransaction,
+};
+use swig_interface::program_id;
+use swig_state_x::{
+    authority::AuthorityType,
+    swig::{sub_account_seeds, swig_account_seeds, SwigWithRoles},
+};
+
+use super::*;
+use crate::tests::common::*;
+use litesvm_token::spl_token;
+
+#[test_log::test]
+fn test_sub_account_functionality() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [3u8; 32];
+    let root_authority = Keypair::new();
+    let sub_account_authority = Keypair::new();
+    let role_id = 0;
+
+    println!("Root authority: {:?}", root_authority.pubkey());
+    println!(
+        "Sub-account authority: {:?}",
+        sub_account_authority.pubkey()
+    );
+
+    // Fund the root authority with some SOL
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), 1_000_000)
+        .unwrap();
+
+    // First create the Swig account with root authority
+    let (swig_key, _) = create_swig_ed25519(&mut context, &root_authority, swig_id).unwrap();
+
+    // Create instruction builder with root authority
+    let mut builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(root_authority.pubkey()),
+        context.default_payer.pubkey(),
+        role_id,
+    );
+
+    // Add a new authority to the Swig account with SubAccount permission
+    let ix = builder
+        .add_authority_instruction(
+            AuthorityType::Ed25519,
+            &sub_account_authority.pubkey().to_bytes(),
+            vec![Permission::SubAccount {
+                sub_account: [0; 32],
+            }],
+            None,
+        )
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &root_authority],
+    )
+    .unwrap();
+
+    context.svm.send_transaction(tx).unwrap();
+
+    // Create a sub-account using the sub-account authority
+    let sub_account_role_id = 1; // The sub-account authority has role_id 1
+    let mut sub_account_builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(sub_account_authority.pubkey()),
+        context.default_payer.pubkey(),
+        sub_account_role_id,
+    );
+
+    let create_sub_account_ix = sub_account_builder.create_sub_account(None).unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[create_sub_account_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &sub_account_authority],
+    )
+    .unwrap();
+
+    context.svm.send_transaction(tx).unwrap();
+
+    // Get the sub-account address
+    let role_id_bytes = sub_account_role_id.to_le_bytes();
+    let (sub_account, _) =
+        Pubkey::find_program_address(&sub_account_seeds(&swig_id, &role_id_bytes), &program_id());
+
+    // Fund the sub-account with some SOL for testing
+    context.svm.airdrop(&sub_account, 5_000_000_000).unwrap();
+
+    // Create a test recipient for transfer
+    let recipient = Keypair::new();
+    context.svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
+
+    // Get initial balances
+    let initial_sub_account_balance = context.svm.get_account(&sub_account).unwrap().lamports;
+    let initial_recipient_balance = context
+        .svm
+        .get_account(&recipient.pubkey())
+        .unwrap()
+        .lamports;
+    println!(
+        "Initial sub-account balance: {}",
+        initial_sub_account_balance
+    );
+    println!("Initial recipient balance: {}", initial_recipient_balance);
+
+    // Create a transfer instruction to be executed by the sub-account
+    let transfer_amount = 1_000_000;
+    let transfer_ix = system_instruction::transfer(
+        &sub_account,
+        &recipient.pubkey(),
+        1_000_000, // 0.001 SOL
+    );
+
+    // Sign and execute the transfer using the sub-account authority
+    let sub_account_sign_ix = sub_account_builder
+        .sign_instruction_with_sub_account(vec![transfer_ix], None)
+        .unwrap();
+
+    println!("Sub-account sign instruction: {:?}", sub_account_sign_ix);
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[sub_account_sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    println!("Message: {:?}", msg);
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &sub_account_authority],
+    )
+    .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to execute sub-account transfer: {:?}",
+        result.err()
+    );
+
+    // Verify the transfer was successful
+    let final_sub_account_balance = context.svm.get_account(&sub_account).unwrap().lamports;
+    let final_recipient_balance = context
+        .svm
+        .get_account(&recipient.pubkey())
+        .unwrap()
+        .lamports;
+    println!("Final sub-account balance: {}", final_sub_account_balance);
+    println!("Final recipient balance: {}", final_recipient_balance);
+
+    assert_eq!(
+        final_recipient_balance,
+        initial_recipient_balance + transfer_amount,
+        "Recipient balance did not increase by the correct amount"
+    );
+    assert_eq!(
+        final_sub_account_balance,
+        initial_sub_account_balance - transfer_amount,
+        "Sub-account balance did not decrease by the correct amount"
+    );
+
+    println!("Testing withdraw");
+
+    // Get balances before withdraw
+    let pre_withdraw_sub_account_balance = context.svm.get_account(&sub_account).unwrap().lamports;
+    let pre_withdraw_swig_balance = context.svm.get_account(&swig_key).unwrap().lamports;
+    println!(
+        "Pre-withdraw sub-account balance: {}",
+        pre_withdraw_sub_account_balance
+    );
+    println!(
+        "Pre-withdraw swig account balance: {}",
+        pre_withdraw_swig_balance
+    );
+
+    let withdraw_amount = 1_000_000;
+    let withdraw_ix = builder
+        .withdraw_from_sub_account(sub_account, withdraw_amount, None)
+        .unwrap();
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[withdraw_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &root_authority],
+    )
+    .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to withdraw from sub-account: {:?}",
+        result.err()
+    );
+
+    // Verify the withdraw was successful
+    let post_withdraw_sub_account_balance = context.svm.get_account(&sub_account).unwrap().lamports;
+    let post_withdraw_swig_balance = context.svm.get_account(&swig_key).unwrap().lamports;
+    println!(
+        "Post-withdraw sub-account balance: {}",
+        post_withdraw_sub_account_balance
+    );
+    println!(
+        "Post-withdraw swig account balance: {}",
+        post_withdraw_swig_balance
+    );
+
+    assert_eq!(
+        post_withdraw_sub_account_balance,
+        pre_withdraw_sub_account_balance - withdraw_amount,
+        "Sub-account balance did not decrease by the correct withdraw amount"
+    );
+    assert_eq!(
+        post_withdraw_swig_balance,
+        pre_withdraw_swig_balance + withdraw_amount,
+        "Swig account balance did not increase by the correct withdraw amount"
+    );
+
+    // Test toggling the sub-account (disable/enable)
+    let toggle_ix = builder
+        .toggle_sub_account(sub_account, false, None)
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[toggle_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &root_authority],
+    )
+    .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to toggle sub-account: {:?}",
+        result.err()
+    );
+
+    // Verify the sub-account is disabled by attempting another transfer (should fail)
+    let transfer_ix =
+        system_instruction::transfer(&sub_account, &recipient.pubkey(), transfer_amount);
+    let sub_account_sign_ix = sub_account_builder
+        .sign_instruction_with_sub_account(vec![transfer_ix], None)
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[sub_account_sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &sub_account_authority],
+    )
+    .unwrap();
+
+    // This should fail because the sub-account is disabled
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_err(),
+        "Transaction should fail with disabled sub-account"
+    );
+}

--- a/rust-sdk/src/tests/ix_builder/swig_account_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/swig_account_tests.rs
@@ -1,0 +1,102 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    signature::{Keypair, Signer},
+    transaction::VersionedTransaction,
+};
+use swig_interface::program_id;
+use swig_state_x::swig::{swig_account_seeds, SwigWithRoles};
+
+use super::*;
+
+#[test_log::test]
+fn test_create_swig_account_with_ed25519_authority() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [1u8; 32];
+    let authority = Keypair::new();
+    let payer = context.default_payer;
+    let role_id = 0;
+
+    let builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(authority.pubkey()),
+        payer.pubkey(),
+        role_id,
+    );
+
+    let ix = builder.build_swig_account().unwrap();
+
+    let msg = v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+        .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[payer]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create Swig account: {:?}",
+        result.err()
+    );
+
+    // Verify the account was created correctly
+    let (swig_key, _) = Pubkey::find_program_address(&swig_account_seeds(&swig_id), &program_id());
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    let root_role = swig_data.get_role(0).unwrap().unwrap();
+
+    assert_eq!(swig_data.state.id, swig_id);
+    assert_eq!(swig_data.state.roles, 1);
+}
+
+#[test_log::test]
+fn test_create_swig_account_with_secp256k1_authority() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [1u8; 32];
+
+    let wallet = LocalSigner::random();
+
+    let secp_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let payer = &context.default_payer;
+    let role_id = 0;
+
+    let builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Secp256k1(secp_pubkey, Box::new(|_| [0u8; 65])),
+        payer.pubkey(),
+        role_id,
+    );
+
+    let ix = builder.build_swig_account().unwrap();
+    let msg = v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+        .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[payer]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create Swig account: {:?}",
+        result.err()
+    );
+
+    // Verify the account was created correctly
+    let (swig_key, _) = Pubkey::find_program_address(&swig_account_seeds(&swig_id), &program_id());
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    let root_role = swig_data.get_role(0).unwrap().unwrap();
+
+    assert_eq!(swig_data.state.id, swig_id);
+    assert_eq!(swig_data.state.roles, 1);
+    assert_eq!(
+        root_role.authority.authority_type(),
+        AuthorityType::Secp256k1
+    );
+}

--- a/rust-sdk/src/tests/ix_builder/transfer_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/transfer_tests.rs
@@ -1,0 +1,179 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_program::{pubkey::Pubkey, system_instruction};
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    signature::{Keypair, Signer},
+    transaction::VersionedTransaction,
+};
+use swig_interface::program_id;
+use swig_state_x::{
+    authority::AuthorityType,
+    swig::{swig_account_seeds, SwigWithRoles},
+};
+
+use super::*;
+
+#[test_log::test]
+fn test_sign_instruction_with_ed25519_authority() {
+    // First create the Swig account
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [1u8; 32];
+    let authority = Keypair::new();
+    let payer = &context.default_payer;
+    let role_id = 0;
+
+    let builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(authority.pubkey()),
+        payer.pubkey(),
+        role_id,
+    );
+
+    let ix = builder.build_swig_account().unwrap();
+    let msg = v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+        .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[payer]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create Swig account: {:?}",
+        result.err()
+    );
+
+    let swig_key = builder.get_swig_account().unwrap();
+
+    // Fund the Swig account
+    context.svm.airdrop(&swig_key, 1_000_000_000).unwrap();
+
+    let mut builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Ed25519(authority.pubkey()),
+        context.default_payer.pubkey(),
+        role_id,
+    );
+
+    // Create a transfer instruction to test signing
+    let recipient = Keypair::new();
+    let transfer_amount = 100_000;
+    let transfer_ix = solana_program::system_instruction::transfer(
+        &swig_key,
+        &recipient.pubkey(),
+        transfer_amount,
+    );
+
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+
+    let sign_ix = builder
+        .sign_instruction(vec![transfer_ix], Some(current_slot))
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &sign_ix,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &authority],
+    );
+
+    assert!(tx.is_ok(), "Failed to create transaction {:?}", tx.err());
+
+    let result = context.svm.send_transaction(tx.unwrap());
+    assert!(
+        result.is_ok(),
+        "Failed to execute signed instruction: {:?}",
+        result.err()
+    );
+
+    // Verify the transfer was successful
+    let recipient_account = context.svm.get_account(&recipient.pubkey()).unwrap();
+    assert_eq!(recipient_account.lamports, transfer_amount);
+}
+
+#[test_log::test]
+fn test_sign_instruction_with_secp256k1_authority() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [6u8; 32];
+    let payer = &context.default_payer;
+    let role_id = 0;
+
+    let wallet = LocalSigner::random();
+    let secp_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let wallet = wallet.clone();
+    let signing_fn = move |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        let hash = B256::from(hash);
+        wallet.sign_hash_sync(&hash).unwrap().as_bytes()
+    };
+
+    let mut builder = SwigInstructionBuilder::new(
+        swig_id,
+        AuthorityManager::Secp256k1(secp_pubkey, Box::new(signing_fn)),
+        payer.pubkey(),
+        role_id,
+    );
+
+    let ix = builder.build_swig_account().unwrap();
+    let msg = v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+        .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[payer]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to create Swig account: {:?}",
+        result.err()
+    );
+
+    let swig_key = builder.get_swig_account().unwrap();
+    context.svm.airdrop(&swig_key, 1_000_000_000).unwrap();
+
+    let recipient = Keypair::new();
+    let transfer_amount = 100_000;
+    let transfer_ix = solana_program::system_instruction::transfer(
+        &swig_key,
+        &recipient.pubkey(),
+        transfer_amount,
+    );
+
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let sign_ix = builder
+        .sign_instruction(vec![transfer_ix], Some(current_slot))
+        .unwrap();
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &sign_ix,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[&context.default_payer]);
+    assert!(tx.is_ok(), "Failed to create transaction {:?}", tx.err());
+
+    let result = context.svm.send_transaction(tx.unwrap());
+    assert!(
+        result.is_ok(),
+        "Failed to execute signed instruction: {:?}",
+        result.err()
+    );
+
+    let recipient_account = context.svm.get_account(&recipient.pubkey()).unwrap();
+    assert_eq!(recipient_account.lamports, transfer_amount);
+}

--- a/rust-sdk/src/tests/mod.rs
+++ b/rust-sdk/src/tests/mod.rs
@@ -1,3 +1,7 @@
 pub mod common;
-pub mod swig_ix_test;
-pub mod wallet_tests;
+
+// pub mod swig_ix_test;
+// pub mod wallet_tests;
+
+pub mod ix_builder;
+pub mod wallet;

--- a/rust-sdk/src/tests/wallet/authority_tests.rs
+++ b/rust-sdk/src/tests/wallet/authority_tests.rs
@@ -1,0 +1,233 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_sdk::signature::{Keypair, Signer};
+use swig_state_x::authority::AuthorityType;
+
+use super::*;
+
+#[test_log::test]
+fn should_manage_authorities_successfully() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let secondary_authority = Keypair::new();
+
+    // Add secondary authority with SOL permission
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 10_000_000_000,
+                recurring: None,
+            }],
+        )
+        .unwrap();
+
+    // Verify both authorities exist
+    swig_wallet.display_swig().unwrap();
+
+    // Remove secondary authority
+    swig_wallet
+        .remove_authority(&secondary_authority.pubkey().to_bytes())
+        .unwrap();
+
+    swig_wallet.display_swig().unwrap();
+
+    // Add third authority with recurring permissions
+    let third_authority = Keypair::new();
+
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &third_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 10_000_000_000,
+                recurring: Some(RecurringConfig::new(100)),
+            }],
+        )
+        .unwrap();
+
+    swig_wallet.display_swig().unwrap();
+
+    // Switch to third authority
+    swig_wallet
+        .switch_authority(
+            1,
+            AuthorityManager::Ed25519(third_authority.pubkey()),
+            Some(&third_authority),
+        )
+        .unwrap();
+
+    swig_wallet
+        .authenticate_authority(&third_authority.pubkey().to_bytes())
+        .unwrap();
+}
+
+#[test_log::test]
+fn should_add_secp256k1_authority() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    let wallet = LocalSigner::random();
+    println!("wallet: {:?}", wallet.address());
+
+    let secp_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let sec1_bytes = wallet.credential().verifying_key().to_sec1_bytes();
+    let secp1_pubkey = sec1_bytes.as_ref();
+
+    let authority_hex = hex::encode([&[0x4].as_slice(), secp1_pubkey].concat());
+    let mut hasher = solana_sdk::keccak::Hasher::default();
+    hasher.hash(authority_hex.as_bytes());
+    let hash = hasher.result();
+    let address = format!("0x{}", hex::encode(&hash.0[12..32]));
+    println!("address: {:?}", address);
+
+    println!(
+        "\t\tAuthority Public Key: 0x{} address {}",
+        authority_hex, address
+    );
+    println!("secp_pubkey length: {:?}", secp_pubkey);
+    println!("secp1_pubkey length: {:?}", secp1_pubkey);
+
+    // Add secondary authority with SOL permission
+    swig_wallet
+        .add_authority(
+            AuthorityType::Secp256k1,
+            &secp_pubkey.as_ref()[1..],
+            vec![Permission::Sol {
+                amount: 10_000_000_000,
+                recurring: None,
+            }],
+        )
+        .unwrap();
+
+    // Verify both authorities exist
+    swig_wallet.display_swig().unwrap();
+
+    // Remove secondary authority
+    swig_wallet
+        .remove_authority(&secp_pubkey.as_ref()[1..])
+        .unwrap();
+
+    swig_wallet.display_swig().unwrap();
+
+    // Add third authority with recurring permissions
+    let third_authority = Keypair::new();
+
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &third_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 10_000_000_000,
+                recurring: Some(RecurringConfig::new(100)),
+            }],
+        )
+        .unwrap();
+
+    swig_wallet.display_swig().unwrap();
+
+    // Switch to third authority
+    swig_wallet
+        .switch_authority(
+            1,
+            AuthorityManager::Ed25519(third_authority.pubkey()),
+            Some(&third_authority),
+        )
+        .unwrap();
+
+    swig_wallet
+        .authenticate_authority(&third_authority.pubkey().to_bytes())
+        .unwrap();
+}
+
+#[test_log::test]
+fn should_switch_authority_and_payer() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let secondary_authority = Keypair::new();
+    litesvm
+        .airdrop(&secondary_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Add and switch to secondary authority
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 10_000_000_000,
+                recurring: Some(RecurringConfig::new(100)),
+            }],
+        )
+        .unwrap();
+
+    swig_wallet
+        .switch_authority(
+            1,
+            AuthorityManager::Ed25519(secondary_authority.pubkey()),
+            Some(&secondary_authority),
+        )
+        .unwrap();
+
+    swig_wallet.switch_payer(&secondary_authority).unwrap();
+    swig_wallet.display_swig().unwrap();
+}
+
+#[test_log::test]
+fn should_replace_authority() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let old_authority = Keypair::new();
+    let new_authority = Keypair::new();
+
+    println!("old authority: {:?}", old_authority.pubkey());
+    println!("new authority: {:?}", new_authority.pubkey());
+    // Add old authority with SOL permission
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &old_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 10_000_000_000,
+                recurring: None,
+            }],
+        )
+        .unwrap();
+
+    // Verify old authority exists
+    swig_wallet.display_swig().unwrap();
+
+    // Replace old authority with new authority
+    swig_wallet
+        .replace_authority(
+            1,
+            AuthorityType::Ed25519,
+            &new_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 5_000_000_000, // Different amount to verify the replacement
+                recurring: None,
+            }],
+        )
+        .unwrap();
+
+    // Verify the replacement
+    swig_wallet.display_swig().unwrap();
+
+    // Try to authenticate with new authority (should succeed)
+    assert!(swig_wallet
+        .authenticate_authority(&new_authority.pubkey().to_bytes())
+        .is_ok());
+
+    // Try to authenticate with old authority (should fail)
+    assert!(swig_wallet
+        .authenticate_authority(&old_authority.pubkey().to_bytes())
+        .is_err());
+}

--- a/rust-sdk/src/tests/wallet/creation_tests.rs
+++ b/rust-sdk/src/tests/wallet/creation_tests.rs
@@ -1,0 +1,56 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_sdk::signature::{Keypair, Signer};
+
+use super::*;
+
+#[test_log::test]
+fn should_create_ed25519_wallet() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    swig_wallet.display_swig().unwrap();
+
+    let swig_pubkey = swig_wallet.get_swig_account().unwrap();
+    let swig_data = swig_wallet.litesvm().get_account(&swig_pubkey).unwrap();
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data.data).unwrap();
+
+    assert_eq!(swig_with_roles.state.id, [0; 32]);
+}
+
+#[test_log::test]
+fn should_create_secp256k1_wallet() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let wallet = LocalSigner::random();
+    let secp_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let sign_fn = move |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        let hash = B256::from(hash);
+        let tsig = wallet
+            .sign_hash_sync(&hash)
+            .map_err(|_| SwigError::InvalidSecp256k1)
+            .unwrap()
+            .as_bytes();
+        let mut sig = [0u8; 65];
+        sig.copy_from_slice(&tsig);
+        sig
+    };
+
+    let swig_wallet = SwigWallet::new(
+        [0; 32],
+        AuthorityManager::Secp256k1(secp_pubkey, Box::new(sign_fn)),
+        &main_authority,
+        &main_authority,
+        "http://localhost:8899".to_string(),
+        litesvm,
+    )
+    .unwrap();
+
+    swig_wallet.display_swig().unwrap();
+}

--- a/rust-sdk/src/tests/wallet/mod.rs
+++ b/rust-sdk/src/tests/wallet/mod.rs
@@ -1,0 +1,56 @@
+pub mod authority_tests;
+pub mod creation_tests;
+pub mod program_scope_test;
+pub mod session_tests;
+pub mod transfer_tests;
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use litesvm::LiteSVM;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signer};
+use swig_interface::swig;
+use swig_state_x::{
+    authority::{
+        ed25519::{CreateEd25519SessionAuthority, Ed25519SessionAuthority},
+        secp256k1::{CreateSecp256k1SessionAuthority, Secp256k1SessionAuthority},
+        AuthorityType,
+    },
+    swig::{swig_account_seeds, SwigWithRoles},
+    IntoBytes,
+};
+
+use crate::{
+    error::SwigError, instruction_builder::AuthorityManager, types::Permission, RecurringConfig,
+    SwigWallet,
+};
+
+use super::*;
+
+// Test helper functions
+fn setup_test_environment() -> (LiteSVM, Keypair) {
+    let mut litesvm = LiteSVM::new();
+    let main_authority = Keypair::new();
+
+    litesvm
+        .add_program_from_file(Pubkey::new_from_array(swig::ID), "../target/deploy/swig.so")
+        .map_err(|_| anyhow::anyhow!("Failed to load program"))
+        .unwrap();
+    litesvm
+        .airdrop(&main_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    (litesvm, main_authority)
+}
+
+fn create_test_wallet(litesvm: LiteSVM, authority: &Keypair) -> SwigWallet {
+    SwigWallet::new(
+        [0; 32],
+        AuthorityManager::Ed25519(authority.pubkey()),
+        authority,
+        authority,
+        "http://localhost:8899".to_string(),
+        litesvm,
+    )
+    .unwrap()
+}

--- a/rust-sdk/src/tests/wallet/mod.rs
+++ b/rust-sdk/src/tests/wallet/mod.rs
@@ -2,7 +2,9 @@ pub mod authority_tests;
 pub mod creation_tests;
 pub mod program_scope_test;
 pub mod session_tests;
+pub mod sub_accounts_test;
 pub mod transfer_tests;
+
 use alloy_primitives::B256;
 use alloy_signer::SignerSync;
 use alloy_signer_local::LocalSigner;

--- a/rust-sdk/src/tests/wallet/program_scope_test.rs
+++ b/rust-sdk/src/tests/wallet/program_scope_test.rs
@@ -1,0 +1,247 @@
+use super::*;
+use crate::tests::common::*;
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use litesvm_token::spl_token;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::{clock::Clock, signature::Keypair, transaction::VersionedTransaction};
+
+#[test_log::test]
+fn should_token_transfer_with_program_scope() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let recipient = Keypair::new();
+    let secondary_authority = Keypair::new();
+
+    litesvm
+        .airdrop(&secondary_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    // Setup token mint
+    let mint_pubkey = setup_mint(&mut litesvm, &main_authority).unwrap();
+
+    // Setup token accounts
+    let recipient_ata = setup_ata(
+        &mut litesvm,
+        &mint_pubkey,
+        &recipient.pubkey(),
+        &main_authority,
+    )
+    .unwrap();
+
+    // Create swig wallet
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let swig_ata = swig_wallet.create_ata(&mint_pubkey).unwrap();
+
+    let recipient = Keypair::new();
+
+    // Add authority with program scope
+    let new_authority = Keypair::new();
+
+    let permissions = vec![Permission::ProgramScope {
+        program_id: spl_token::ID,
+        target_account: swig_ata,
+        numeric_type: 2,
+        limit: None,
+        window: None,
+        balance_field_start: Some(64),
+        balance_field_end: Some(72),
+    }];
+
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &new_authority.pubkey().to_bytes(),
+            permissions,
+        )
+        .unwrap();
+
+    let swig_pubkey = swig_wallet.get_swig_account().unwrap();
+    let swig_data = swig_wallet.litesvm().get_account(&swig_pubkey).unwrap();
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data.data).unwrap();
+
+    assert_eq!(swig_with_roles.state.roles, 2);
+
+    // Mint tokens to swig wallet
+    let initial_token_amount = 2000;
+    mint_to(
+        &mut swig_wallet.litesvm(),
+        &mint_pubkey,
+        &main_authority,
+        &swig_ata,
+        initial_token_amount,
+    )
+    .unwrap();
+
+    // Transfer tokens
+    let swig_transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &recipient_ata,
+        &swig_wallet.get_swig_account().unwrap(),
+        &[],
+        100,
+    )
+    .unwrap();
+
+    let sign_ix = swig_wallet.sign(vec![swig_transfer_ix], None).unwrap();
+}
+
+#[test_log::test]
+fn should_token_transfer_with_recurring_limit_program_scope() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let recipient = Keypair::new();
+    let secondary_authority = Keypair::new();
+
+    litesvm
+        .airdrop(&secondary_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    // Setup token mint
+    let mint_pubkey = setup_mint(&mut litesvm, &main_authority).unwrap();
+
+    // Setup token accounts
+    let recipient_ata = setup_ata(
+        &mut litesvm,
+        &mint_pubkey,
+        &recipient.pubkey(),
+        &main_authority,
+    )
+    .unwrap();
+
+    // Create swig wallet
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let swig_ata = swig_wallet.create_ata(&mint_pubkey).unwrap();
+
+    // Setup a RecurringLimit program scope
+    // Set a limit of 500 tokens per 100 slots
+    let window_size = 100;
+    let transfer_limit = 500_u64;
+
+    let new_authority = Keypair::new();
+
+    let permissions = vec![Permission::ProgramScope {
+        program_id: spl_token::ID,
+        target_account: swig_ata,
+        numeric_type: 2, // U64
+        limit: Some(transfer_limit),
+        window: Some(window_size),
+        balance_field_start: Some(64),
+        balance_field_end: Some(72),
+    }];
+
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &new_authority.pubkey().to_bytes(),
+            permissions,
+        )
+        .unwrap();
+
+    let swig_pubkey = swig_wallet.get_swig_account().unwrap();
+    let swig_data = swig_wallet.litesvm().get_account(&swig_pubkey).unwrap();
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data.data).unwrap();
+
+    assert_eq!(swig_with_roles.state.roles, 2);
+
+    // Switch to the new authority
+    let authority_manager = AuthorityManager::Ed25519(new_authority.pubkey());
+    swig_wallet
+        .switch_authority(1, authority_manager, Some(&new_authority))
+        .unwrap();
+
+    // Mint initial tokens to swig wallet
+    let initial_token_amount = 2000;
+    mint_to(
+        &mut swig_wallet.litesvm(),
+        &mint_pubkey,
+        &main_authority,
+        &swig_ata,
+        initial_token_amount,
+    )
+    .unwrap();
+
+    // First batch of transfers - should succeed up to the limit
+    let transfer_batch = 100;
+    let mut transferred = 0;
+
+    // Transfer in batches of 100 tokens up to limit (should succeed)
+    while transferred + transfer_batch <= transfer_limit {
+        let before_token_account = swig_wallet.litesvm().get_account(&swig_ata).unwrap();
+        let before_balance = if before_token_account.data.len() >= 72 {
+            // SPL token accounts have their balance at offset 64-72
+            u64::from_le_bytes(before_token_account.data[64..72].try_into().unwrap())
+        } else {
+            0
+        };
+        println!("Before transfer, token balance: {}", before_balance);
+        let current_slot = swig_wallet.litesvm().get_sysvar::<Clock>().slot;
+        let swig_transfer_ix = spl_token::instruction::transfer(
+            &spl_token::ID,
+            &swig_ata,
+            &recipient_ata,
+            &swig_wallet.get_swig_account().unwrap(),
+            &[],
+            transfer_batch,
+        )
+        .unwrap();
+
+        let sign_ix = swig_wallet.sign(vec![swig_transfer_ix], None).unwrap();
+        transferred += transfer_batch;
+
+        swig_wallet.litesvm().expire_blockhash();
+
+        // Get the current token balance after the transfer
+        let after_token_account = swig_wallet.litesvm().get_account(&swig_ata).unwrap();
+        let after_balance = if after_token_account.data.len() >= 72 {
+            // SPL token accounts have their balance at offset 64-72
+            u64::from_le_bytes(after_token_account.data[64..72].try_into().unwrap())
+        } else {
+            0
+        };
+        println!("After transfer, token balance: {}", after_balance);
+
+        swig_wallet.display_swig().unwrap();
+    }
+
+    // Try to transfer one more batch (should fail)
+    let swig_transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &recipient_ata,
+        &swig_wallet.get_swig_account().unwrap(),
+        &[],
+        transfer_batch,
+    )
+    .unwrap();
+
+    let sign_result = swig_wallet.sign(vec![swig_transfer_ix], None);
+    assert!(
+        sign_result.is_err(),
+        "Transfer should have failed due to limit"
+    );
+
+    // Advance the clock past the window to trigger a reset
+    let current_slot = swig_wallet.litesvm().get_sysvar::<Clock>().slot;
+    swig_wallet
+        .litesvm()
+        .warp_to_slot(current_slot + window_size + 1);
+    swig_wallet.litesvm().expire_blockhash();
+
+    // After resetting the clock, we should be able to transfer again
+    let swig_transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &recipient_ata,
+        &swig_wallet.get_swig_account().unwrap(),
+        &[],
+        transfer_batch,
+    )
+    .unwrap();
+
+    let sign_result = swig_wallet.sign(vec![swig_transfer_ix], None);
+    assert!(
+        sign_result.is_ok(),
+        "Token transfer after window reset failed: {:?}",
+        sign_result.err()
+    );
+}

--- a/rust-sdk/src/tests/wallet/session_tests.rs
+++ b/rust-sdk/src/tests/wallet/session_tests.rs
@@ -1,0 +1,81 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_sdk::signature::{Keypair, Signer};
+use swig_state_x::authority::{
+    ed25519::{CreateEd25519SessionAuthority, Ed25519SessionAuthority},
+    secp256k1::{CreateSecp256k1SessionAuthority, Secp256k1SessionAuthority},
+    AuthorityType,
+};
+
+use super::*;
+
+#[test_log::test]
+fn should_create_ed25519_session_authority() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let session_key = Keypair::new();
+
+    let mut swig_wallet = SwigWallet::new(
+        [0; 32],
+        AuthorityManager::Ed25519Session(CreateEd25519SessionAuthority::new(
+            main_authority.pubkey().to_bytes(),
+            session_key.pubkey().to_bytes(),
+            100,
+        )),
+        &main_authority,
+        &main_authority,
+        "http://localhost:8899".to_string(),
+        litesvm,
+    )
+    .unwrap();
+
+    let swig_pubkey = swig_wallet.get_swig_account().unwrap();
+    swig_wallet
+        .litesvm()
+        .airdrop(&swig_pubkey, 10_000_000_000)
+        .unwrap();
+
+    let new_session_key = Keypair::new();
+    swig_wallet
+        .create_session(new_session_key.pubkey(), 100)
+        .unwrap();
+
+    swig_wallet.display_swig().unwrap();
+}
+
+#[test_log::test]
+fn should_create_secp256k1_session_authority() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let wallet = LocalSigner::random();
+    let secp_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let sign_fn = move |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        let hash = B256::from(hash);
+        wallet.sign_hash_sync(&hash).unwrap().as_bytes()
+    };
+
+    let swig_wallet = SwigWallet::new(
+        [0; 32],
+        AuthorityManager::Secp256k1Session(
+            CreateSecp256k1SessionAuthority::new(
+                secp_pubkey[1..].try_into().unwrap(),
+                [0; 32],
+                100,
+            ),
+            Box::new(sign_fn),
+        ),
+        &main_authority,
+        &main_authority,
+        "http://localhost:8899".to_string(),
+        litesvm,
+    )
+    .unwrap();
+
+    swig_wallet.display_swig().unwrap();
+}

--- a/rust-sdk/src/tests/wallet/sub_accounts_test.rs
+++ b/rust-sdk/src/tests/wallet/sub_accounts_test.rs
@@ -1,0 +1,478 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_program::system_instruction;
+use solana_sdk::signature::{Keypair, Signer};
+use spl_token::ID as TOKEN_PROGRAM_ID;
+
+use super::*;
+
+#[test_log::test]
+fn test_sub_account_creation_and_setup() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Create a secondary authority with sub-account permissions
+    let secondary_authority = Keypair::new();
+    let secondary_role_id = 1;
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::SubAccount {
+                sub_account: [0; 32],
+            }],
+        )
+        .unwrap();
+
+    // Verify initial setup
+    swig_wallet.display_swig().unwrap();
+
+    // Switch to secondary authority and create sub-account
+    swig_wallet
+        .switch_authority(
+            secondary_role_id,
+            AuthorityManager::Ed25519(secondary_authority.pubkey()),
+            Some(&secondary_authority),
+        )
+        .unwrap();
+
+    let signature = swig_wallet.create_sub_account().unwrap();
+    println!("Sub-account created with signature: {:?}", signature);
+
+    // Verify sub-account creation
+    let role_id_bytes = swig_wallet.get_current_role_id().unwrap().to_le_bytes();
+    let (sub_account, _) = Pubkey::find_program_address(
+        &swig_state_x::swig::sub_account_seeds(&[0; 32], &role_id_bytes),
+        &swig_interface::program_id(),
+    );
+    println!("Sub-account address: {}", &sub_account);
+}
+
+#[test_log::test]
+fn test_sub_account_sol_operations() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Setup secondary authority and create sub-account
+    let secondary_authority = Keypair::new();
+    let secondary_role_id = 1;
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::SubAccount {
+                sub_account: [0; 32],
+            }],
+        )
+        .unwrap();
+
+    // Switch to secondary authority with explicit authority keypair
+    swig_wallet
+        .switch_authority(
+            secondary_role_id,
+            AuthorityManager::Ed25519(secondary_authority.pubkey()),
+            Some(&secondary_authority), // Pass the actual keypair
+        )
+        .unwrap();
+
+    // Create sub-account
+    let signature = swig_wallet.create_sub_account().unwrap();
+    println!("Created sub-account with signature: {:?}", signature);
+
+    // Get sub-account address
+    let role_id_bytes = swig_wallet.get_current_role_id().unwrap().to_le_bytes();
+
+    println!("Swig ID: {:?}", [0; 32]);
+    println!("Role ID: {:?}", swig_wallet.get_current_role_id().unwrap());
+    println!("program_id: {:?}", swig_interface::program_id());
+    let (sub_account, _) = Pubkey::find_program_address(
+        &swig_state_x::swig::sub_account_seeds(&[0; 32], &role_id_bytes),
+        &swig_interface::program_id(),
+    );
+    println!("Sub-account address: {}", &sub_account);
+
+    // Fund accounts
+    swig_wallet
+        .litesvm()
+        .airdrop(&sub_account, 100_000_000)
+        .unwrap();
+
+    let recipient = Keypair::new();
+    swig_wallet
+        .litesvm()
+        .airdrop(&recipient.pubkey(), 1_000_000)
+        .unwrap();
+
+    swig_wallet
+        .litesvm()
+        .airdrop(&secondary_authority.pubkey(), 1_000_000)
+        .unwrap();
+
+    // Get initial balances
+    let initial_balance = swig_wallet.litesvm().get_balance(&sub_account).unwrap();
+    println!("Initial sub-account balance: {:?}", initial_balance);
+    let initial_recipient_balance = swig_wallet
+        .litesvm()
+        .get_balance(&recipient.pubkey())
+        .unwrap();
+    println!("Initial recipient balance: {:?}", initial_recipient_balance);
+
+    // Test transfer
+    let transfer_ix = system_instruction::transfer(&sub_account, &recipient.pubkey(), 1_000_000);
+    let signature = swig_wallet
+        .sign_with_sub_account(vec![transfer_ix], None)
+        .unwrap();
+    println!("Transfer signature: {:?}", signature);
+
+    // Verify the transfer
+    let final_balance = swig_wallet.litesvm().get_balance(&sub_account).unwrap();
+    let recipient_balance = swig_wallet
+        .litesvm()
+        .get_balance(&recipient.pubkey())
+        .unwrap();
+    assert_eq!(
+        initial_balance - final_balance,
+        1_000_000,
+        "Transfer amount mismatch"
+    );
+    assert_eq!(
+        recipient_balance,
+        2_000_000, // Initial 1M + transferred 1M
+        "Recipient balance mismatch"
+    );
+
+    // Test withdrawal
+    let initial_balance = final_balance;
+
+    // Switch back to main authority
+    swig_wallet
+        .switch_authority(
+            0,
+            AuthorityManager::Ed25519(main_authority.pubkey()),
+            Some(&main_authority),
+        )
+        .unwrap();
+
+    let signature = swig_wallet
+        .withdraw_from_sub_account(sub_account, 500_000)
+        .unwrap();
+    println!("Withdrawal signature: {:?}", signature);
+
+    // Verify the withdrawal
+    let final_balance = swig_wallet.litesvm().get_balance(&sub_account).unwrap();
+    assert_eq!(
+        initial_balance - final_balance,
+        500_000,
+        "Withdrawal amount mismatch"
+    );
+}
+
+#[test_log::test]
+fn test_sub_account_token_operations() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Setup and create sub-account
+    let secondary_authority = Keypair::new();
+    let secondary_role_id = 1;
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::SubAccount {
+                sub_account: [0; 32],
+            }],
+        )
+        .unwrap();
+
+    swig_wallet
+        .switch_authority(
+            secondary_role_id,
+            AuthorityManager::Ed25519(secondary_authority.pubkey()),
+            Some(&secondary_authority),
+        )
+        .unwrap();
+
+    let signature = swig_wallet.create_sub_account().unwrap();
+    let role_id_bytes = swig_wallet.get_current_role_id().unwrap().to_le_bytes();
+    let (sub_account, _) = Pubkey::find_program_address(
+        &swig_state_x::swig::sub_account_seeds(&[0; 32], &role_id_bytes),
+        &swig_interface::program_id(),
+    );
+
+    use crate::tests::common::{mint_to, setup_ata, setup_mint};
+    // Test token operations
+    let mint = setup_mint(swig_wallet.litesvm(), &main_authority).unwrap();
+
+    // Setup ATAs for sub-account and swig
+    let sub_account_ata =
+        setup_ata(swig_wallet.litesvm(), &mint, &sub_account, &main_authority).unwrap();
+    let swig_account = swig_wallet.get_swig_account().unwrap();
+    let swig_token =
+        setup_ata(swig_wallet.litesvm(), &mint, &swig_account, &main_authority).unwrap();
+
+    // Mint some tokens to the sub-account ATA
+    mint_to(
+        swig_wallet.litesvm(),
+        &mint,
+        &main_authority,
+        &sub_account_ata,
+        10000,
+    )
+    .unwrap();
+
+    swig_wallet
+        .switch_authority(
+            0,
+            AuthorityManager::Ed25519(main_authority.pubkey()),
+            Some(&main_authority),
+        )
+        .unwrap();
+    let signature = swig_wallet
+        .withdraw_token_from_sub_account(
+            sub_account,
+            sub_account_ata,
+            swig_token,
+            TOKEN_PROGRAM_ID,
+            1000,
+        )
+        .unwrap();
+    println!("Token withdrawal signature: {:?}", signature);
+}
+
+#[test_log::test]
+fn test_sub_account_toggle_operations() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Setup and create sub-account
+    let secondary_authority = Keypair::new();
+    let secondary_role_id = 1;
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::SubAccount {
+                sub_account: [0; 32],
+            }],
+        )
+        .unwrap();
+
+    swig_wallet
+        .switch_authority(
+            secondary_role_id,
+            AuthorityManager::Ed25519(secondary_authority.pubkey()),
+            Some(&secondary_authority),
+        )
+        .unwrap();
+
+    let signature = swig_wallet.create_sub_account().unwrap();
+    let role_id_bytes = swig_wallet.get_current_role_id().unwrap().to_le_bytes();
+    let (sub_account, _) = Pubkey::find_program_address(
+        &swig_state_x::swig::sub_account_seeds(&[0; 32], &role_id_bytes),
+        &swig_interface::program_id(),
+    );
+
+    swig_wallet
+        .switch_authority(
+            0,
+            AuthorityManager::Ed25519(main_authority.pubkey()),
+            Some(&main_authority),
+        )
+        .unwrap();
+
+    // Test toggle operations
+    let signature = swig_wallet.toggle_sub_account(sub_account, false).unwrap();
+    println!("Disable signature: {:?}", signature);
+
+    let signature = swig_wallet.toggle_sub_account(sub_account, true).unwrap();
+    println!("Enable signature: {:?}", signature);
+}
+
+#[test_log::test]
+fn test_secondary_authority_operations() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Setup secondary authority
+    let secondary_authority = Keypair::new();
+    let secondary_role_id = 1;
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::SubAccount {
+                sub_account: [0; 32],
+            }],
+        )
+        .unwrap();
+
+    // Create sub-account with main authority
+    swig_wallet
+        .switch_authority(
+            secondary_role_id,
+            AuthorityManager::Ed25519(secondary_authority.pubkey()),
+            Some(&secondary_authority),
+        )
+        .unwrap();
+
+    let signature = swig_wallet.create_sub_account().unwrap();
+    let role_id_bytes = swig_wallet.get_current_role_id().unwrap().to_le_bytes();
+    let (sub_account, _) = Pubkey::find_program_address(
+        &swig_state_x::swig::sub_account_seeds(&[0; 32], &role_id_bytes),
+        &swig_interface::program_id(),
+    );
+
+    // Test secondary authority operations
+    let recipient = Keypair::new();
+    let transfer_ix = system_instruction::transfer(&sub_account, &recipient.pubkey(), 1_000_000);
+
+    // Fund sub-account
+    swig_wallet
+        .litesvm()
+        .airdrop(&sub_account, 100_000_000)
+        .unwrap();
+
+    let signature = swig_wallet
+        .sign_with_sub_account(vec![transfer_ix], None)
+        .unwrap();
+    println!("Secondary authority signature: {:?}", signature);
+
+    // Verify final state
+    swig_wallet.display_swig().unwrap();
+}
+
+#[test_log::test]
+fn test_sub_account_error_cases() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Test Case 1: Non-existent sub-account operations
+    let non_existent_sub_account = Pubkey::new_unique();
+    let result = swig_wallet.withdraw_from_sub_account(non_existent_sub_account, 1000);
+    assert!(matches!(
+        result.unwrap_err(),
+        SwigError::TransactionFailedWithLogs { .. }
+    ));
+
+    // Test Case 2: Authority without sub-account permissions
+    let unauthorized_authority = Keypair::new();
+    let recurring = RecurringConfig::new(100);
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &unauthorized_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 100_000_000,
+                recurring: Some(recurring),
+            }], // No sub-account permission
+        )
+        .unwrap();
+
+    // Switch to unauthorized authority
+    swig_wallet
+        .switch_authority(
+            1,
+            AuthorityManager::Ed25519(unauthorized_authority.pubkey()),
+            Some(&unauthorized_authority),
+        )
+        .unwrap();
+
+    // Fund the unauthorized authority for transaction fees
+    swig_wallet
+        .litesvm()
+        .airdrop(&unauthorized_authority.pubkey(), 100_000_000)
+        .unwrap();
+
+    // Test Case 3: Creating sub-account without permission
+    let result = swig_wallet.create_sub_account();
+    assert!(matches!(
+        result.unwrap_err(),
+        SwigError::TransactionFailedWithLogs { .. }
+    ));
+
+    // Test Case 4: Create valid sub-account with main authority
+    // First, ensure main authority has sub-account permission
+    // Add sub-account permission to main authority
+    swig_wallet
+        .switch_authority(
+            0,
+            AuthorityManager::Ed25519(main_authority.pubkey()),
+            Some(&main_authority),
+        )
+        .unwrap();
+
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &main_authority.pubkey().to_bytes(),
+            vec![Permission::SubAccount {
+                sub_account: [0; 32],
+            }],
+        )
+        .unwrap();
+
+    swig_wallet
+        .switch_authority(
+            2,
+            AuthorityManager::Ed25519(main_authority.pubkey()),
+            Some(&main_authority),
+        )
+        .unwrap();
+
+    let signature = swig_wallet.create_sub_account().unwrap();
+    println!("Created sub-account with signature: {:?}", signature);
+
+    // Get sub-account address
+    let role_id_bytes = swig_wallet.get_current_role_id().unwrap().to_le_bytes();
+    let (sub_account, _) = Pubkey::find_program_address(
+        &swig_state_x::swig::sub_account_seeds(&[0; 32], &role_id_bytes),
+        &swig_interface::program_id(),
+    );
+
+    // Fund the sub-account for withdrawal tests
+    swig_wallet
+        .litesvm()
+        .airdrop(&sub_account, 1_000_000)
+        .unwrap();
+
+    // Test Case 5: Unauthorized operations on existing sub-account
+    swig_wallet
+        .switch_authority(
+            1,
+            AuthorityManager::Ed25519(unauthorized_authority.pubkey()),
+            Some(&unauthorized_authority),
+        )
+        .unwrap();
+
+    // Try to withdraw with unauthorized authority
+    let result = swig_wallet.withdraw_from_sub_account(sub_account, 1000);
+    assert!(matches!(
+        result.unwrap_err(),
+        SwigError::TransactionFailedWithLogs { .. }
+    ));
+
+    // Try to toggle with unauthorized authority
+    let result = swig_wallet.toggle_sub_account(sub_account, false);
+    assert!(matches!(
+        result.unwrap_err(),
+        SwigError::TransactionFailedWithLogs { .. }
+    ));
+
+    // Test Case 6: Invalid sub-account operations with main authority
+    swig_wallet
+        .switch_authority(
+            0,
+            AuthorityManager::Ed25519(main_authority.pubkey()),
+            Some(&main_authority),
+        )
+        .unwrap();
+
+    // Try to withdraw more than balance
+    let result = swig_wallet.withdraw_from_sub_account(sub_account, u64::MAX);
+    assert!(matches!(
+        result.unwrap_err(),
+        SwigError::TransactionFailedWithLogs { .. }
+    ));
+}

--- a/rust-sdk/src/tests/wallet/transfer_tests.rs
+++ b/rust-sdk/src/tests/wallet/transfer_tests.rs
@@ -1,0 +1,131 @@
+use solana_program::system_instruction;
+use solana_sdk::signature::{Keypair, Signer};
+
+use super::*;
+
+#[test_log::test]
+fn should_transfer_within_limits() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let secondary_authority = Keypair::new();
+    litesvm
+        .airdrop(&secondary_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Setup secondary authority with permissions
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 1_000_000_000,
+                recurring: None,
+            }],
+        )
+        .unwrap();
+
+    swig_wallet
+        .switch_authority(
+            1,
+            AuthorityManager::Ed25519(secondary_authority.pubkey()),
+            Some(&secondary_authority),
+        )
+        .unwrap();
+    swig_wallet.switch_payer(&secondary_authority).unwrap();
+
+    let swig_account = swig_wallet.get_swig_account().unwrap();
+    let recipient = Keypair::new();
+
+    // Airdrop funds to swig account
+    swig_wallet
+        .litesvm()
+        .airdrop(&swig_account, 5_000_000_000)
+        .unwrap();
+
+    // Transfer within limits
+    let transfer_ix = system_instruction::transfer(&swig_account, &recipient.pubkey(), 100_000_000);
+
+    assert!(swig_wallet.sign(vec![transfer_ix], None).is_ok());
+    swig_wallet.display_swig().unwrap();
+}
+
+#[test_log::test]
+fn should_fail_transfer_beyond_limits() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let secondary_authority = Keypair::new();
+    litesvm
+        .airdrop(&secondary_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Add secondary authority with limited SOL permission
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 1_000_000_000,
+                recurring: None,
+            }],
+        )
+        .unwrap();
+
+    swig_wallet
+        .switch_authority(
+            1,
+            AuthorityManager::Ed25519(secondary_authority.pubkey()),
+            Some(&secondary_authority),
+        )
+        .unwrap();
+    swig_wallet.switch_payer(&secondary_authority).unwrap();
+
+    // Attempt transfer beyond limits
+    let recipient = Keypair::new();
+    let transfer_ix = system_instruction::transfer(
+        &swig_wallet.get_swig_account().unwrap(),
+        &recipient.pubkey(),
+        2_000_000_000, // Amount greater than permission limit
+    );
+
+    assert!(swig_wallet.sign(vec![transfer_ix], None).is_err());
+}
+
+#[test_log::test]
+fn should_get_role_id() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    let authority_2 = Keypair::new();
+    let authority_3 = Keypair::new();
+
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &authority_2.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 10_000_000_000,
+                recurring: None,
+            }],
+        )
+        .unwrap();
+
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &authority_3.pubkey().to_bytes(),
+            vec![Permission::Sol {
+                amount: 10_000_000_000,
+                recurring: None,
+            }],
+        )
+        .unwrap();
+
+    swig_wallet.display_swig().unwrap();
+    let role_id = swig_wallet
+        .get_role_id(&authority_3.pubkey().to_bytes())
+        .unwrap();
+    println!("role_id: {:?}", role_id);
+    assert_eq!(role_id, 2);
+}

--- a/rust-sdk/src/tests/wallet/transfer_tests.rs
+++ b/rust-sdk/src/tests/wallet/transfer_tests.rs
@@ -32,7 +32,6 @@ fn should_transfer_within_limits() {
             Some(&secondary_authority),
         )
         .unwrap();
-    swig_wallet.switch_payer(&secondary_authority).unwrap();
 
     let swig_account = swig_wallet.get_swig_account().unwrap();
     let recipient = Keypair::new();

--- a/rust-sdk/src/types.rs
+++ b/rust-sdk/src/types.rs
@@ -1,10 +1,21 @@
 use solana_program::pubkey::Pubkey;
 use swig_interface::ClientAction;
 use swig_state_x::action::{
-    all::All, manage_authority::ManageAuthority, program::Program, sol_limit::SolLimit,
-    sol_recurring_limit::SolRecurringLimit, sub_account::SubAccount, token_limit::TokenLimit,
+    all::All,
+    manage_authority::ManageAuthority,
+    program::Program,
+    program_scope::{NumericType, ProgramScope, ProgramScopeType},
+    sol_limit::SolLimit,
+    sol_recurring_limit::SolRecurringLimit,
+    stake_all::StakeAll,
+    stake_limit::StakeLimit,
+    stake_recurring_limit::StakeRecurringLimit,
+    sub_account::SubAccount,
+    token_limit::TokenLimit,
     token_recurring_limit::TokenRecurringLimit,
 };
+
+use crate::SwigError;
 
 /// Configuration for recurring limits that reset after a specified time window
 #[derive(Debug, Clone)]
@@ -70,12 +81,37 @@ pub enum Permission {
         program_id: Pubkey,
     },
 
+    /// Permission to interact with specific programs. This allows the wallet
+    /// to execute instructions for the specified program.
+    ProgramScope {
+        program_id: Pubkey,
+        target_account: Pubkey,
+        numeric_type: u64,
+        limit: Option<u64>,
+        window: Option<u64>,
+        balance_field_start: Option<u64>,
+        balance_field_end: Option<u64>,
+    },
+
     /// Permission to manage sub-accounts. This allows creating and managing
     /// hierarchical wallet structures through sub-accounts.
     SubAccount {
         /// The public key of the sub-account
         sub_account: Pubkey,
     },
+
+    /// Permission to manage stake accounts with a fixed limit
+    Stake {
+        /// The maximum amount of stake (in lamports) that can be managed
+        amount: u64,
+        /// Optional recurring configuration. If provided, the amount becomes a
+        /// recurring limit that resets after the specified window
+        /// period. If None, amount is treated as a fixed limit.
+        recurring: Option<RecurringConfig>,
+    },
+
+    /// Permission to manage all stake-related operations without limits
+    StakeAll,
 }
 
 impl Permission {
@@ -130,10 +166,57 @@ impl Permission {
                         program_id: program_id.to_bytes(),
                     }));
                 },
+                Permission::ProgramScope {
+                    program_id,
+                    target_account,
+                    numeric_type,
+                    window,
+                    limit,
+                    balance_field_start,
+                    balance_field_end,
+                } => {
+                    let (scope_type, window, limit) = match (window, limit) {
+                        (Some(window), Some(limit)) => {
+                            (ProgramScopeType::RecurringLimit as u64, window, limit)
+                        },
+                        (None, Some(limit)) => (ProgramScopeType::Limit as u64, 0, limit),
+                        (None, None) => (ProgramScopeType::Basic as u64, 0, 0),
+                        (Some(_), None) => (ProgramScopeType::Basic as u64, 0, 0),
+                    };
+
+                    actions.push(ClientAction::ProgramScope(ProgramScope {
+                        program_id: program_id.to_bytes(),
+                        target_account: target_account.to_bytes(),
+                        scope_type: scope_type as u64,
+                        numeric_type: numeric_type as u64,
+                        current_amount: 0 as u128,
+                        limit: limit as u128,
+                        window: window as u64,
+                        last_reset: 0,
+                        balance_field_start: balance_field_start.unwrap_or(0) as u64,
+                        balance_field_end: balance_field_end.unwrap_or(0) as u64,
+                    }));
+                },
                 Permission::SubAccount { sub_account } => {
                     actions.push(ClientAction::SubAccount(SubAccount {
                         sub_account: sub_account.to_bytes(),
                     }));
+                },
+                Permission::Stake { amount, recurring } => match recurring {
+                    Some(config) => {
+                        actions.push(ClientAction::StakeRecurringLimit(StakeRecurringLimit {
+                            recurring_amount: amount,
+                            window: config.window,
+                            last_reset: 0,
+                            current_amount: 0,
+                        }));
+                    },
+                    None => {
+                        actions.push(ClientAction::StakeLimit(StakeLimit { amount }));
+                    },
+                },
+                Permission::StakeAll => {
+                    actions.push(ClientAction::StakeAll(StakeAll {}));
                 },
             }
         }

--- a/rust-sdk/src/types.rs
+++ b/rust-sdk/src/types.rs
@@ -95,10 +95,7 @@ pub enum Permission {
 
     /// Permission to manage sub-accounts. This allows creating and managing
     /// hierarchical wallet structures through sub-accounts.
-    SubAccount {
-        /// The public key of the sub-account
-        sub_account: Pubkey,
-    },
+    SubAccount { sub_account: [u8; 32] },
 
     /// Permission to manage stake accounts with a fixed limit
     Stake {
@@ -198,9 +195,7 @@ impl Permission {
                     }));
                 },
                 Permission::SubAccount { sub_account } => {
-                    actions.push(ClientAction::SubAccount(SubAccount {
-                        sub_account: sub_account.to_bytes(),
-                    }));
+                    actions.push(ClientAction::SubAccount(SubAccount { sub_account }));
                 },
                 Permission::Stake { amount, recurring } => match recurring {
                     Some(config) => {

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -30,7 +30,7 @@ use swig_state_x::{action::program_scope::ProgramScope, authority::secp256k1::Se
 use swig_state_x::{
     action::{
         all::All, manage_authority::ManageAuthority, sol_limit::SolLimit,
-        sol_recurring_limit::SolRecurringLimit,
+        sol_recurring_limit::SolRecurringLimit, sub_account::SubAccount,
     },
     authority::{self, AuthorityType},
     role::Role,
@@ -294,13 +294,7 @@ impl<'c> SwigWallet<'c> {
             self.get_current_blockhash()?,
         )?;
 
-        let tx = VersionedTransaction::try_new(
-            VersionedMessage::V0(msg),
-            &[
-                &self.fee_payer.insecure_clone(),
-                &self.authority.insecure_clone(),
-            ],
-        )?;
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
 
         self.send_and_confirm_transaction(tx)
     }
@@ -341,10 +335,180 @@ impl<'c> SwigWallet<'c> {
             self.get_current_blockhash()?,
         )?;
 
-        let tx = VersionedTransaction::try_new(
-            VersionedMessage::V0(msg),
-            &[self.fee_payer.insecure_clone()],
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+
+        self.send_and_confirm_transaction(tx)
+    }
+
+    /// Creates a new sub-account for the Swig wallet
+    ///
+    /// # Arguments
+    ///
+    /// * `role_id` - The ID of the role to create the sub-account for
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the transaction signature or a `SwigError`
+    pub fn create_sub_account(&mut self) -> Result<Signature, SwigError> {
+        let instruction = self
+            .instruction_builder
+            .create_sub_account(Some(self.get_current_slot()?))?;
+
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &[instruction],
+            &[],
+            self.get_current_blockhash()?,
         )?;
+
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+
+        self.send_and_confirm_transaction(tx)
+    }
+
+    /// Signs instructions with a sub-account
+    ///
+    /// # Arguments
+    ///
+    /// * `instructions` - Vector of instructions to sign with the sub-account
+    /// * `sub_account` - The public key of the sub-account
+    /// * `alt` - Optional slice of Address Lookup Table accounts
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the transaction signature or a `SwigError`
+    pub fn sign_with_sub_account(
+        &mut self,
+        instructions: Vec<Instruction>,
+        alt: Option<&[AddressLookupTableAccount]>,
+    ) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let sign_ix = self
+            .instruction_builder
+            .sign_instruction_with_sub_account(instructions, Some(current_slot))?;
+
+        let alt = if alt.is_some() { alt.unwrap() } else { &[] };
+
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &[sign_ix],
+            alt,
+            self.get_current_blockhash()?,
+        )?;
+
+        // We need both the fee payer and the authority to sign
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+
+        self.send_and_confirm_transaction(tx)
+    }
+
+    /// Withdraws native SOL from a sub-account
+    ///
+    /// # Arguments
+    ///
+    /// * `sub_account` - The public key of the sub-account
+    /// * `amount` - The amount of SOL to withdraw in lamports
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the transaction signature or a `SwigError`
+    pub fn withdraw_from_sub_account(
+        &mut self,
+        sub_account: Pubkey,
+        amount: u64,
+    ) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let withdraw_ix = self.instruction_builder.withdraw_from_sub_account(
+            sub_account,
+            amount,
+            Some(current_slot),
+        )?;
+
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &[withdraw_ix],
+            &[],
+            self.get_current_blockhash()?,
+        )?;
+
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+
+        self.send_and_confirm_transaction(tx)
+    }
+
+    /// Withdraws SPL tokens from a sub-account
+    ///
+    /// # Arguments
+    ///
+    /// * `sub_account` - The public key of the sub-account
+    /// * `sub_account_token` - The token account of the sub-account
+    /// * `swig_token` - The token account of the Swig account
+    /// * `token_program` - The token program ID
+    /// * `amount` - The amount of tokens to withdraw
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the transaction signature or a `SwigError`
+    pub fn withdraw_token_from_sub_account(
+        &mut self,
+        sub_account: Pubkey,
+        sub_account_token: Pubkey,
+        swig_token: Pubkey,
+        token_program: Pubkey,
+        amount: u64,
+    ) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let withdraw_ix = self.instruction_builder.withdraw_token_from_sub_account(
+            sub_account,
+            sub_account_token,
+            swig_token,
+            token_program,
+            amount,
+            Some(current_slot),
+        )?;
+
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &[withdraw_ix],
+            &[],
+            self.get_current_blockhash()?,
+        )?;
+
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+
+        self.send_and_confirm_transaction(tx)
+    }
+
+    /// Toggles a sub-account's enabled state
+    ///
+    /// # Arguments
+    ///
+    /// * `sub_account` - The public key of the sub-account
+    /// * `enabled` - Whether to enable or disable the sub-account
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the transaction signature or a `SwigError`
+    pub fn toggle_sub_account(
+        &mut self,
+        sub_account: Pubkey,
+        enabled: bool,
+    ) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let toggle_ix = self.instruction_builder.toggle_sub_account(
+            sub_account,
+            enabled,
+            Some(current_slot),
+        )?;
+
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &[toggle_ix],
+            &[],
+            self.get_current_blockhash()?,
+        )?;
+
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
 
         self.send_and_confirm_transaction(tx)
     }
@@ -365,17 +529,14 @@ impl<'c> SwigWallet<'c> {
         #[cfg(not(all(feature = "rust_sdk_test", test)))]
         let signature = self.rpc_client.send_and_confirm_transaction(&tx)?;
         #[cfg(all(feature = "rust_sdk_test", test))]
-        let signature = self.litesvm.send_transaction(tx).map_err(|e| {
-            SwigError::TransactionFailedWithLogs {
+        let signature = self
+            .litesvm
+            .send_transaction(tx)
+            .map_err(|e| SwigError::TransactionFailedWithLogs {
                 error: e.err.to_string(),
                 logs: e.meta.logs,
-            }
-        })?;
-        #[cfg(all(feature = "rust_sdk_test", test))]
-        println!("signature: {:?}", signature);
-
-        #[cfg(all(feature = "rust_sdk_test", test))]
-        let signature = signature.signature;
+            })?
+            .signature;
 
         Ok(signature)
     }
@@ -676,6 +837,14 @@ impl<'c> SwigWallet<'c> {
                     println!("║ │  │  ");
                 }
 
+                // Check Sub Account
+                if let Some(action) = Role::get_action::<SubAccount>(&role, &[])
+                    .map_err(|_| SwigError::AuthorityNotFound)?
+                {
+                    println!("║ │  ├─ Sub Account");
+                    println!("║ │  │  ├─ Sub Account: {:?}", action.sub_account);
+                }
+
                 println!("║ │  ");
             }
         }
@@ -712,12 +881,24 @@ impl<'c> SwigWallet<'c> {
         }
     }
 
+    /// Returns the role id of the Swig account
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the role id of the Swig account or a
+    /// `SwigError`
+    pub fn get_current_role_id(&self) -> Result<u32, SwigError> {
+        Ok(self.instruction_builder.get_role_id())
+    }
+
     /// Switches to a different authority for the Swig wallet
     ///
     /// # Arguments
     ///
     /// * `role_id` - The new role ID to switch to
-    /// * `authority` - The public key of the new authority
+    /// * `authority_manager` - The authority manager specifying the type of
+    ///   signing authority
+    /// * `authority_kp` - The public key of the new authority
     ///
     /// # Returns
     ///
@@ -728,11 +909,15 @@ impl<'c> SwigWallet<'c> {
         authority_manager: AuthorityManager,
         authority_kp: Option<&'c Keypair>,
     ) -> Result<(), SwigError> {
+        // Ensure authority keypair is provided when switching authorities
+        let authority_kp = authority_kp.ok_or(SwigError::AuthorityNotFound)?;
+
+        // Update the instruction builder's authority
         self.instruction_builder
             .switch_authority(role_id, authority_manager)?;
-        if let Some(authority_kp) = authority_kp {
-            self.authority = authority_kp;
-        }
+
+        // Update the authority keypair that will be used for signing
+        self.authority = authority_kp;
         Ok(())
     }
 
@@ -852,6 +1037,20 @@ impl<'c> SwigWallet<'c> {
         #[cfg(all(feature = "rust_sdk_test", test))]
         let balance = self.litesvm.get_balance(&swig_pubkey).unwrap();
         Ok(balance)
+    }
+
+    /// Returns the keypairs for signing transactions
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the keypairs for signing transactions or a `SwigError`
+    fn get_keypairs(&self) -> Result<Vec<&Keypair>, SwigError> {
+        // Check if the authority and fee payer are the same
+        if self.fee_payer.pubkey() == self.authority.pubkey() {
+            Ok(vec![&self.fee_payer])
+        } else {
+            Ok(vec![&self.fee_payer, &self.authority])
+        }
     }
 
     /// Creates an associated token account for the Swig wallet


### PR DESCRIPTION
This change includes support for

- Sub Accounts
- Program Scope

The change is adopted in the 

- Swig Instruction Builder
- Swig Wallet SDK
- Swig CLI  (interactive mode and command mode)