### PR TITLE
Secp256r1 Support and Sig replay fix for session 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,7 +59,7 @@ version = "2.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf37e04221e454874cc9cebf92482ee40e4f1fb5412f701cd712835725582190"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "solana-epoch-schedule",
  "solana-hash",
  "solana-pubkey",
@@ -97,17 +87,6 @@ dependencies = [
  "solana-sdk-ids",
  "solana-secp256k1-program",
  "solana-secp256r1-program",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -326,7 +305,7 @@ dependencies = [
  "proptest",
  "rand 0.9.0",
  "ruint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -888,12 +867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,22 +968,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitcoin-io"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
-dependencies = [
- "bitcoin-io",
- "hex-conservative",
-]
 
 [[package]]
 name = "bitflags"
@@ -1204,28 +1161,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,103 +1287,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width 0.1.14",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim 0.11.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "cli-x"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "alloy-signer",
- "alloy-signer-local",
- "anyhow",
- "bs58",
- "clap 4.5.36",
- "colored",
- "console",
- "dialoguer 0.11.0",
- "directories 5.0.1",
- "dirs",
- "hex",
- "indicatif",
- "rand 0.8.5",
- "secp256k1 0.30.0",
- "serde",
- "serde_json",
- "solana-sdk",
- "spl-associated-token-account 7.0.0",
- "spl-token 8.0.0",
- "swig-sdk",
- "tokio",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "combine"
@@ -1491,7 +1333,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.59.0",
 ]
 
@@ -1763,7 +1605,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.100",
 ]
 
@@ -1901,31 +1743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
-dependencies = [
- "console",
- "shell-words",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
-name = "dialoguer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
-dependencies = [
- "console",
- "shell-words",
- "tempfile",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,78 +1761,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "directories"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
-dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "directories"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
-dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.4.6",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.0",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
 ]
 
 [[package]]
@@ -2600,26 +2345,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.12",
- "indexmap 2.9.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.3.1",
+ "http",
  "indexmap 2.9.0",
  "slab",
  "tokio",
@@ -2641,9 +2367,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2651,7 +2374,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
 ]
 
 [[package]]
@@ -2698,28 +2421,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "hex-conservative"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "hidapi"
-version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b876ecf37e86b359573c16c8366bc3eba52b689884a0fc42ba3f67203d2a8b"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "pkg-config",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2770,47 +2471,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http 1.3.1",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
  "pin-project-lite",
 ]
 
@@ -2842,9 +2509,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2857,90 +2524,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2 0.4.9",
- "http 1.3.1",
- "http-body 1.0.1",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
+ "http",
+ "hyper",
  "rustls 0.21.12",
  "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-dependencies = [
- "futures-util",
- "http 1.3.1",
- "hyper 1.6.0",
- "hyper-util",
- "rustls 0.23.26",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.2",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
- "libc",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3163,7 +2757,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "web-time",
 ]
 
@@ -3279,23 +2873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jupiter-swap-api-client"
-version = "0.1.0"
-source = "git+https://github.com/austbot/jupiter-swap-api-client.git#b12348206cc85033fdf859129ce68b2e39a078ed"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "reqwest 0.12.15",
- "rust_decimal",
- "serde",
- "serde_json",
- "serde_qs",
- "solana-account-decoder",
- "solana-sdk",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,16 +2924,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.9.0",
- "libc",
-]
-
-[[package]]
 name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,14 +2951,11 @@ dependencies = [
  "arrayref",
  "base64 0.22.1",
  "digest 0.9.0",
- "hmac-drbg",
  "libsecp256k1-core 0.3.0",
  "libsecp256k1-gen-ecmult 0.3.0",
  "libsecp256k1-gen-genmult 0.3.0",
  "rand 0.8.5",
  "serde",
- "sha2 0.9.9",
- "typenum",
 ]
 
 [[package]]
@@ -3555,7 +3119,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "spl-associated-token-account-client",
- "spl-token 7.0.0",
+ "spl-token",
 ]
 
 [[package]]
@@ -3584,22 +3148,6 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
-
-[[package]]
-name = "macro_rules_attribute"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a82271f7bc033d84bbca59a3ce3e4159938cb08a9c3aebbe54d215131518a13"
-dependencies = [
- "macro_rules_attribute-proc_macro",
- "paste",
-]
-
-[[package]]
-name = "macro_rules_attribute-proc_macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dd856d451cc0da70e2ef2ce95a18e39a93b7558bedf10201ad28503f918568"
 
 [[package]]
 name = "matchers"
@@ -3693,23 +3241,6 @@ name = "murmur3"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "nix"
@@ -4004,12 +3535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4077,15 +3602,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pbkdf2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
-dependencies = [
- "crypto-mac",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -4315,26 +3831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,7 +3882,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.26",
  "socket2",
  "thiserror 2.0.12",
@@ -4405,7 +3901,7 @@ dependencies = [
  "getrandom 0.3.2",
  "rand 0.9.0",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.26",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4603,28 +4099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.15",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
-dependencies = [
- "getrandom 0.2.15",
- "libredox",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,15 +4143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4689,11 +4154,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -4703,14 +4168,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -4722,50 +4187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.4.9",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-rustls 0.27.5",
- "hyper-tls",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 2.2.0",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows-registry",
-]
-
-[[package]]
 name = "reqwest-middleware"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4773,8 +4194,8 @@ checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 0.2.12",
- "reqwest 0.11.27",
+ "http",
+ "reqwest",
  "serde",
  "task-local-extensions",
  "thiserror 1.0.69",
@@ -4805,35 +4226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4841,27 +4233,6 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
-]
-
-[[package]]
-name = "rpassword"
-version = "7.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4898,32 +4269,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
-name = "rust_decimal"
-version = "1.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa7de2ba56ac291bd90c6b9bece784a52ae1411f9506544b3eae36dd2356d50"
-dependencies = [
- "arrayvec",
- "borsh 1.5.7",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5012,7 +4361,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -5022,15 +4371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -5057,7 +4397,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.1",
- "security-framework 3.2.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.59.0",
@@ -5149,12 +4489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5167,57 +4501,6 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
-dependencies = [
- "secp256k1-sys 0.4.2",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
-dependencies = [
- "bitcoin_hashes",
- "rand 0.8.5",
- "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -5318,17 +4601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5368,19 +4640,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.9.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5500,12 +4759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5545,12 +4798,6 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5602,45 +4849,6 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-sysvar",
-]
-
-[[package]]
-name = "solana-account-decoder"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a8e4aacc7c681419ae63c1de36349d2156d5a4f4ffaea8e507335013e57189"
-dependencies = [
- "Inflector",
- "base64 0.22.1",
- "bincode",
- "bs58",
- "bv",
- "lazy_static",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account",
- "solana-account-decoder-client-types",
- "solana-clock",
- "solana-config-program",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-instruction",
- "solana-nonce",
- "solana-program",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-sysvar",
- "spl-token 7.0.0",
- "spl-token-2022 7.0.0",
- "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface 0.6.0",
- "thiserror 2.0.12",
- "zstd",
 ]
 
 [[package]]
@@ -5859,7 +5067,7 @@ version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb6728141dc45bdde9d68b67bb914013be28f94a2aea8bb7131ea8c6161c30e"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "lazy_static",
  "log",
  "qualifier_attr",
@@ -5874,51 +5082,6 @@ dependencies = [
  "solana-stake-program",
  "solana-system-program",
  "solana-vote-program",
-]
-
-[[package]]
-name = "solana-clap-utils"
-version = "2.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3c210e89742f6c661eb4e7549eb779dbc56cab4b700a1fd761cd7c9b2de6e6"
-dependencies = [
- "chrono",
- "clap 2.34.0",
- "rpassword",
- "solana-clock",
- "solana-cluster-type",
- "solana-commitment-config",
- "solana-derivation-path",
- "solana-hash",
- "solana-keypair",
- "solana-message",
- "solana-native-token",
- "solana-presigner",
- "solana-pubkey",
- "solana-remote-wallet",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
- "thiserror 2.0.12",
- "tiny-bip39",
- "uriparse",
- "url",
-]
-
-[[package]]
-name = "solana-cli-config"
-version = "2.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdb4a08bb852494082cd115e3b654b5505af4d2c0e9d24e602553d36dc2f1f5"
-dependencies = [
- "dirs-next",
- "lazy_static",
- "serde",
- "serde_derive",
- "serde_yaml",
- "solana-clap-utils",
- "solana-commitment-config",
- "url",
 ]
 
 [[package]]
@@ -6287,7 +5450,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e1d3b52b4a014efeaaab67f14e40af3972a4be61c523d612860db8e3145529"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "lazy_static",
  "solana-epoch-schedule",
  "solana-hash",
@@ -6618,7 +5781,7 @@ dependencies = [
  "gethostname",
  "lazy_static",
  "log",
- "reqwest 0.11.27",
+ "reqwest",
  "solana-clock",
  "solana-cluster-type",
  "solana-sha256-hasher",
@@ -6725,7 +5888,7 @@ version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b87939c18937f8bfad6028779a02fa123b27e986fb2c55fbbf683952a0e4932"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "bincode",
  "bv",
  "caps",
@@ -7021,7 +6184,7 @@ dependencies = [
  "crossbeam-channel",
  "futures-util",
  "log",
- "reqwest 0.11.27",
+ "reqwest",
  "semver 1.0.26",
  "serde",
  "serde_derive",
@@ -7087,30 +6250,6 @@ checksum = "7bf3ad7091b26c9bd0ebabff6ac4d825c88ecf2eafdb83de30dffda80ffc2f17"
 dependencies = [
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "solana-remote-wallet"
-version = "2.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71f9dfc6f2a5df04c3fed2b90b0fbf0da3939f3383a9bf24a5c0bcf994f2b10"
-dependencies = [
- "console",
- "dialoguer 0.10.4",
- "hidapi",
- "log",
- "num-derive",
- "num-traits",
- "parking_lot",
- "qstring",
- "semver 1.0.26",
- "solana-derivation-path",
- "solana-offchain-message",
- "solana-pubkey",
- "solana-signature",
- "solana-signer",
- "thiserror 2.0.12",
- "uriparse",
 ]
 
 [[package]]
@@ -7187,7 +6326,7 @@ dependencies = [
  "bs58",
  "indicatif",
  "log",
- "reqwest 0.11.27",
+ "reqwest",
  "reqwest-middleware",
  "semver 1.0.26",
  "serde",
@@ -7223,7 +6362,7 @@ dependencies = [
  "base64 0.22.1",
  "bs58",
  "jsonrpc-core",
- "reqwest 0.11.27",
+ "reqwest",
  "reqwest-middleware",
  "semver 1.0.26",
  "serde",
@@ -7421,12 +6560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-security-txt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
-
-[[package]]
 name = "solana-seed-derivable"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7442,7 +6575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha2 0.10.8",
 ]
 
@@ -7950,47 +7083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-transaction-status"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05fc20dd8feb089562b113a80115dab32b22fc64d63ca45c14d7b71e5e98d67"
-dependencies = [
- "Inflector",
- "base64 0.22.1",
- "bincode",
- "borsh 1.5.7",
- "bs58",
- "lazy_static",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account-decoder",
- "solana-clock",
- "solana-hash",
- "solana-instruction",
- "solana-loader-v2-interface",
- "solana-message",
- "solana-program",
- "solana-pubkey",
- "solana-reserved-account-keys",
- "solana-reward-info",
- "solana-sdk-ids",
- "solana-signature",
- "solana-system-interface",
- "solana-transaction",
- "solana-transaction-error",
- "solana-transaction-status-client-types",
- "spl-associated-token-account 6.0.0",
- "spl-memo",
- "spl-token 7.0.0",
- "spl-token-2022 7.0.0",
- "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface 0.6.0",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "solana-transaction-status-client-types"
 version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8243,38 +7335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-associated-token-account"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fee7d65013667032d499adc3c895e286197a35a0d3a4643c80e7fd3e9969e3"
-dependencies = [
- "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-associated-token-account-client",
- "spl-token 7.0.0",
- "spl-token-2022 6.0.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-associated-token-account"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae179d4a26b3c7a20c839898e6aed84cb4477adf108a366c95532f058aea041b"
-dependencies = [
- "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-associated-token-account-client",
- "spl-token 8.0.0",
- "spl-token-2022 8.0.1",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "spl-associated-token-account-client"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8282,78 +7342,6 @@ checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7398da23554a31660f17718164e31d31900956054f54f52d5ec1be51cb4f4b3"
-dependencies = [
- "bytemuck",
- "solana-program-error",
- "solana-sha256-hasher",
- "spl-discriminator-derive",
-]
-
-[[package]]
-name = "spl-discriminator-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
-dependencies = [
- "quote",
- "spl-discriminator-syn",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "spl-discriminator-syn"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.100",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-elgamal-registry"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0f668975d2b0536e8a8fd60e56a05c467f06021dae037f1d0cfed0de2e231d"
-dependencies = [
- "bytemuck",
- "solana-program",
- "solana-zk-sdk",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
-]
-
-[[package]]
-name = "spl-elgamal-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction 0.3.0",
 ]
 
 [[package]]
@@ -8368,122 +7356,6 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey",
-]
-
-[[package]]
-name = "spl-pod"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d994afaf86b779104b4a95ba9ca75b8ced3fdb17ee934e38cb69e72afbe17799"
-dependencies = [
- "borsh 1.5.7",
- "bytemuck",
- "bytemuck_derive",
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "solana-program-option",
- "solana-pubkey",
- "solana-zk-sdk",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d39b5186f42b2b50168029d81e58e800b690877ef0b30580d107659250da1d1"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-program-error-derive 0.4.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-program-error-derive 0.5.0",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d375dd76c517836353e093c2dbb490938ff72821ab568b545fd30ab3256b3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd99ff1e9ed2ab86e3fd582850d47a739fec1be9f4661cba1782d3a0f26805f3"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.6.0",
- "spl-type-length-value 0.7.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.7.0",
- "spl-type-length-value 0.8.0",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8502,391 +7374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053067c6a82c705004f91dae058b11b4780407e9ccd6799dc9e7d0fab5f242da"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-sysvar",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b27f7405010ef816587c944536b0eafbcc35206ab6ba0f2ca79f1d28e488f4f"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-security-txt",
- "solana-zk-sdk",
- "spl-elgamal-registry 0.1.1",
- "spl-memo",
- "spl-pod",
- "spl-token 7.0.0",
- "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
- "spl-token-confidential-transfer-proof-generation 0.2.0",
- "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface 0.6.0",
- "spl-transfer-hook-interface 0.9.0",
- "spl-type-length-value 0.7.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9048b26b0df0290f929ff91317c83db28b3ef99af2b3493dd35baa146774924c"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-security-txt",
- "solana-zk-sdk",
- "spl-elgamal-registry 0.1.1",
- "spl-memo",
- "spl-pod",
- "spl-token 7.0.0",
- "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
- "spl-token-confidential-transfer-proof-generation 0.3.0",
- "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface 0.6.0",
- "spl-transfer-hook-interface 0.9.0",
- "spl-type-length-value 0.7.0",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-security-txt",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk",
- "spl-elgamal-registry 0.2.0",
- "spl-memo",
- "spl-pod",
- "spl-token 8.0.0",
- "spl-token-confidential-transfer-ciphertext-arithmetic 0.3.0",
- "spl-token-confidential-transfer-proof-extraction 0.3.0",
- "spl-token-confidential-transfer-proof-generation 0.4.0",
- "spl-token-group-interface 0.6.0",
- "spl-token-metadata-interface 0.7.0",
- "spl-transfer-hook-interface 0.10.0",
- "spl-type-length-value 0.8.0",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170378693c5516090f6d37ae9bad2b9b6125069be68d9acd4865bbe9fc8499fd"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519",
- "solana-zk-sdk",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab20faf7b5edaa79acd240e0f21d5a2ef936aa99ed98f698573a2825b299c4"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519",
- "solana-zk-sdk",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2d6a445a147c9d6dd77b8301b1e116c8299601794b558eafa409b342faf96"
-dependencies = [
- "bytemuck",
- "solana-curve25519",
- "solana-program",
- "solana-zk-sdk",
- "spl-pod",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-curve25519",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-zk-sdk",
- "spl-pod",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-generation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8627184782eec1894de8ea26129c61303f1f0adeed65c20e0b10bc584f09356d"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "solana-zk-sdk",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-generation"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3597628b0d2fe94e7900fd17cdb4cfbb31ee35c66f82809d27d86e44b2848b"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "solana-zk-sdk",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-generation"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "solana-zk-sdk",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d595667ed72dbfed8c251708f406d7c2814a3fa6879893b323d56a10bedfc799"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5597b4cd76f85ce7cd206045b7dc22da8c25516573d42d267c8d1fd128db5129"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb9c89dbc877abd735f05547dcf9e6e12c00c11d6d74d8817506cab4c99fdbb"
-dependencies = [
- "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-borsh",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-type-length-value 0.7.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304d6e06f0de0c13a621464b1fd5d4b1bebf60d15ca71a44d3839958e0da16ee"
-dependencies = [
- "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-borsh",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-type-length-value 0.8.0",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa7503d52107c33c88e845e1351565050362c2314036ddf19a36cd25137c043"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.6.0",
- "spl-tlv-account-resolution 0.9.0",
- "spl-type-length-value 0.7.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.7.0",
- "spl-tlv-account-resolution 0.10.0",
- "spl-type-length-value 0.8.0",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba70ef09b13af616a4c987797870122863cba03acc4284f226a4473b043923f9"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-discriminator",
- "spl-pod",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d417eb548214fa822d93f84444024b4e57c13ed6719d4dcc68eec24fb481e9f5"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-discriminator",
- "spl-pod",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8897,12 +7384,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -8966,36 +7447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "swig-cli"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "borsh 1.5.7",
- "bs58",
- "clap 4.5.36",
- "directories 6.0.0",
- "hex",
- "jupiter-swap-api-client",
- "libsecp256k1 0.7.2",
- "macro_rules_attribute",
- "rand 0.8.5",
- "secp256k1 0.30.0",
- "serde",
- "serde_json",
- "solana-account-decoder-client-types",
- "solana-cli-config",
- "solana-client",
- "solana-pubkey",
- "solana-sdk",
- "solana-transaction-status",
- "spl-associated-token-account 6.0.0",
- "spl-token 7.0.0",
- "swig-interface",
- "swig-state-x",
- "tokio",
-]
-
-[[package]]
 name = "swig-compact-instructions"
 version = "0.0.1"
 dependencies = [
@@ -9012,35 +7463,10 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "solana-sdk",
+ "solana-secp256r1-program",
  "swig",
  "swig-compact-instructions",
  "swig-state-x",
-]
-
-[[package]]
-name = "swig-sdk"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "alloy-signer",
- "alloy-signer-local",
- "anyhow",
- "bs58",
- "hex",
- "litesvm",
- "litesvm-token",
- "rand 0.8.5",
- "secp256k1 0.21.3",
- "solana-account-decoder-client-types",
- "solana-client",
- "solana-program",
- "solana-sdk",
- "spl-associated-token-account 7.0.0",
- "spl-token 8.0.0",
- "swig-interface",
- "swig-state-x",
- "test-log",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9101,15 +7527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9140,18 +7557,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -9159,16 +7565,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -9231,15 +7627,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -9333,25 +7720,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-bip39"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
-dependencies = [
- "anyhow",
- "hmac 0.8.1",
- "once_cell",
- "pbkdf2 0.4.0",
- "rand 0.7.3",
- "rustc-hash 1.1.0",
- "sha2 0.9.9",
- "thiserror 1.0.69",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9415,32 +7783,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
-dependencies = [
- "rustls 0.23.26",
  "tokio",
 ]
 
@@ -9465,7 +7813,7 @@ dependencies = [
  "log",
  "rustls 0.21.12",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.25.4",
 ]
@@ -9508,27 +7856,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "tower"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -9612,7 +7939,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.12",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -9667,21 +7994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9711,12 +8023,6 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -9770,12 +8076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9786,12 +8086,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -10010,7 +8304,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings",
 ]
 
 [[package]]
@@ -10042,30 +8336,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -10154,27 +8428,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -10196,12 +8454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10218,12 +8470,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10244,22 +8490,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10280,12 +8514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10302,12 +8530,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10328,12 +8550,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10350,12 +8566,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-feature-set"
+version = "2.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf37e04221e454874cc9cebf92482ee40e4f1fb5412f701cd712835725582190"
+dependencies = [
+ "ahash 0.8.11",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "agave-precompiles"
+version = "2.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d3dd7591df608931ace909f1948fa14a8850d4919250ca6977f26a135b8665"
+dependencies = [
+ "agave-feature-set",
+ "bincode",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "lazy_static",
+ "libsecp256k1 0.6.0",
+ "openssl",
+ "sha3",
+ "solana-ed25519-program",
+ "solana-message",
+ "solana-precompile-error",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-secp256k1-program",
+ "solana-secp256r1-program",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,6 +3982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.0+3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,6 +3998,7 @@ checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6134,9 +6180,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0c4dfce08d71d8f1e9b7d1b4e2c7101a8109903ad481acbbc1119a73d459f2"
+checksum = "a1feafa1691ea3ae588f99056f4bdd1293212c7ece28243d7da257c443e84753"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7362,9 +7408,9 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256r1-program"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ea9282950921611bd9e0200da7236fbb1d4f8388942f8451bd55e9f3cb228f"
+checksum = "cf903cbdc36a161533812f90acfccdb434ed48982bd5dd71f3217930572c4a80"
 dependencies = [
  "bytemuck",
  "openssl",
@@ -8882,11 +8928,13 @@ dependencies = [
  "bs58",
  "bytemuck",
  "ecdsa",
+ "hex",
  "litesvm",
  "litesvm-token",
  "no-padding",
  "num_enum",
  "once_cell",
+ "openssl",
  "pinocchio 0.8.1",
  "pinocchio-pubkey",
  "pinocchio-system",
@@ -8897,6 +8945,7 @@ dependencies = [
  "solana-clock",
  "solana-program",
  "solana-sdk",
+ "solana-secp256r1-program",
  "solana-stake-interface",
  "spl-memo",
  "static_assertions",
@@ -8998,12 +9047,16 @@ dependencies = [
 name = "swig-state-x"
 version = "0.1.0"
 dependencies = [
+ "agave-precompiles",
  "hex",
  "libsecp256k1 0.7.2",
  "murmur3",
  "no-padding",
+ "openssl",
  "pinocchio 0.8.1",
+ "pinocchio-pubkey",
  "rand 0.9.0",
+ "solana-secp256r1-program",
  "swig-assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ members = [
   "state-x",
   "assertions",
   "no-padding",
-  "rust-sdk",
-  "cli",
-  "cli-x",
+  # "rust-sdk",
+  # "cli",
+  # "cli-x",
 ]
 
 [workspace.lints.rust]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -17,3 +17,4 @@ swig-compact-instructions = { path = "../instructions", default-features = false
 ] }
 swig-state-x = { path = "../state-x" }
 anyhow = "1.0.75"
+solana-secp256r1-program = "2.2.1"

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -371,8 +371,9 @@ impl AddAuthorityInstruction {
         // Create secp256r1 verify instruction
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
-        // Must be at least 17 bytes to satisfy secp256r1_authority_authenticate() requirements
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding Must be at least 17 bytes to satisfy
+        // secp256r1_authority_authenticate() requirements
         let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
@@ -538,8 +539,9 @@ impl SignInstruction {
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
-        // Must be at least 17 bytes to satisfy secp256r1_authority_authenticate() requirements
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding Must be at least 17 bytes to satisfy
+        // secp256r1_authority_authenticate() requirements
         let instruction_sysvar_index = 3; // Try hardcoded index 3 for debugging
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
@@ -695,7 +697,8 @@ impl RemoveAuthorityInstruction {
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding
         let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
@@ -856,7 +859,8 @@ impl CreateSessionInstruction {
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding
         let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
@@ -1018,7 +1022,8 @@ impl CreateSubAccountInstruction {
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
@@ -1264,7 +1269,8 @@ impl WithdrawFromSubAccountInstruction {
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding
         let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
@@ -1348,7 +1354,8 @@ impl WithdrawFromSubAccountInstruction {
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
@@ -1512,7 +1519,8 @@ impl SubAccountSignInstruction {
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
@@ -1676,7 +1684,8 @@ impl ToggleSubAccountInstruction {
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
-        // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        // For secp256r1, the authority payload includes slot, counter, instruction
+        // index, and padding
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -304,6 +304,7 @@ impl AddAuthorityInstruction {
         current_slot: u64,
         counter: u32,
         acting_role_id: u32,
+        public_key: &[u8; 33],
         new_authority_config: AuthorityConfig,
         actions: Vec<ClientAction>,
     ) -> anyhow::Result<Vec<Instruction>>
@@ -367,18 +368,17 @@ impl AddAuthorityInstruction {
 
         // Get signature from authority function
         let signature = authority_payload_fn(&message_hash);
-        let public_key: &[u8; 33] = new_authority_config.authority.try_into().map_err(|_| {
-            anyhow::anyhow!("Invalid secp256r1 public key length, expected 33 bytes")
-        })?;
         // Create secp256r1 verify instruction
         let secp256r1_verify_ix =
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
         // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
         // Must be at least 17 bytes to satisfy secp256r1_authority_authenticate() requirements
+        let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
         let mut authority_payload = Vec::new();
-        authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8; bytes
+        authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
-        authority_payload.push(3); // this is the index of the instruction sysvar
+        authority_payload.push(instruction_sysvar_index as u8); // 1 byte: index of instruction sysvar
+        authority_payload.extend_from_slice(&[0u8; 4]); // 4 bytes padding to meet 17 byte minimum
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -540,10 +540,12 @@ impl SignInstruction {
 
         // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
         // Must be at least 17 bytes to satisfy secp256r1_authority_authenticate() requirements
+        let instruction_sysvar_index = 3; // Try hardcoded index 3 for debugging
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
-        authority_payload.push(3); // this is the index of the instruction sysvar
+        authority_payload.push(instruction_sysvar_index as u8); // 1 byte: index of instruction sysvar
+        authority_payload.extend_from_slice(&[0u8; 4]); // 4 bytes padding to meet 17 byte minimum
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -694,10 +696,12 @@ impl RemoveAuthorityInstruction {
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
         // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
-        authority_payload.push(3); // this is the index of the instruction sysvar
+        authority_payload.push(instruction_sysvar_index as u8); // 1 byte: index of instruction sysvar
+        authority_payload.extend_from_slice(&[0u8; 4]); // 4 bytes padding to meet 17 byte minimum
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -853,10 +857,12 @@ impl CreateSessionInstruction {
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
         // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
-        authority_payload.push(3); // this is the index of the instruction sysvar
+        authority_payload.push(instruction_sysvar_index as u8); // 1 byte: index of instruction sysvar
+        authority_payload.extend_from_slice(&[0u8; 4]); // 4 bytes padding to meet 17 byte minimum
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -1259,10 +1265,12 @@ impl WithdrawFromSubAccountInstruction {
             new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
 
         // For secp256r1, the authority payload includes slot, counter, instruction index, and padding
+        let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
         authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
-        authority_payload.push(4); // this is the index of the instruction sysvar
+        authority_payload.push(instruction_sysvar_index as u8); // 1 byte: index of instruction sysvar
+        authority_payload.extend_from_slice(&[0u8; 4]); // 4 bytes padding to meet 17 byte minimum
 
         let main_ix = Instruction {
             program_id: program_id(),

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -43,6 +43,9 @@ solana-client = "=2.2.4"
 solana-program = "=2.2.1"
 once_cell = "1.21.3"
 spl-memo = "=6.0.0"
+solana-secp256r1-program = "2.2.1"
+openssl = { version = "0.10.72", features = ["vendored"] }
+hex = "0.4.3"
 
 [features]
 test-bpf = []

--- a/program/src/actions/remove_authority_v1.rs
+++ b/program/src/actions/remove_authority_v1.rs
@@ -172,7 +172,6 @@ pub fn remove_authority_v1(
             // Authenticate the caller
             let clock = Clock::get()?;
             let slot = clock.slot;
-
             if acting_role.authority.session_based() {
                 acting_role.authority.authenticate_session(
                     all_accounts,
@@ -181,6 +180,7 @@ pub fn remove_authority_v1(
                     slot,
                 )?;
             } else {
+                
                 acting_role.authority.authenticate(
                     all_accounts,
                     remove_authority_v1.authority_payload,

--- a/program/src/actions/remove_authority_v1.rs
+++ b/program/src/actions/remove_authority_v1.rs
@@ -180,7 +180,6 @@ pub fn remove_authority_v1(
                     slot,
                 )?;
             } else {
-                
                 acting_role.authority.authenticate(
                     all_accounts,
                     remove_authority_v1.authority_payload,

--- a/program/src/actions/sign_v1.rs
+++ b/program/src/actions/sign_v1.rs
@@ -40,6 +40,7 @@ use crate::{
         accounts::{Context, SignV1Accounts},
         SwigInstruction,
     },
+    util::build_restricted_keys,
     AccountClassification,
 };
 // use swig_instructions::InstructionIterator;

--- a/program/src/actions/sub_account_sign_v1.rs
+++ b/program/src/actions/sub_account_sign_v1.rs
@@ -28,6 +28,7 @@ use crate::{
         accounts::{Context, SubAccountSignV1Accounts},
         SwigInstruction,
     },
+    util::build_restricted_keys,
     AccountClassification,
 };
 

--- a/program/src/util/mod.rs
+++ b/program/src/util/mod.rs
@@ -21,8 +21,10 @@ use swig_state_x::{
         program_scope::{NumericType, ProgramScope},
         Action, Permission,
     },
+    authority::AuthorityType,
     constants::PROGRAM_SCOPE_BYTE_SIZE,
     read_numeric_field,
+    role::RoleMut,
     swig::{Swig, SwigWithRoles},
     Transmutable,
 };
@@ -280,5 +282,56 @@ impl<'a> TokenTransfer<'a> {
         };
 
         invoke_signed(&instruction, &[self.from, self.to, self.authority], signers)
+    }
+}
+
+/// Builds a restricted keys array for transaction signing.
+///
+/// This function creates an array of public keys that are restricted from being
+/// used as signers in the transaction. The behavior differs based on the
+/// authority type:
+/// - For Secp256k1 and Secp256r1: Only includes the payer key
+/// - For other authority types: Includes both the payer key and the authority
+///   key
+///
+/// # Arguments
+/// * `role` - The role containing the authority type information
+/// * `payer_key` - The payer account's public key
+/// * `authority_payload` - The authority payload containing the authority index
+/// * `all_accounts` - All accounts involved in the transaction
+///
+/// # Returns
+/// * `Result<&[&Pubkey], ProgramError>` - A slice of restricted public keys
+///
+/// # Safety
+/// This function uses unsafe operations for performance. The caller must
+/// ensure:
+/// - `authority_payload` has at least one byte when authority type is not
+///   Secp256k1/r1
+/// - `all_accounts` contains the account at the specified authority index
+#[inline(always)]
+pub unsafe fn build_restricted_keys<'a>(
+    role: &RoleMut,
+    payer_key: &'a Pubkey,
+    authority_payload: &[u8],
+    all_accounts: &'a [AccountInfo],
+    restricted_keys_storage: &'a mut [MaybeUninit<&'a Pubkey>; 2],
+) -> Result<&'a [&'a Pubkey], ProgramError> {
+    if role.position.authority_type()? == AuthorityType::Secp256k1
+        || role.position.authority_type()? == AuthorityType::Secp256r1
+    {
+        restricted_keys_storage[0].write(payer_key);
+        Ok(core::slice::from_raw_parts(
+            restricted_keys_storage.as_ptr() as _,
+            1,
+        ))
+    } else {
+        let authority_index = *authority_payload.get_unchecked(0) as usize;
+        restricted_keys_storage[0].write(payer_key);
+        restricted_keys_storage[1].write(all_accounts[authority_index].key());
+        Ok(core::slice::from_raw_parts(
+            restricted_keys_storage.as_ptr() as _,
+            2,
+        ))
     }
 }

--- a/program/tests/common/mod.rs
+++ b/program/tests/common/mod.rs
@@ -20,7 +20,7 @@ use swig_state_x::{
     action::{all::All, manage_authority::ManageAuthority, sub_account::SubAccount},
     authority::{
         ed25519::CreateEd25519SessionAuthority, secp256k1::CreateSecp256k1SessionAuthority,
-        AuthorityType,
+        secp256r1::CreateSecp256r1SessionAuthority, AuthorityType,
     },
     swig::{sub_account_seeds, swig_account_seeds, SwigWithRoles},
     IntoBytes, Transmutable,
@@ -247,6 +247,60 @@ pub fn create_swig_secp256k1_session(
 
     let initial_authority = AuthorityConfig {
         authority_type: AuthorityType::Secp256k1Session,
+        authority: authority_data
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize authority data {:?}", e))?,
+    };
+
+    let create_ix = CreateInstruction::new(
+        swig,
+        bump,
+        payer_pubkey,
+        initial_authority,
+        vec![ClientAction::All(All {})],
+        id,
+    )?;
+
+    let msg = v0::Message::try_compile(
+        &payer_pubkey,
+        &[create_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[context.default_payer.insecure_clone()],
+    )
+    .unwrap();
+
+    let bench = context
+        .svm
+        .send_transaction(tx)
+        .map_err(|e| anyhow::anyhow!("Failed to send transaction {:?}", e))?;
+
+    Ok((swig, bench))
+}
+
+pub fn create_swig_secp256r1_session(
+    context: &mut SwigTestContext,
+    public_key: &[u8; 33],
+    id: [u8; 32],
+    session_max_length: u64,
+    initial_session_key: [u8; 32],
+) -> anyhow::Result<(Pubkey, TransactionMetadata)> {
+    use swig_state_x::authority::secp256r1::CreateSecp256r1SessionAuthority;
+
+    let payer_pubkey = context.default_payer.pubkey();
+    let (swig, bump) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
+
+    // Create the session authority data
+    let authority_data =
+        CreateSecp256r1SessionAuthority::new(*public_key, initial_session_key, session_max_length);
+
+    let initial_authority = AuthorityConfig {
+        authority_type: AuthorityType::Secp256r1Session,
         authority: authority_data
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize authority data {:?}", e))?,

--- a/program/tests/create_session_test.rs
+++ b/program/tests/create_session_test.rs
@@ -518,6 +518,7 @@ fn test_secp256k1_session() {
     assert_eq!(auth.public_key, compressed_eth_pubkey.as_ref());
     assert_eq!(auth.current_session_expiration, 0);
     assert_eq!(auth.session_key, [0; 32]);
+    assert_eq!(auth.signature_odometer, 0, "Initial odometer should be 0");
 
     context
         .svm
@@ -541,6 +542,7 @@ fn test_secp256k1_session() {
         context.default_payer.pubkey(),
         signing_fn,
         current_slot,
+        1, // Counter for session authorities (starting from 1)
         0, // Role ID 0 is the root authority
         session_key.pubkey(),
         session_duration,
@@ -580,6 +582,10 @@ fn test_secp256k1_session() {
         current_slot + session_duration
     );
     assert_eq!(auth.session_key, session_key.pubkey().to_bytes());
+    assert_eq!(
+        auth.signature_odometer, 1,
+        "Odometer should be 1 after session creation"
+    );
 
     // Create a receiver keypair
     let receiver = Keypair::new();

--- a/program/tests/remove_authority_test.rs
+++ b/program/tests/remove_authority_test.rs
@@ -258,7 +258,8 @@ fn test_secp256k1_root_remove_authority() {
         .airdrop(&second_authority.pubkey(), 10_000_000_000)
         .unwrap();
 
-    // Create signing function for secp256k1 authority (same pattern as working test)
+    // Create signing function for secp256k1 authority (same pattern as working
+    // test)
     let signing_fn = |payload: &[u8]| -> [u8; 65] {
         let mut hash = [0u8; 32];
         hash.copy_from_slice(&payload[..32]);
@@ -266,7 +267,8 @@ fn test_secp256k1_root_remove_authority() {
         root_wallet.sign_hash_sync(&hash).unwrap().as_bytes()
     };
 
-    // Add the second authority using secp256k1 root authority (same as working test)
+    // Add the second authority using secp256k1 root authority (same as working
+    // test)
     let add_authority_ix = swig_interface::AddAuthorityInstruction::new_with_secp256k1_authority(
         swig_key,
         context.default_payer.pubkey(),

--- a/program/tests/remove_authority_test.rs
+++ b/program/tests/remove_authority_test.rs
@@ -236,6 +236,124 @@ fn test_create_remove_secp_authority() {
 }
 
 #[test_log::test]
+fn test_secp256k1_root_remove_authority() {
+    use alloy_primitives::B256;
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::LocalSigner;
+
+    let mut context = setup_test_context().unwrap();
+
+    // Create a secp256k1 root authority wallet
+    let root_wallet = LocalSigner::random();
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a swig wallet with secp256k1 root authority
+    let (swig_key, _) = create_swig_secp256k1(&mut context, &root_wallet, id).unwrap();
+    context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
+
+    // Create a second Ed25519 authority to add and later remove
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    // Create signing function for secp256k1 authority (same pattern as working test)
+    let signing_fn = |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        let hash = B256::from(hash);
+        root_wallet.sign_hash_sync(&hash).unwrap().as_bytes()
+    };
+
+    // Add the second authority using secp256k1 root authority (same as working test)
+    let add_authority_ix = swig_interface::AddAuthorityInstruction::new_with_secp256k1_authority(
+        swig_key,
+        context.default_payer.pubkey(),
+        signing_fn,
+        0, // current slot (same as working test)
+        1, // counter = 1 (first transaction, same as working test)
+        0, // role_id of the primary wallet
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[add_authority_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&context.default_payer])
+            .unwrap();
+
+    // Transaction should succeed
+    let result = context.svm.send_transaction(tx);
+    context.svm.expire_blockhash();
+    context.svm.warp_to_slot(1);
+    assert!(
+        result.is_ok(),
+        "Failed to add ed25519 authority: {:?}",
+        result.err()
+    );
+
+    // Verify the authority was added
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig_state.state.roles, 2);
+
+    let remove_ix = RemoveAuthorityInstruction::new_with_secp256k1_authority(
+        swig_key,
+        context.default_payer.pubkey(),
+        signing_fn,
+        1, // current slot
+        2, // counter = 2 (second transaction),
+        0, // role_id of the primary wallet (secp256k1 root authority)
+        1, // Authority to remove (the Ed25519 authority)
+    )
+    .unwrap();
+
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[remove_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&context.default_payer])
+            .unwrap();
+
+    // Transaction should succeed
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to remove authority with secp256k1: {:?}",
+        result.err()
+    );
+
+    // Verify that only one authority remains (the secp256k1 root)
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig_state.state.roles, 1);
+
+    // Verify it's the secp256k1 root authority by checking the authority type
+    let role = swig_state.get_role(0).unwrap().unwrap();
+    assert_eq!(role.authority.authority_type(), AuthorityType::Secp256k1);
+
+    println!("✓ Secp256k1 root authority successfully removed Ed25519 authority");
+    println!("✓ Signature counter functionality verified for secp256k1 remove authority operation");
+}
+
+#[test_log::test]
 fn test_remove_authority_permissions() {
     let mut context = setup_test_context().unwrap();
     let root_authority = Keypair::new();

--- a/program/tests/sign_secp256k1.rs
+++ b/program/tests/sign_secp256k1.rs
@@ -937,11 +937,6 @@ fn test_secp256k1_replay_scenario_2() {
             .unwrap();
 
     let result2 = context.svm.send_transaction(tx2);
-    // assert!(
-    //     result2.is_ok(),
-    //     "Expected second transaction to succeed (demonstrating vulnerability):
-    // {:?}",     result2.err()
-    // );
     assert!(
         result2.is_err(),
         "Expected second transaction to succeed (demonstrating vulnerability): {:?}",

--- a/program/tests/sign_secp256r1.rs
+++ b/program/tests/sign_secp256r1.rs
@@ -1,0 +1,561 @@
+#![cfg(not(feature = "program_scope_test"))]
+// This feature flag ensures these tests are only run when the
+// "program_scope_test" feature is not enabled. This allows us to isolate
+// and run only program_scope tests or only the regular tests.
+
+mod common;
+use common::*;
+use solana_sdk::{
+    clock::Clock,
+    instruction::InstructionError,
+    message::{v0, VersionedMessage},
+    signature::Keypair,
+    signer::Signer,
+    system_instruction,
+    transaction::{TransactionError, VersionedTransaction},
+};
+use swig_interface::{AuthorityConfig, ClientAction};
+use swig_state_x::{
+    action::all::All,
+    authority::{
+        secp256r1::{Secp256r1Authority, Secp256r1SessionAuthority},
+        AuthorityType,
+    },
+    swig::SwigWithRoles,
+};
+
+/// Helper to generate a real secp256r1 key pair for testing
+fn create_test_secp256r1_keypair() -> (openssl::ec::EcKey<openssl::pkey::Private>, [u8; 33]) {
+    use openssl::bn::BigNumContext;
+    use openssl::ec::{EcGroup, EcKey, PointConversionForm};
+    use openssl::nid::Nid;
+
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    let signing_key = EcKey::generate(&group).unwrap();
+
+    let mut ctx = BigNumContext::new().unwrap();
+    let pubkey_bytes = signing_key
+        .public_key()
+        .to_bytes(&group, PointConversionForm::COMPRESSED, &mut ctx)
+        .unwrap();
+
+    let pubkey_array: [u8; 33] = pubkey_bytes.try_into().unwrap();
+    (signing_key, pubkey_array)
+}
+
+/// Helper function to create a secp256r1 authority with a test public key
+fn create_test_secp256r1_authority() -> [u8; 33] {
+    let (_, pubkey) = create_test_secp256r1_keypair();
+    pubkey
+}
+
+/// Helper function to get the current signature counter for a secp256r1 authority
+fn get_secp256r1_counter(
+    context: &SwigTestContext,
+    swig_key: &solana_sdk::pubkey::Pubkey,
+    public_key: &[u8; 33],
+) -> Result<u32, String> {
+    // Get the swig account data
+    let swig_account = context
+        .svm
+        .get_account(swig_key)
+        .ok_or("Swig account not found")?;
+    let swig = SwigWithRoles::from_bytes(&swig_account.data)
+        .map_err(|e| format!("Failed to parse swig data: {:?}", e))?;
+
+    // Look up the role ID for this authority
+    let role_id = swig
+        .lookup_role_id(public_key)
+        .map_err(|e| format!("Failed to lookup role: {:?}", e))?
+        .ok_or("Authority not found in swig account")?;
+
+    // Get the role
+    let role = swig
+        .get_role(role_id)
+        .map_err(|e| format!("Failed to get role: {:?}", e))?
+        .ok_or("Role not found")?;
+
+    // The authority should be a Secp256r1Authority
+    if matches!(role.authority.authority_type(), AuthorityType::Secp256r1) {
+        // Get the authority from the any() interface
+        let secp_authority = role
+            .authority
+            .as_any()
+            .downcast_ref::<Secp256r1Authority>()
+            .ok_or("Failed to downcast to Secp256r1Authority")?;
+
+        Ok(secp_authority.signature_odometer)
+    } else {
+        Err("Authority is not a Secp256r1Authority".to_string())
+    }
+}
+
+/// Helper to compute the message hash that secp256r1 verification expects
+fn compute_secp256r1_message_hash(
+    instruction_data: &[u8],
+    accounts: &[(solana_sdk::pubkey::Pubkey, bool, bool)], // (pubkey, is_writable, is_signer)
+    slot: u64,
+    counter: u32,
+) -> [u8; 32] {
+    use solana_sdk::keccak::{hash as keccak_hash, Hash as KeccakHash};
+    let mut accounts_payload = Vec::new();
+
+    for (pubkey, is_writable, is_signer) in accounts {
+        accounts_payload.extend_from_slice(pubkey.as_ref()); // 32 bytes: pubkey
+        accounts_payload.push(*is_writable as u8); // 1 byte: is_writable
+        accounts_payload.push(*is_signer as u8); // 1 byte: is_signer
+        accounts_payload.extend_from_slice(&[0u8; 6]); // 6 bytes: padding
+    }
+
+    // Combine all the data that goes into the hash
+    let mut combined_data = Vec::new();
+    combined_data.extend_from_slice(instruction_data);
+    combined_data.extend_from_slice(&accounts_payload);
+    combined_data.extend_from_slice(&slot.to_le_bytes());
+    combined_data.extend_from_slice(&counter.to_le_bytes());
+
+    // Keccak hash for the final result (compatible with passkeys)
+    let final_hash = keccak_hash(&combined_data);
+    final_hash.to_bytes()
+}
+
+/// Create a real secp256r1 precompile instruction using actual cryptography
+fn create_secp256r1_instruction(
+    signing_key: &openssl::ec::EcKey<openssl::pkey::Private>,
+    public_key: &[u8; 33],
+    message: &[u8],
+) -> solana_sdk::instruction::Instruction {
+    use solana_secp256r1_program::{new_secp256r1_instruction_with_signature, sign_message};
+
+    // Create the signature using the official Solana function
+    let signature = sign_message(message, &signing_key.private_key_to_der().unwrap()).unwrap();
+
+    // Create the instruction using the official Solana function
+    let instruction = new_secp256r1_instruction_with_signature(message, &signature, public_key);
+
+    instruction
+}
+
+#[test_log::test]
+fn test_secp256r1_basic_signing() {
+    let mut context = setup_test_context().unwrap();
+
+    // Create a real secp256r1 key pair for testing
+    let (signing_key, public_key) = create_test_secp256r1_keypair();
+
+    // Create a new swig with the secp256r1 authority
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+    context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
+
+    // Set up a recipient and transaction
+    let recipient = Keypair::new();
+    context.svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
+    let transfer_amount = 5_000_000;
+    let transfer_ix = system_instruction::transfer(&swig_key, &recipient.pubkey(), transfer_amount);
+
+    // Get current slot and counter
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let current_counter = get_secp256r1_counter(&context, &swig_key, &public_key).unwrap();
+    let next_counter = current_counter + 1;
+
+    println!(
+        "Current counter: {}, using next counter: {}",
+        current_counter, next_counter
+    );
+
+    // Create the secp256r1 signing instruction
+    let sign_ix = swig_interface::SignInstruction::new_secp256r1(
+        swig_key,
+        context.default_payer.pubkey(),
+        current_slot,
+        next_counter,
+        transfer_ix.clone(),
+        0, // Role ID 0
+    )
+    .unwrap();
+
+    // Compute the message hash that the secp256r1 verification will expect
+    // Account info: (pubkey, is_writable, is_signer)
+    let accounts = sign_ix
+        .accounts
+        .iter()
+        .map(|a| (a.pubkey, a.is_writable, a.is_signer))
+        .collect::<Vec<_>>();
+    let message_hash =
+        compute_secp256r1_message_hash(&transfer_ix.data, &accounts, current_slot, next_counter);
+
+    // Create a real secp256r1 verification instruction with proper cryptography
+    let secp256r1_verify_ix =
+        create_secp256r1_instruction(&signing_key, &public_key, &message_hash);
+
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[secp256r1_verify_ix, sign_ix], // secp256r1 verification must come first
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&context.default_payer])
+            .unwrap();
+
+    // Send the transaction - should now succeed with real cryptography
+    let result = context.svm.send_transaction(tx);
+
+    println!("Transaction result: {:?}", result);
+
+    // Verify the transaction succeeded
+    assert!(
+        result.is_ok(),
+        "Transaction should succeed with real secp256r1 signature: {:?}",
+        result.err()
+    );
+
+    // Verify the counter was incremented
+    let new_counter = get_secp256r1_counter(&context, &swig_key, &public_key).unwrap();
+    assert_eq!(
+        new_counter, next_counter,
+        "Counter should be incremented after successful transaction"
+    );
+
+    // Verify the transfer actually happened
+    let recipient_balance = context
+        .svm
+        .get_account(&recipient.pubkey())
+        .unwrap()
+        .lamports;
+    assert_eq!(
+        recipient_balance,
+        1_000_000 + transfer_amount,
+        "Recipient should receive the transferred amount"
+    );
+
+    println!("✓ Secp256r1 signing test passed with real cryptography");
+}
+
+#[test_log::test]
+fn test_secp256r1_counter_increment() {
+    let mut context = setup_test_context().unwrap();
+
+    // Create a real secp256r1 key pair for testing
+    let (_, public_key) = create_test_secp256r1_keypair();
+
+    // Create a new swig with the secp256r1 authority
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+    context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
+
+    // Verify initial counter is 0
+    let initial_counter = get_secp256r1_counter(&context, &swig_key, &public_key).unwrap();
+    assert_eq!(initial_counter, 0, "Initial counter should be 0");
+
+    println!("✓ Initial counter verified as 0");
+    println!("✓ Secp256r1 authority structure works correctly");
+}
+
+#[test_log::test]
+fn test_secp256r1_replay_protection() {
+    let mut context = setup_test_context().unwrap();
+
+    // Create a real secp256r1 key pair for testing
+    let (signing_key, public_key) = create_test_secp256r1_keypair();
+
+    // Create a new swig with the secp256r1 authority
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+    context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
+
+    // Set up transfer instruction
+    let recipient = Keypair::new();
+    context.svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
+    let transfer_amount = 1_000_000;
+    let transfer_ix = system_instruction::transfer(&swig_key, &recipient.pubkey(), transfer_amount);
+
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+
+    // First transaction with counter 1
+    let counter1 = 1;
+    let sign_ix1 = swig_interface::SignInstruction::new_secp256r1(
+        swig_key,
+        context.default_payer.pubkey(),
+        current_slot,
+        counter1,
+        transfer_ix.clone(),
+        0,
+    )
+    .unwrap();
+
+    // Create message hash and secp256r1 instruction for first transaction
+    let accounts = vec![
+        (swig_key, true, false), // Swig account (writable, not signer)
+        (context.default_payer.pubkey(), true, true), // Payer (writable, signer)
+        (solana_sdk::system_program::ID, false, false), // System program (not writable, not signer)
+        (solana_sdk::sysvar::instructions::ID, false, false), // Instructions sysvar (not writable, not signer)
+    ];
+    let message_hash1 =
+        compute_secp256r1_message_hash(&transfer_ix.data, &accounts, current_slot, counter1);
+    let secp256r1_verify_ix1 =
+        create_secp256r1_instruction(&signing_key, &public_key, &message_hash1);
+
+    // Execute first transaction
+    let message1 = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[secp256r1_verify_ix1, sign_ix1],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx1 =
+        VersionedTransaction::try_new(VersionedMessage::V0(message1), &[&context.default_payer])
+            .unwrap();
+    let result1 = context.svm.send_transaction(tx1);
+
+    assert!(
+        result1.is_ok(),
+        "First transaction should succeed: {:?}",
+        result1.err()
+    );
+    println!("✓ First transaction with counter 1 succeeded");
+
+    // Try second transaction with same counter (should fail due to replay protection)
+    let sign_ix2 = swig_interface::SignInstruction::new_secp256r1(
+        swig_key,
+        context.default_payer.pubkey(),
+        current_slot,
+        counter1, // Same counter - should trigger replay protection
+        transfer_ix.clone(),
+        0,
+    )
+    .unwrap();
+
+    let message_hash2 =
+        compute_secp256r1_message_hash(&transfer_ix.data, &accounts, current_slot, counter1);
+    let secp256r1_verify_ix2 =
+        create_secp256r1_instruction(&signing_key, &public_key, &message_hash2);
+
+    let message2 = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[secp256r1_verify_ix2, sign_ix2],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx2 =
+        VersionedTransaction::try_new(VersionedMessage::V0(message2), &[&context.default_payer])
+            .unwrap();
+    let result2 = context.svm.send_transaction(tx2);
+
+    assert!(
+        result2.is_err(),
+        "Second transaction with same counter should fail due to replay protection"
+    );
+    println!("✓ Second transaction with same counter failed (replay protection working)");
+
+    // Verify counter is now 1
+    let current_counter = get_secp256r1_counter(&context, &swig_key, &public_key).unwrap();
+    assert_eq!(
+        current_counter, 1,
+        "Counter should be 1 after first transaction"
+    );
+
+    println!("✓ Replay protection test passed - counter-based protection is working");
+}
+
+#[test_log::test]
+fn test_secp256r1_add_authority() {
+    let mut context = setup_test_context().unwrap();
+
+    // Create primary Ed25519 authority
+    let primary_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a new swig with Ed25519 authority
+    let (swig_key, _) = create_swig_ed25519(&mut context, &primary_authority, id).unwrap();
+    context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
+
+    // Create a real secp256r1 public key to add as second authority
+    let (_, secp256r1_pubkey) = create_test_secp256r1_keypair();
+
+    // Create instruction to add the Secp256r1 authority
+    let add_authority_ix = swig_interface::AddAuthorityInstruction::new_with_ed25519_authority(
+        swig_key,
+        context.default_payer.pubkey(),
+        primary_authority.pubkey(),
+        0, // role_id of the primary wallet
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256r1,
+            authority: &secp256r1_pubkey,
+        },
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[add_authority_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(message),
+        &[&context.default_payer, &primary_authority],
+    )
+    .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to add Secp256r1 authority: {:?}",
+        result.err()
+    );
+
+    // Verify the authority was added
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig_state.state.roles, 2);
+
+    println!("✓ Successfully added Secp256r1 authority");
+    println!("✓ Authority count increased to 2");
+}
+
+#[test_log::test]
+fn test_secp256r1_session_authority() {
+    let mut context = setup_test_context().unwrap();
+
+    // Create a real secp256r1 public key for session authority
+    let (_, public_key) = create_test_secp256r1_keypair();
+
+    // Create session authority parameters
+    let session_key = rand::random::<[u8; 32]>();
+    let max_session_length = 1000; // 1000 slots
+
+    let create_params = swig_state_x::authority::secp256r1::CreateSecp256r1SessionAuthority::new(
+        public_key,
+        session_key,
+        max_session_length,
+    );
+
+    // Verify the structure works
+    assert_eq!(create_params.public_key, public_key);
+    assert_eq!(create_params.session_key, session_key);
+    assert_eq!(create_params.max_session_length, max_session_length);
+
+    println!("✓ Secp256r1 session authority structure works correctly");
+    println!(
+        "✓ Session parameters: max_length = {} slots",
+        max_session_length
+    );
+}
+
+#[test_log::test]
+fn test_secp256r1_session_authority_odometer() {
+    let mut context = setup_test_context().unwrap();
+
+    // Create a real secp256r1 key pair for testing
+    let (_, public_key) = create_test_secp256r1_keypair();
+
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a swig with secp256r1 session authority type using the helper function
+    let (swig_key, _) =
+        create_swig_secp256r1_session(&mut context, &public_key, id, 100, [0; 32]).unwrap();
+
+    // Helper function to read the current counter for session authorities
+    let get_session_counter = |ctx: &SwigTestContext| -> Result<u32, String> {
+        let swig_account = ctx
+            .svm
+            .get_account(&swig_key)
+            .ok_or("Swig account not found")?;
+        let swig = SwigWithRoles::from_bytes(&swig_account.data)
+            .map_err(|e| format!("Failed to parse swig data: {:?}", e))?;
+
+        let role = swig
+            .get_role(0)
+            .map_err(|e| format!("Failed to get role: {:?}", e))?
+            .ok_or("Role not found")?;
+
+        if let Some(auth) = role
+            .authority
+            .as_any()
+            .downcast_ref::<Secp256r1SessionAuthority>()
+        {
+            Ok(auth.signature_odometer)
+        } else {
+            Err("Authority is not a Secp256r1SessionAuthority".to_string())
+        }
+    };
+
+    // Initial counter should be 0
+    let initial_counter = get_session_counter(&context).unwrap();
+    assert_eq!(initial_counter, 0, "Initial session counter should be 0");
+
+    // Verify the session authority structure is correctly initialized
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig.state.roles, 1);
+    let role = swig.get_role(0).unwrap().unwrap();
+
+    assert_eq!(
+        role.authority.authority_type(),
+        AuthorityType::Secp256r1Session
+    );
+    assert!(role.authority.session_based());
+
+    let auth: &Secp256r1SessionAuthority = role.authority.as_any().downcast_ref().unwrap();
+    assert_eq!(auth.max_session_age, 100);
+    assert_eq!(auth.public_key, public_key);
+    assert_eq!(auth.current_session_expiration, 0);
+    assert_eq!(auth.session_key, [0; 32]);
+    assert_eq!(auth.signature_odometer, 0, "Initial odometer should be 0");
+
+    println!("✓ Secp256r1 session authority structure correctly initialized");
+    println!("✓ Signature odometer field present and initialized to 0");
+    println!("✓ Session authority has proper session-based behavior");
+}
+
+/// Helper function to create a swig account with secp256r1 authority for testing
+fn create_swig_secp256r1(
+    context: &mut SwigTestContext,
+    public_key: &[u8; 33],
+    id: [u8; 32],
+) -> Result<(solana_sdk::pubkey::Pubkey, u8), Box<dyn std::error::Error>> {
+    use swig_state_x::swig::swig_account_seeds;
+
+    let payer_pubkey = context.default_payer.pubkey();
+    let (swig_address, swig_bump) = solana_sdk::pubkey::Pubkey::find_program_address(
+        &swig_account_seeds(&id),
+        &common::program_id(),
+    );
+
+    let create_ix = swig_interface::CreateInstruction::new(
+        swig_address,
+        swig_bump,
+        payer_pubkey,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256r1,
+            authority: public_key,
+        },
+        vec![ClientAction::All(All {})],
+        id,
+    )?;
+
+    let message = v0::Message::try_compile(
+        &payer_pubkey,
+        &[create_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )?;
+
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&context.default_payer])?;
+
+    context.svm.send_transaction(tx).unwrap();
+
+    Ok((swig_address, swig_bump))
+}

--- a/program/tests/sign_secp256r1.rs
+++ b/program/tests/sign_secp256r1.rs
@@ -549,6 +549,7 @@ fn test_secp256r1_add_authority_with_secp256r1() {
         current_slot,
         next_counter,
         0, // role_id of the primary authority
+        &public_key,
         AuthorityConfig {
             authority_type: AuthorityType::Secp256r1,
             authority: &new_public_key,

--- a/program/tests/sign_secp256r1.rs
+++ b/program/tests/sign_secp256r1.rs
@@ -90,52 +90,6 @@ fn get_secp256r1_counter(
     }
 }
 
-/// Helper to compute the message hash that secp256r1 verification expects
-fn compute_secp256r1_message_hash(
-    instruction_data: &[u8],
-    accounts: &[(solana_sdk::pubkey::Pubkey, bool, bool)], // (pubkey, is_writable, is_signer)
-    slot: u64,
-    counter: u32,
-) -> [u8; 32] {
-    use solana_sdk::keccak::{hash as keccak_hash, Hash as KeccakHash};
-    let mut accounts_payload = Vec::new();
-
-    for (pubkey, is_writable, is_signer) in accounts {
-        accounts_payload.extend_from_slice(pubkey.as_ref()); // 32 bytes: pubkey
-        accounts_payload.push(*is_writable as u8); // 1 byte: is_writable
-        accounts_payload.push(*is_signer as u8); // 1 byte: is_signer
-        accounts_payload.extend_from_slice(&[0u8; 6]); // 6 bytes: padding
-    }
-
-    // Combine all the data that goes into the hash
-    let mut combined_data = Vec::new();
-    combined_data.extend_from_slice(instruction_data);
-    combined_data.extend_from_slice(&accounts_payload);
-    combined_data.extend_from_slice(&slot.to_le_bytes());
-    combined_data.extend_from_slice(&counter.to_le_bytes());
-
-    // Keccak hash for the final result (compatible with passkeys)
-    let final_hash = keccak_hash(&combined_data);
-    final_hash.to_bytes()
-}
-
-/// Create a real secp256r1 precompile instruction using actual cryptography
-fn create_secp256r1_instruction(
-    signing_key: &openssl::ec::EcKey<openssl::pkey::Private>,
-    public_key: &[u8; 33],
-    message: &[u8],
-) -> solana_sdk::instruction::Instruction {
-    use solana_secp256r1_program::{new_secp256r1_instruction_with_signature, sign_message};
-
-    // Create the signature using the official Solana function
-    let signature = sign_message(message, &signing_key.private_key_to_der().unwrap()).unwrap();
-
-    // Create the instruction using the official Solana function
-    let instruction = new_secp256r1_instruction_with_signature(message, &signature, public_key);
-
-    instruction
-}
-
 #[test_log::test]
 fn test_secp256r1_basic_signing() {
     let mut context = setup_test_context().unwrap();
@@ -164,34 +118,30 @@ fn test_secp256r1_basic_signing() {
         current_counter, next_counter
     );
 
-    // Create the secp256r1 signing instruction
-    let sign_ix = swig_interface::SignInstruction::new_secp256r1(
+    // Create authority function that signs the message hash
+    let mut authority_fn = |message_hash: &[u8]| -> [u8; 64] {
+        use solana_secp256r1_program::sign_message;
+        let signature =
+            sign_message(message_hash, &signing_key.private_key_to_der().unwrap()).unwrap();
+        signature
+    };
+
+    // Create the secp256r1 signing instructions (returns Vec<Instruction>)
+    let instructions = swig_interface::SignInstruction::new_secp256r1(
         swig_key,
         context.default_payer.pubkey(),
+        authority_fn,
         current_slot,
         next_counter,
         transfer_ix.clone(),
         0, // Role ID 0
+        &public_key,
     )
     .unwrap();
 
-    // Compute the message hash that the secp256r1 verification will expect
-    // Account info: (pubkey, is_writable, is_signer)
-    let accounts = sign_ix
-        .accounts
-        .iter()
-        .map(|a| (a.pubkey, a.is_writable, a.is_signer))
-        .collect::<Vec<_>>();
-    let message_hash =
-        compute_secp256r1_message_hash(&transfer_ix.data, &accounts, current_slot, next_counter);
-
-    // Create a real secp256r1 verification instruction with proper cryptography
-    let secp256r1_verify_ix =
-        create_secp256r1_instruction(&signing_key, &public_key, &message_hash);
-
     let message = v0::Message::try_compile(
         &context.default_payer.pubkey(),
-        &[secp256r1_verify_ix, sign_ix], // secp256r1 verification must come first
+        &instructions, // Use the returned instructions directly
         &[],
         context.svm.latest_blockhash(),
     )
@@ -277,32 +227,31 @@ fn test_secp256r1_replay_protection() {
 
     // First transaction with counter 1
     let counter1 = 1;
-    let sign_ix1 = swig_interface::SignInstruction::new_secp256r1(
+
+    // Create authority function that signs the message hash
+    let mut authority_fn1 = |message_hash: &[u8]| -> [u8; 64] {
+        use solana_secp256r1_program::sign_message;
+        let signature =
+            sign_message(message_hash, &signing_key.private_key_to_der().unwrap()).unwrap();
+        signature
+    };
+
+    let instructions1 = swig_interface::SignInstruction::new_secp256r1(
         swig_key,
         context.default_payer.pubkey(),
+        authority_fn1,
         current_slot,
         counter1,
         transfer_ix.clone(),
         0,
+        &public_key,
     )
     .unwrap();
-
-    // Create message hash and secp256r1 instruction for first transaction
-    let accounts = vec![
-        (swig_key, true, false), // Swig account (writable, not signer)
-        (context.default_payer.pubkey(), true, true), // Payer (writable, signer)
-        (solana_sdk::system_program::ID, false, false), // System program (not writable, not signer)
-        (solana_sdk::sysvar::instructions::ID, false, false), // Instructions sysvar (not writable, not signer)
-    ];
-    let message_hash1 =
-        compute_secp256r1_message_hash(&transfer_ix.data, &accounts, current_slot, counter1);
-    let secp256r1_verify_ix1 =
-        create_secp256r1_instruction(&signing_key, &public_key, &message_hash1);
 
     // Execute first transaction
     let message1 = v0::Message::try_compile(
         &context.default_payer.pubkey(),
-        &[secp256r1_verify_ix1, sign_ix1],
+        &instructions1,
         &[],
         context.svm.latest_blockhash(),
     )
@@ -321,24 +270,28 @@ fn test_secp256r1_replay_protection() {
     println!("✓ First transaction with counter 1 succeeded");
 
     // Try second transaction with same counter (should fail due to replay protection)
-    let sign_ix2 = swig_interface::SignInstruction::new_secp256r1(
+    let mut authority_fn2 = |message_hash: &[u8]| -> [u8; 64] {
+        use solana_secp256r1_program::sign_message;
+        let signature =
+            sign_message(message_hash, &signing_key.private_key_to_der().unwrap()).unwrap();
+        signature
+    };
+
+    let instructions2 = swig_interface::SignInstruction::new_secp256r1(
         swig_key,
         context.default_payer.pubkey(),
+        authority_fn2,
         current_slot,
         counter1, // Same counter - should trigger replay protection
         transfer_ix.clone(),
         0,
+        &public_key,
     )
     .unwrap();
 
-    let message_hash2 =
-        compute_secp256r1_message_hash(&transfer_ix.data, &accounts, current_slot, counter1);
-    let secp256r1_verify_ix2 =
-        create_secp256r1_instruction(&signing_key, &public_key, &message_hash2);
-
     let message2 = v0::Message::try_compile(
         &context.default_payer.pubkey(),
-        &[secp256r1_verify_ix2, sign_ix2],
+        &instructions2,
         &[],
         context.svm.latest_blockhash(),
     )
@@ -558,4 +511,84 @@ fn create_swig_secp256r1(
     context.svm.send_transaction(tx).unwrap();
 
     Ok((swig_address, swig_bump))
+}
+
+#[test_log::test]
+fn test_secp256r1_add_authority_with_secp256r1() {
+    let mut context = setup_test_context().unwrap();
+
+    // Create a real secp256r1 key pair for the primary authority
+    let (signing_key, public_key) = create_test_secp256r1_keypair();
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a new swig with secp256r1 authority
+    let (swig_key, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+    context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
+
+    // Create a second secp256r1 public key to add as a new authority
+    let (_, new_public_key) = create_test_secp256r1_keypair();
+
+    // Get current slot and counter for the authority
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let current_counter = get_secp256r1_counter(&context, &swig_key, &public_key).unwrap();
+    let next_counter = current_counter + 1;
+
+    // Create authority function that signs the message hash
+    let mut authority_fn = |message_hash: &[u8]| -> [u8; 64] {
+        use solana_secp256r1_program::sign_message;
+        let signature =
+            sign_message(message_hash, &signing_key.private_key_to_der().unwrap()).unwrap();
+        signature
+    };
+
+    // Create instruction to add the new Secp256r1 authority
+    let instructions = swig_interface::AddAuthorityInstruction::new_with_secp256r1_authority(
+        swig_key,
+        context.default_payer.pubkey(),
+        authority_fn,
+        current_slot,
+        next_counter,
+        0, // role_id of the primary authority
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256r1,
+            authority: &new_public_key,
+        },
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &instructions,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&context.default_payer])
+            .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Failed to add Secp256r1 authority using secp256r1 signature: {:?}",
+        result.err()
+    );
+
+    // Verify the authority was added
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig_state.state.roles, 2);
+
+    // Verify the counter was incremented
+    let new_counter = get_secp256r1_counter(&context, &swig_key, &public_key).unwrap();
+    assert_eq!(
+        new_counter, next_counter,
+        "Counter should be incremented after successful transaction"
+    );
+
+    println!("✓ Successfully added Secp256r1 authority using secp256r1 signature");
+    println!("✓ Authority count increased to 2");
+    println!("✓ Counter incremented correctly");
 }

--- a/program/tests/sign_secp256r1.rs
+++ b/program/tests/sign_secp256r1.rs
@@ -26,9 +26,11 @@ use swig_state_x::{
 
 /// Helper to generate a real secp256r1 key pair for testing
 fn create_test_secp256r1_keypair() -> (openssl::ec::EcKey<openssl::pkey::Private>, [u8; 33]) {
-    use openssl::bn::BigNumContext;
-    use openssl::ec::{EcGroup, EcKey, PointConversionForm};
-    use openssl::nid::Nid;
+    use openssl::{
+        bn::BigNumContext,
+        ec::{EcGroup, EcKey, PointConversionForm},
+        nid::Nid,
+    };
 
     let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
     let signing_key = EcKey::generate(&group).unwrap();
@@ -49,7 +51,8 @@ fn create_test_secp256r1_authority() -> [u8; 33] {
     pubkey
 }
 
-/// Helper function to get the current signature counter for a secp256r1 authority
+/// Helper function to get the current signature counter for a secp256r1
+/// authority
 fn get_secp256r1_counter(
     context: &SwigTestContext,
     swig_key: &solana_sdk::pubkey::Pubkey,
@@ -269,7 +272,8 @@ fn test_secp256r1_replay_protection() {
     );
     println!("✓ First transaction with counter 1 succeeded");
 
-    // Try second transaction with same counter (should fail due to replay protection)
+    // Try second transaction with same counter (should fail due to replay
+    // protection)
     let mut authority_fn2 = |message_hash: &[u8]| -> [u8; 64] {
         use solana_secp256r1_program::sign_message;
         let signature =
@@ -472,7 +476,8 @@ fn test_secp256r1_session_authority_odometer() {
     println!("✓ Session authority has proper session-based behavior");
 }
 
-/// Helper function to create a swig account with secp256r1 authority for testing
+/// Helper function to create a swig account with secp256r1 authority for
+/// testing
 fn create_swig_secp256r1(
     context: &mut SwigTestContext,
     public_key: &[u8; 33],

--- a/rust-sdk/src/error.rs
+++ b/rust-sdk/src/error.rs
@@ -73,6 +73,10 @@ pub enum SwigError {
     /// Invalid program scope
     #[error("Invalid program scope")]
     InvalidProgramScope,
+
+    /// Counter not set
+    #[error("Counter not set")]
+    CounterNotSet,
 }
 
 impl From<anyhow::Error> for SwigError {

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -53,8 +53,6 @@ pub struct SwigWallet<'a> {
     pub rpc_client: RpcClient,
     /// The wallet's fee payer keypair
     fee_payer: &'a Keypair,
-    /// The authority keypair for signing transactions
-    authority: &'a Keypair,
     /// The LiteSVM instance for testing
     #[cfg(all(feature = "rust_sdk_test", test))]
     litesvm: LiteSVM,
@@ -81,7 +79,6 @@ impl<'c> SwigWallet<'c> {
         swig_id: [u8; 32],
         authority_manager: AuthorityManager,
         fee_payer: &'c Keypair,
-        authority: &'c Keypair,
         rpc_url: String,
         #[cfg(all(feature = "rust_sdk_test", test))] mut litesvm: LiteSVM,
     ) -> Result<Self, SwigError> {
@@ -128,7 +125,6 @@ impl<'c> SwigWallet<'c> {
                 instruction_builder,
                 rpc_client,
                 fee_payer,
-                authority,
                 #[cfg(all(feature = "rust_sdk_test", test))]
                 litesvm,
             })
@@ -174,7 +170,6 @@ impl<'c> SwigWallet<'c> {
                 instruction_builder,
                 rpc_client,
                 fee_payer: &fee_payer,
-                authority: &authority,
                 #[cfg(all(feature = "rust_sdk_test", test))]
                 litesvm,
             })

--- a/state-x/Cargo.toml
+++ b/state-x/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 
 [dependencies]
 pinocchio = { version = "=0.8.1", features = ["std"] }
+pinocchio-pubkey = { version = "0.2.4" }
 swig-assertions = { path = "../assertions" }
 no-padding = { path = "../no-padding" }
-murmur3 = { version = "0.5.2", optional = true }
-libsecp256k1 = { version = "0.7.2", default-features = false}
+libsecp256k1 = { version = "0.7.2", default-features = false }
 
 [target.'cfg(not(feature = "static_syscalls"))'.dependencies]
 murmur3 = "0.5.2"
@@ -18,6 +18,9 @@ murmur3 = "0.5.2"
 [dev-dependencies]
 rand = "0.9.0"
 hex = "0.4.3"
+openssl = { version = "0.10.72", features = ["vendored"] }
+agave-precompiles = "2.2.14"
+solana-secp256r1-program = "2.2.1"
 
 [lints.clippy]
 unexpected_cfgs = "allow"

--- a/state-x/src/authority/mod.rs
+++ b/state-x/src/authority/mod.rs
@@ -7,12 +7,14 @@
 
 pub mod ed25519;
 pub mod secp256k1;
+pub mod secp256r1;
 
 use std::any::Any;
 
 use ed25519::{ED25519Authority, Ed25519SessionAuthority};
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError};
 use secp256k1::{Secp256k1Authority, Secp256k1SessionAuthority};
+use secp256r1::{Secp256r1Authority, Secp256r1SessionAuthority};
 
 use crate::{IntoBytes, SwigAuthenticateError, Transmutable, TransmutableMut};
 
@@ -120,10 +122,10 @@ pub enum AuthorityType {
     Secp256k1,
     /// Session-based Secp256k1 authority
     Secp256k1Session,
+    /// Standard Secp256r1 authority (for passkeys)
+    Secp256r1,
     /// Session-based Secp256r1 authority
     Secp256r1Session,
-    /// Session-based R1 Passkey authority
-    R1PasskeySession,
 }
 
 impl TryFrom<u16> for AuthorityType {
@@ -137,8 +139,8 @@ impl TryFrom<u16> for AuthorityType {
             2 => Ok(AuthorityType::Ed25519Session),
             3 => Ok(AuthorityType::Secp256k1),
             4 => Ok(AuthorityType::Secp256k1Session),
-            5 => Ok(AuthorityType::Secp256r1Session),
-            6 => Ok(AuthorityType::R1PasskeySession),
+            5 => Ok(AuthorityType::Secp256r1),
+            6 => Ok(AuthorityType::Secp256r1Session),
             _ => Err(ProgramError::InvalidInstructionData),
         }
     }
@@ -160,6 +162,8 @@ pub const fn authority_type_to_length(
         AuthorityType::Ed25519Session => Ok(Ed25519SessionAuthority::LEN),
         AuthorityType::Secp256k1 => Ok(Secp256k1Authority::LEN),
         AuthorityType::Secp256k1Session => Ok(Secp256k1SessionAuthority::LEN),
+        AuthorityType::Secp256r1 => Ok(Secp256r1Authority::LEN),
+        AuthorityType::Secp256r1Session => Ok(Secp256r1SessionAuthority::LEN),
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }

--- a/state-x/src/authority/secp256k1.rs
+++ b/state-x/src/authority/secp256k1.rs
@@ -347,7 +347,8 @@ fn secp_authority_authenticate(
 ///
 /// # Arguments
 /// * `authority` - The mutable authority reference for counter updates
-/// * `authority_payload` - The authority payload including slot, counter, and signature
+/// * `authority_payload` - The authority payload including slot, counter, and
+///   signature
 /// * `data_payload` - Additional data to be included in signature verification
 /// * `current_slot` - The current slot number
 /// * `account_infos` - List of accounts involved in the transaction

--- a/state-x/src/authority/secp256k1.rs
+++ b/state-x/src/authority/secp256k1.rs
@@ -169,7 +169,9 @@ impl IntoBytes for Secp256k1Authority {
 pub struct Secp256k1SessionAuthority {
     /// The compressed Secp256k1 public key (33 bytes)
     pub public_key: [u8; 33],
-    _padding: [u8; 7],
+    _padding: [u8; 3],
+    /// Signature counter to prevent signature replay attacks
+    pub signature_odometer: u32,
     /// The current session key
     pub session_key: [u8; 32],
     /// Maximum allowed session duration
@@ -193,6 +195,7 @@ impl Authority for Secp256k1SessionAuthority {
         let authority = unsafe { Secp256k1SessionAuthority::load_mut_unchecked(bytes)? };
         let compressed = compress(&create.public_key);
         authority.public_key = compressed;
+        authority.signature_odometer = 0;
         authority.session_key = create.session_key;
         authority.max_session_age = create.max_session_length;
         Ok(())
@@ -236,7 +239,7 @@ impl AuthorityInfo for Secp256k1SessionAuthority {
         slot: u64,
     ) -> Result<(), ProgramError> {
         secp_session_authority_authenticate(
-            &self.public_key,
+            self,
             authority_payload,
             data_payload,
             slot,
@@ -335,34 +338,44 @@ fn secp_authority_authenticate(
 /// Authenticates a Secp256k1 session authority with additional payload data.
 ///
 /// # Arguments
-/// * `expected_key` - The expected compressed public key
-/// * `authority_payload` - The authority payload including slot and signature
+/// * `authority` - The mutable authority reference for counter updates
+/// * `authority_payload` - The authority payload including slot, counter, and signature
 /// * `data_payload` - Additional data to be included in signature verification
 /// * `current_slot` - The current slot number
 /// * `account_infos` - List of accounts involved in the transaction
 fn secp_session_authority_authenticate(
-    expected_key: &[u8; 33],
+    authority: &mut Secp256k1SessionAuthority,
     authority_payload: &[u8],
     data_payload: &[u8],
     current_slot: u64,
     account_infos: &[AccountInfo],
 ) -> Result<(), ProgramError> {
-    if authority_payload.len() < 73 {
+    if authority_payload.len() < 77 {
         return Err(SwigAuthenticateError::InvalidAuthorityPayload.into());
     }
     let authority_slot =
         u64::from_le_bytes(unsafe { authority_payload.get_unchecked(..8).try_into().unwrap() });
 
+    let counter =
+        u32::from_le_bytes(unsafe { authority_payload.get_unchecked(8..12).try_into().unwrap() });
+
+    let expected_counter = authority.signature_odometer.wrapping_add(1);
+    if counter != expected_counter {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256k1SignatureReused.into());
+    }
+
     secp256k1_authenticate(
-        expected_key,
-        authority_payload[8..73].try_into().unwrap(),
+        &authority.public_key,
+        authority_payload[12..77].try_into().unwrap(),
         data_payload,
         authority_slot,
         current_slot,
         account_infos,
-        authority_payload[73..].try_into().unwrap(),
-        0u32, // Session authorities don't use counter-based replay protection
+        authority_payload[77..].try_into().unwrap(),
+        counter, // Now use proper counter-based replay protection
     )?;
+
+    authority.signature_odometer = counter;
     Ok(())
 }
 

--- a/state-x/src/authority/secp256r1.rs
+++ b/state-x/src/authority/secp256r1.rs
@@ -1,10 +1,10 @@
 //! Secp256r1 authority implementation for passkey support.
 //!
 //! This module provides implementations for Secp256r1-based authority types in
-//! the Swig wallet system, designed to work with passkeys and WebAuthn. It includes
-//! both standard Secp256r1 authority and session-based Secp256r1 authority with
-//! expiration support. The implementation relies on the Solana secp256r1 precompile
-//! program for signature verification.
+//! the Swig wallet system, designed to work with passkeys and WebAuthn. It
+//! includes both standard Secp256r1 authority and session-based Secp256r1
+//! authority with expiration support. The implementation relies on the Solana
+//! secp256r1 precompile program for signature verification.
 
 #![warn(unexpected_cfgs)]
 
@@ -336,7 +336,8 @@ impl IntoBytes for Secp256r1SessionAuthority {
 ///
 /// # Arguments
 /// * `authority` - The mutable authority reference for counter updates
-/// * `authority_payload` - The authority payload including slot, counter, instruction index, and signature
+/// * `authority_payload` - The authority payload including slot, counter,
+///   instruction index, and signature
 /// * `data_payload` - Additional data to be included in signature verification
 /// * `current_slot` - The current slot number
 /// * `account_infos` - List of accounts involved in the transaction
@@ -391,7 +392,8 @@ fn secp256r1_authority_authenticate(
 ///
 /// # Arguments
 /// * `authority` - The mutable authority reference for counter updates
-/// * `authority_payload` - The authority payload including slot, counter, and instruction index
+/// * `authority_payload` - The authority payload including slot, counter, and
+///   instruction index
 /// * `data_payload` - Additional data to be included in signature verification
 /// * `current_slot` - The current slot number
 /// * `account_infos` - List of accounts involved in the transaction
@@ -529,7 +531,8 @@ fn compute_message_hash(
     }
 }
 
-/// Verify the secp256r1 instruction data contains the expected signature and public key
+/// Verify the secp256r1 instruction data contains the expected signature and
+/// public key
 fn verify_secp256r1_instruction_data(
     instruction_data: &[u8],
     expected_pubkey: &[u8; 33],
@@ -568,7 +571,8 @@ fn verify_secp256r1_instruction_data(
 mod tests {
     use super::*;
 
-    /// Helper function to create real secp256r1 instruction data using the official Solana secp256r1 program
+    /// Helper function to create real secp256r1 instruction data using the
+    /// official Solana secp256r1 program
     fn create_test_secp256r1_instruction_data(
         message: &[u8],
         signature: &[u8; 64],
@@ -585,9 +589,11 @@ mod tests {
 
     /// Helper function to create a signature using OpenSSL for testing
     fn create_test_signature_and_pubkey(message: &[u8]) -> ([u8; 64], [u8; 33]) {
-        use openssl::bn::BigNumContext;
-        use openssl::ec::{EcGroup, EcKey, PointConversionForm};
-        use openssl::nid::Nid;
+        use openssl::{
+            bn::BigNumContext,
+            ec::{EcGroup, EcKey, PointConversionForm},
+            nid::Nid,
+        };
         use solana_secp256r1_program::sign_message;
 
         let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();

--- a/state-x/src/authority/secp256r1.rs
+++ b/state-x/src/authority/secp256r1.rs
@@ -1,0 +1,814 @@
+//! Secp256r1 authority implementation for passkey support.
+//!
+//! This module provides implementations for Secp256r1-based authority types in
+//! the Swig wallet system, designed to work with passkeys and WebAuthn. It includes
+//! both standard Secp256r1 authority and session-based Secp256r1 authority with
+//! expiration support. The implementation relies on the Solana secp256r1 precompile
+//! program for signature verification.
+
+#![warn(unexpected_cfgs)]
+
+use core::mem::MaybeUninit;
+
+#[allow(unused_imports)]
+use pinocchio::syscalls::sol_sha256;
+use pinocchio::{
+    account_info::AccountInfo,
+    msg,
+    program_error::ProgramError,
+    pubkey::{self, Pubkey},
+    sysvars::instructions::{Instructions, INSTRUCTIONS_ID},
+};
+use pinocchio_pubkey::pubkey;
+use swig_assertions::sol_assert_bytes_eq;
+
+use super::{Authority, AuthorityInfo, AuthorityType};
+use crate::{IntoBytes, SwigAuthenticateError, SwigStateError, Transmutable, TransmutableMut};
+
+/// Maximum age (in slots) for a Secp256r1 signature to be considered valid
+const MAX_SIGNATURE_AGE_IN_SLOTS: u64 = 60;
+
+/// Secp256r1 program ID
+const SECP256R1_PROGRAM_ID: [u8; 32] = pubkey!("Secp256r1SigVerify1111111111111111111111111");
+
+/// Constants from the secp256r1 program
+const COMPRESSED_PUBKEY_SERIALIZED_SIZE: usize = 33;
+const SIGNATURE_SERIALIZED_SIZE: usize = 64;
+const SIGNATURE_OFFSETS_SERIALIZED_SIZE: usize = 14;
+const SIGNATURE_OFFSETS_START: usize = 2;
+const DATA_START: usize = SIGNATURE_OFFSETS_SERIALIZED_SIZE + SIGNATURE_OFFSETS_START;
+
+/// Secp256r1 signature offsets structure (matches solana-secp256r1-program)
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct Secp256r1SignatureOffsets {
+    /// Offset to compact secp256r1 signature of 64 bytes
+    pub signature_offset: u16,
+    /// Instruction index where the signature can be found
+    pub signature_instruction_index: u16,
+    /// Offset to compressed public key of 33 bytes
+    pub public_key_offset: u16,
+    /// Instruction index where the public key can be found
+    pub public_key_instruction_index: u16,
+    /// Offset to the start of message data
+    pub message_data_offset: u16,
+    /// Size of message data in bytes
+    pub message_data_size: u16,
+    /// Instruction index where the message data can be found
+    pub message_instruction_index: u16,
+}
+
+/// Creation parameters for a session-based Secp256r1 authority.
+#[derive(Debug, no_padding::NoPadding)]
+#[repr(C, align(8))]
+pub struct CreateSecp256r1SessionAuthority {
+    /// The compressed Secp256r1 public key (33 bytes)
+    pub public_key: [u8; 33],
+    /// Padding for alignment
+    _padding: [u8; 7],
+    /// The session key for temporary authentication
+    pub session_key: [u8; 32],
+    /// Maximum duration a session can be valid for
+    pub max_session_length: u64,
+}
+
+impl CreateSecp256r1SessionAuthority {
+    /// Creates a new set of session authority parameters.
+    ///
+    /// # Arguments
+    /// * `public_key` - The compressed Secp256r1 public key
+    /// * `session_key` - The initial session key
+    /// * `max_session_length` - Maximum allowed session duration
+    pub fn new(public_key: [u8; 33], session_key: [u8; 32], max_session_length: u64) -> Self {
+        Self {
+            public_key,
+            _padding: [0; 7],
+            session_key,
+            max_session_length,
+        }
+    }
+}
+
+impl Transmutable for CreateSecp256r1SessionAuthority {
+    const LEN: usize = 33 + 32 + 8;
+}
+
+impl TransmutableMut for CreateSecp256r1SessionAuthority {}
+
+impl IntoBytes for CreateSecp256r1SessionAuthority {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        let bytes =
+            unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) };
+        Ok(bytes)
+    }
+}
+
+/// Standard Secp256r1 authority implementation for passkey support.
+///
+/// This struct represents a Secp256r1 authority with a compressed public key
+/// for signature verification using the Solana secp256r1 precompile program.
+#[derive(Debug, no_padding::NoPadding)]
+#[repr(C, align(8))]
+pub struct Secp256r1Authority {
+    /// The compressed Secp256r1 public key (33 bytes)
+    pub public_key: [u8; 33],
+    /// Padding for u32 alignment
+    _padding: [u8; 3],
+    /// Signature counter to prevent signature replay attacks
+    pub signature_odometer: u32,
+}
+
+impl Secp256r1Authority {
+    /// Creates a new Secp256r1Authority with a compressed public key.
+    pub fn new(public_key: [u8; 33]) -> Self {
+        Self {
+            public_key,
+            _padding: [0; 3],
+            signature_odometer: 0,
+        }
+    }
+}
+
+impl Transmutable for Secp256r1Authority {
+    const LEN: usize = core::mem::size_of::<Secp256r1Authority>();
+}
+
+impl TransmutableMut for Secp256r1Authority {}
+
+impl Authority for Secp256r1Authority {
+    const TYPE: AuthorityType = AuthorityType::Secp256r1;
+    const SESSION_BASED: bool = false;
+
+    fn set_into_bytes(create_data: &[u8], bytes: &mut [u8]) -> Result<(), ProgramError> {
+        if create_data.len() != 33 {
+            return Err(SwigStateError::InvalidRoleData.into());
+        }
+        let authority = unsafe { Secp256r1Authority::load_mut_unchecked(bytes)? };
+        authority.public_key.copy_from_slice(create_data);
+        authority.signature_odometer = 0;
+        Ok(())
+    }
+}
+
+impl AuthorityInfo for Secp256r1Authority {
+    fn authority_type(&self) -> AuthorityType {
+        Self::TYPE
+    }
+
+    fn length(&self) -> usize {
+        Self::LEN
+    }
+
+    fn session_based(&self) -> bool {
+        Self::SESSION_BASED
+    }
+
+    fn identity(&self) -> Result<&[u8], ProgramError> {
+        Ok(self.public_key.as_ref())
+    }
+
+    fn match_data(&self, data: &[u8]) -> bool {
+        if data.len() != 33 {
+            return false;
+        }
+        sol_assert_bytes_eq(&self.public_key, data, 33)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn authenticate(
+        &mut self,
+        account_infos: &[pinocchio::account_info::AccountInfo],
+        authority_payload: &[u8],
+        data_payload: &[u8],
+        slot: u64,
+    ) -> Result<(), ProgramError> {
+        secp256r1_authority_authenticate(self, authority_payload, data_payload, slot, account_infos)
+    }
+}
+
+impl IntoBytes for Secp256r1Authority {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        let bytes =
+            unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) };
+        Ok(bytes)
+    }
+}
+
+/// Session-based Secp256r1 authority implementation.
+///
+/// This struct represents a Secp256r1 authority that supports temporary session
+/// keys with expiration times. It maintains both a root public key and a
+/// session key.
+#[derive(Debug, no_padding::NoPadding)]
+#[repr(C, align(8))]
+pub struct Secp256r1SessionAuthority {
+    /// The compressed Secp256r1 public key (33 bytes)
+    pub public_key: [u8; 33],
+    _padding: [u8; 3],
+    /// Signature counter to prevent signature replay attacks
+    pub signature_odometer: u32,
+    /// The current session key
+    pub session_key: [u8; 32],
+    /// Maximum allowed session duration
+    pub max_session_age: u64,
+    /// Slot when the current session expires
+    pub current_session_expiration: u64,
+}
+
+impl Transmutable for Secp256r1SessionAuthority {
+    const LEN: usize = core::mem::size_of::<Secp256r1SessionAuthority>();
+}
+
+impl TransmutableMut for Secp256r1SessionAuthority {}
+
+impl Authority for Secp256r1SessionAuthority {
+    const TYPE: AuthorityType = AuthorityType::Secp256r1Session;
+    const SESSION_BASED: bool = true;
+
+    fn set_into_bytes(create_data: &[u8], bytes: &mut [u8]) -> Result<(), ProgramError> {
+        let create = unsafe { CreateSecp256r1SessionAuthority::load_unchecked(create_data)? };
+        let authority = unsafe { Secp256r1SessionAuthority::load_mut_unchecked(bytes)? };
+        authority.public_key = create.public_key;
+        authority.signature_odometer = 0;
+        authority.session_key = create.session_key;
+        authority.max_session_age = create.max_session_length;
+        Ok(())
+    }
+}
+
+impl AuthorityInfo for Secp256r1SessionAuthority {
+    fn authority_type(&self) -> AuthorityType {
+        Self::TYPE
+    }
+
+    fn length(&self) -> usize {
+        Self::LEN
+    }
+
+    fn session_based(&self) -> bool {
+        Self::SESSION_BASED
+    }
+
+    fn match_data(&self, data: &[u8]) -> bool {
+        if data.len() != 33 {
+            return false;
+        }
+        sol_assert_bytes_eq(&self.public_key, data, 33)
+    }
+
+    fn identity(&self) -> Result<&[u8], ProgramError> {
+        Ok(self.public_key.as_ref())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn authenticate(
+        &mut self,
+        account_infos: &[pinocchio::account_info::AccountInfo],
+        authority_payload: &[u8],
+        data_payload: &[u8],
+        slot: u64,
+    ) -> Result<(), ProgramError> {
+        secp256r1_session_authority_authenticate(
+            self,
+            authority_payload,
+            data_payload,
+            slot,
+            account_infos,
+        )
+    }
+
+    fn authenticate_session(
+        &mut self,
+        account_infos: &[AccountInfo],
+        authority_payload: &[u8],
+        _data_payload: &[u8],
+        slot: u64,
+    ) -> Result<(), ProgramError> {
+        use super::ed25519::ed25519_authenticate;
+
+        if slot > self.current_session_expiration {
+            return Err(SwigAuthenticateError::PermissionDeniedSessionExpired.into());
+        }
+        ed25519_authenticate(
+            account_infos,
+            authority_payload[0] as usize,
+            &self.session_key,
+        )
+    }
+
+    fn start_session(
+        &mut self,
+        session_key: [u8; 32],
+        current_slot: u64,
+        duration: u64,
+    ) -> Result<(), ProgramError> {
+        if sol_assert_bytes_eq(&self.session_key, &session_key, 32) {
+            return Err(SwigAuthenticateError::InvalidSessionKeyCannotReuseSessionKey.into());
+        }
+        if duration > self.max_session_age {
+            return Err(SwigAuthenticateError::InvalidSessionDuration.into());
+        }
+        self.current_session_expiration = current_slot + duration;
+        self.session_key = session_key;
+        Ok(())
+    }
+}
+
+impl IntoBytes for Secp256r1SessionAuthority {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        let bytes =
+            unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) };
+        Ok(bytes)
+    }
+}
+
+/// Authenticates a Secp256r1 authority with additional payload data.
+///
+/// # Arguments
+/// * `authority` - The mutable authority reference for counter updates
+/// * `authority_payload` - The authority payload including slot, counter, instruction index, and signature
+/// * `data_payload` - Additional data to be included in signature verification
+/// * `current_slot` - The current slot number
+/// * `account_infos` - List of accounts involved in the transaction
+fn secp256r1_authority_authenticate(
+    authority: &mut Secp256r1Authority,
+    authority_payload: &[u8],
+    data_payload: &[u8],
+    current_slot: u64,
+    account_infos: &[AccountInfo],
+) -> Result<(), ProgramError> {
+    if authority_payload.len() < 17 {
+        // 8 + 4 + 1 + 4 = slot + counter + instructions_account_index + extra data
+        return Err(SwigAuthenticateError::InvalidAuthorityPayload.into());
+    }
+
+    let authority_slot =
+        u64::from_le_bytes(unsafe { authority_payload.get_unchecked(..8).try_into().unwrap() });
+
+    let counter =
+        u32::from_le_bytes(unsafe { authority_payload.get_unchecked(8..12).try_into().unwrap() });
+
+    let instruction_account_index = authority_payload[12] as usize;
+
+    let expected_counter = authority.signature_odometer.wrapping_add(1);
+    if counter != expected_counter {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256k1SignatureReused.into());
+    }
+
+    secp256r1_authenticate(
+        &authority.public_key,
+        data_payload,
+        authority_slot,
+        current_slot,
+        account_infos,
+        instruction_account_index,
+        counter,
+    )?;
+
+    authority.signature_odometer = counter;
+    Ok(())
+}
+
+/// Authenticates a Secp256r1 session authority with additional payload data.
+///
+/// # Arguments
+/// * `authority` - The mutable authority reference for counter updates
+/// * `authority_payload` - The authority payload including slot, counter, and instruction index
+/// * `data_payload` - Additional data to be included in signature verification
+/// * `current_slot` - The current slot number
+/// * `account_infos` - List of accounts involved in the transaction
+fn secp256r1_session_authority_authenticate(
+    authority: &mut Secp256r1SessionAuthority,
+    authority_payload: &[u8],
+    data_payload: &[u8],
+    current_slot: u64,
+    account_infos: &[AccountInfo],
+) -> Result<(), ProgramError> {
+    if authority_payload.len() < 13 {
+        // 8 + 4 + 1 = slot + counter + instruction_index
+        return Err(SwigAuthenticateError::InvalidAuthorityPayload.into());
+    }
+
+    let authority_slot =
+        u64::from_le_bytes(unsafe { authority_payload.get_unchecked(..8).try_into().unwrap() });
+
+    let counter =
+        u32::from_le_bytes(unsafe { authority_payload.get_unchecked(8..12).try_into().unwrap() });
+
+    let instruction_index = authority_payload[12] as usize;
+
+    let expected_counter = authority.signature_odometer.wrapping_add(1);
+    if counter != expected_counter {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256k1SignatureReused.into());
+    }
+
+    secp256r1_authenticate(
+        &authority.public_key,
+        data_payload,
+        authority_slot,
+        current_slot,
+        account_infos,
+        instruction_index,
+        counter, // Now use proper counter-based replay protection
+    )?;
+
+    authority.signature_odometer = counter;
+    Ok(())
+}
+
+/// Core Secp256r1 signature verification function.
+///
+/// This function performs the actual signature verification by:
+/// - Validating signature age
+/// - Computing the message hash (including counter for replay protection)
+/// - Finding and validating the secp256r1 precompile instruction
+/// - Verifying the message hash matches what was passed to the precompile
+/// - Verifying the public key matches
+fn secp256r1_authenticate(
+    expected_key: &[u8; 33],
+    data_payload: &[u8],
+    authority_slot: u64,
+    current_slot: u64,
+    account_infos: &[AccountInfo],
+    instruction_account_index: usize,
+    counter: u32,
+) -> Result<(), ProgramError> {
+    // Validate signature age
+    if current_slot < authority_slot || current_slot - authority_slot > MAX_SIGNATURE_AGE_IN_SLOTS {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256k1InvalidSignatureAge.into());
+    }
+
+    // Compute our expected message hash
+    let computed_hash = compute_message_hash(data_payload, account_infos, authority_slot, counter)?;
+
+    // Get the sysvar instructions account
+    let sysvar_instructions = account_infos
+        .get(instruction_account_index)
+        .ok_or(SwigAuthenticateError::InvalidAuthorityPayload)?;
+
+    // Verify this is the sysvar instructions account
+
+    if sysvar_instructions.key().as_ref() != &INSTRUCTIONS_ID {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into());
+    }
+
+    let sysvar_instructions_data = unsafe { sysvar_instructions.borrow_data_unchecked() };
+    let ixs = unsafe { Instructions::new_unchecked(sysvar_instructions_data) };
+    let current_index = ixs.load_current_index() as usize;
+    if current_index == 0 {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into());
+    }
+    let secpr1ix = unsafe { ixs.deserialize_instruction_unchecked(current_index - 1) };
+    // Verify the instruction is calling the secp256r1 program
+    if secpr1ix.get_program_id() != &SECP256R1_PROGRAM_ID {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into());
+    }
+    let instruction_data = secpr1ix.get_instruction_data();
+    // Parse and verify the secp256r1 instruction data
+    verify_secp256r1_instruction_data(&instruction_data, expected_key, &computed_hash)?;
+    Ok(())
+}
+
+/// Compute the message hash for secp256r1 authentication
+fn compute_message_hash(
+    data_payload: &[u8],
+    account_infos: &[AccountInfo],
+    authority_slot: u64,
+    counter: u32,
+) -> Result<[u8; 32], ProgramError> {
+    use super::secp256k1::AccountsPayload;
+
+    let mut accounts_payload = [0u8; 64 * AccountsPayload::LEN];
+    let mut cursor = 0;
+
+    for account in account_infos {
+        let offset = cursor + AccountsPayload::LEN;
+        accounts_payload[cursor..offset]
+            .copy_from_slice(AccountsPayload::from(account).into_bytes()?);
+        cursor = offset;
+    }
+
+    let mut hash = MaybeUninit::<[u8; 32]>::uninit();
+    let data: &[&[u8]] = &[
+        data_payload,
+        &accounts_payload[..cursor],
+        &authority_slot.to_le_bytes(),
+        &counter.to_le_bytes(),
+    ];
+
+    unsafe {
+        #[cfg(target_os = "solana")]
+        let res = pinocchio::syscalls::sol_keccak256(
+            data.as_ptr() as *const u8,
+            4,
+            hash.as_mut_ptr() as *mut u8,
+        );
+        #[cfg(not(target_os = "solana"))]
+        let res = 0;
+        if res != 0 {
+            return Err(SwigAuthenticateError::PermissionDeniedSecp256k1InvalidHash.into());
+        }
+
+        Ok(hash.assume_init())
+    }
+}
+
+/// Verify the secp256r1 instruction data contains the expected signature and public key
+fn verify_secp256r1_instruction_data(
+    instruction_data: &[u8],
+    expected_pubkey: &[u8; 33],
+    expected_message: &[u8],
+) -> Result<(), ProgramError> {
+    // Minimum check: must have at least the header and offsets
+    if instruction_data.len() < DATA_START {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into());
+    }
+    let num_signatures = instruction_data[0] as usize;
+    if num_signatures == 0 || num_signatures > 1 {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into());
+    }
+
+    // Parse signature offsets to ensure no cross-instruction references
+    let offsets_start = SIGNATURE_OFFSETS_START;
+    let signature_instruction_index = u16::from_le_bytes([
+        instruction_data[offsets_start + 2],
+        instruction_data[offsets_start + 3],
+    ]);
+    let public_key_instruction_index = u16::from_le_bytes([
+        instruction_data[offsets_start + 6],
+        instruction_data[offsets_start + 7],
+    ]);
+    let message_instruction_index = u16::from_le_bytes([
+        instruction_data[offsets_start + 12],
+        instruction_data[offsets_start + 13],
+    ]);
+
+    // All data must come from the same instruction
+    // Official Solana uses 0xFFFF to indicate "same instruction"
+    if signature_instruction_index != public_key_instruction_index
+        || signature_instruction_index != message_instruction_index
+        || public_key_instruction_index != message_instruction_index
+    {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into());
+    }
+
+    // Extract the message size from the signature offsets
+    let message_data_size = u16::from_le_bytes([
+        instruction_data[offsets_start + 10],
+        instruction_data[offsets_start + 11],
+    ]) as usize;
+
+    // Check that we have enough data for the complete instruction
+    if instruction_data.len()
+        < DATA_START
+            + SIGNATURE_SERIALIZED_SIZE
+            + COMPRESSED_PUBKEY_SERIALIZED_SIZE
+            + message_data_size
+    {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into());
+    }
+
+    let pubkey_data = &instruction_data[DATA_START..DATA_START + COMPRESSED_PUBKEY_SERIALIZED_SIZE];
+    let message_data = &instruction_data[DATA_START
+        + COMPRESSED_PUBKEY_SERIALIZED_SIZE
+        + SIGNATURE_SERIALIZED_SIZE
+        ..DATA_START
+            + COMPRESSED_PUBKEY_SERIALIZED_SIZE
+            + SIGNATURE_SERIALIZED_SIZE
+            + message_data_size];
+
+    if pubkey_data != expected_pubkey {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidPubkey.into());
+    }
+    msg!("message_data: {:?}", message_data);
+    msg!("expected_message: {:?}", expected_message);
+    if message_data != expected_message {
+        return Err(SwigAuthenticateError::PermissionDeniedSecp256r1InvalidMessageHash.into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper function to create real secp256r1 instruction data using the official Solana secp256r1 program
+    fn create_test_secp256r1_instruction_data(
+        message: &[u8],
+        signature: &[u8; 64],
+        pubkey: &[u8; 33],
+    ) -> Vec<u8> {
+        use solana_secp256r1_program::new_secp256r1_instruction_with_signature;
+
+        // Use the official Solana function to create the instruction data
+        // This ensures we match exactly what the Solana runtime expects
+        let instruction = new_secp256r1_instruction_with_signature(message, signature, pubkey);
+
+        instruction.data
+    }
+
+    /// Helper function to create a signature using OpenSSL for testing
+    fn create_test_signature_and_pubkey(message: &[u8]) -> ([u8; 64], [u8; 33]) {
+        use openssl::bn::BigNumContext;
+        use openssl::ec::{EcGroup, EcKey, PointConversionForm};
+        use openssl::nid::Nid;
+        use solana_secp256r1_program::sign_message;
+
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let signing_key = EcKey::generate(&group).unwrap();
+
+        let signature = sign_message(message, &signing_key.private_key_to_der().unwrap()).unwrap();
+
+        let mut ctx = BigNumContext::new().unwrap();
+        let pubkey_bytes = signing_key
+            .public_key()
+            .to_bytes(&group, PointConversionForm::COMPRESSED, &mut ctx)
+            .unwrap();
+
+        assert_eq!(pubkey_bytes.len(), COMPRESSED_PUBKEY_SERIALIZED_SIZE);
+
+        (signature, pubkey_bytes.try_into().unwrap())
+    }
+
+    #[test]
+    fn test_verify_secp256r1_instruction_data_single_signature() {
+        let test_message = b"test message for secp256r1";
+        let test_signature = [0xCD; 64]; // Test signature
+        let test_pubkey = [0x02; 33]; // Test compressed pubkey
+
+        let instruction_data =
+            create_test_secp256r1_instruction_data(test_message, &test_signature, &test_pubkey);
+
+        // Should succeed with matching pubkey and message hash
+        let result =
+            verify_secp256r1_instruction_data(&instruction_data, &test_pubkey, test_message);
+        assert!(
+            result.is_ok(),
+            "Verification should succeed with correct data. Error: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_verify_secp256r1_instruction_data_wrong_pubkey() {
+        let test_message = b"test message for secp256r1";
+        let test_pubkey = [0x02; 33];
+        let wrong_pubkey = [0x03; 33]; // Different pubkey
+        let test_signature = [0xCD; 64];
+
+        let instruction_data =
+            create_test_secp256r1_instruction_data(test_message, &test_signature, &test_pubkey);
+
+        // Should fail with wrong pubkey
+        let result =
+            verify_secp256r1_instruction_data(&instruction_data, &wrong_pubkey, test_message);
+        assert!(
+            result.is_err(),
+            "Verification should fail with wrong pubkey"
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            SwigAuthenticateError::PermissionDeniedSecp256r1InvalidPubkey.into()
+        );
+    }
+
+    #[test]
+    fn test_verify_secp256r1_instruction_data_wrong_message_hash() {
+        let test_message = b"test message for secp256r1";
+        let wrong_message = b"different message"; // Different message
+        let test_pubkey = [0x02; 33];
+        let test_signature = [0xCD; 64];
+
+        let instruction_data =
+            create_test_secp256r1_instruction_data(test_message, &test_signature, &test_pubkey);
+
+        // Should fail with wrong message hash
+        let result =
+            verify_secp256r1_instruction_data(&instruction_data, &test_pubkey, wrong_message);
+        assert!(
+            result.is_err(),
+            "Verification should fail with wrong message hash"
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            SwigAuthenticateError::PermissionDeniedSecp256r1InvalidMessageHash.into()
+        );
+    }
+
+    #[test]
+    fn test_verify_secp256r1_instruction_data_insufficient_length() {
+        let short_data = vec![0x01, 0x00]; // Only 2 bytes
+
+        let test_pubkey = [0x02; 33];
+        let test_message_hash = [0xAB; 32];
+
+        let result =
+            verify_secp256r1_instruction_data(&short_data, &test_pubkey, &test_message_hash);
+        assert!(
+            result.is_err(),
+            "Verification should fail with insufficient data"
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into()
+        );
+    }
+
+    #[test]
+    fn test_verify_secp256r1_instruction_data_zero_signatures() {
+        let mut instruction_data = Vec::new();
+        instruction_data.push(0u8); // Zero signatures (1 byte, not 2)
+        instruction_data.push(0u8); // Padding
+
+        let test_pubkey = [0x02; 33];
+        let test_message_hash = [0xAB; 32];
+
+        let result =
+            verify_secp256r1_instruction_data(&instruction_data, &test_pubkey, &test_message_hash);
+        assert!(
+            result.is_err(),
+            "Verification should fail with zero signatures"
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into()
+        );
+    }
+
+    #[test]
+    fn test_verify_secp256r1_instruction_data_cross_instruction_reference() {
+        let mut instruction_data = Vec::new();
+
+        // Number of signature sets (1 byte) and padding (1 byte)
+        instruction_data.push(1u8); // Number of signature sets
+        instruction_data.push(0u8); // Padding
+
+        // Signature offsets with cross-instruction reference
+        instruction_data.extend_from_slice(&16u16.to_le_bytes()); // signature_offset
+        instruction_data.extend_from_slice(&1u16.to_le_bytes()); // signature_instruction_index (different instruction)
+        instruction_data.extend_from_slice(&80u16.to_le_bytes()); // public_key_offset
+        instruction_data.extend_from_slice(&0u16.to_le_bytes()); // public_key_instruction_index
+        instruction_data.extend_from_slice(&113u16.to_le_bytes()); // message_data_offset
+        instruction_data.extend_from_slice(&32u16.to_le_bytes()); // message_data_size
+        instruction_data.extend_from_slice(&0u16.to_le_bytes()); // message_instruction_index
+
+        let test_pubkey = [0x02; 33];
+        let test_message_hash = [0xAB; 32];
+
+        let result =
+            verify_secp256r1_instruction_data(&instruction_data, &test_pubkey, &test_message_hash);
+        assert!(
+            result.is_err(),
+            "Verification should fail with cross-instruction reference"
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            SwigAuthenticateError::PermissionDeniedSecp256r1InvalidInstruction.into()
+        );
+    }
+
+    #[test]
+    fn test_verify_secp256r1_with_real_crypto() {
+        // Create a test message
+        let test_message = b"Hello, secp256r1 world!";
+
+        // Generate real cryptographic signature and pubkey using OpenSSL
+        let (signature_bytes, pubkey_bytes) = create_test_signature_and_pubkey(test_message);
+
+        // Create instruction data using the official Solana function
+        let instruction_data =
+            create_test_secp256r1_instruction_data(test_message, &signature_bytes, &pubkey_bytes);
+
+        // Should succeed with real cryptographic data
+        let result =
+            verify_secp256r1_instruction_data(&instruction_data, &pubkey_bytes, test_message);
+        assert!(
+            result.is_ok(),
+            "Verification should succeed with real cryptographic data"
+        );
+
+        // Should fail with wrong message
+        let wrong_message = b"Different message";
+        let result =
+            verify_secp256r1_instruction_data(&instruction_data, &pubkey_bytes, wrong_message);
+        assert!(
+            result.is_err(),
+            "Verification should fail with wrong message"
+        );
+
+        // Should fail with wrong public key
+        let wrong_pubkey = [0xFF; 33];
+        let result =
+            verify_secp256r1_instruction_data(&instruction_data, &wrong_pubkey, test_message);
+        assert!(
+            result.is_err(),
+            "Verification should fail with wrong public key"
+        );
+    }
+}

--- a/state-x/src/lib.rs
+++ b/state-x/src/lib.rs
@@ -145,6 +145,12 @@ pub enum SwigAuthenticateError {
     InvalidSessionDuration,
     /// Token account authority is not the Swig account
     PermissionDeniedTokenAccountAuthorityNotSwig,
+    /// Invalid Secp256r1 instruction
+    PermissionDeniedSecp256r1InvalidInstruction,
+    /// Invalid Secp256r1 public key
+    PermissionDeniedSecp256r1InvalidPubkey,
+    /// Invalid Secp256r1 message hash
+    PermissionDeniedSecp256r1InvalidMessageHash,
 }
 
 impl From<SwigStateError> for ProgramError {


### PR DESCRIPTION
This adds r1 support (broken currently) and odometer to session secp authorities.

This breaks the CLI and Instructionbuilder/Wallet as they need dynamic counters.

It seems to me that the wallet and instruction builder should be changed so that the AuthorityManager enum is only used to lookup the role for the SwigWallet then from there the full role is is stored on the wallet and it is a dyn impl of the ClientRole trait which has its own implementation of all the instructions, this way we can avoid match statement everywher and we can handle the counter effectivley