### PR TITLE
fix: eliminate num_actions instruction arg

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -153,7 +153,6 @@ impl CreateInstruction {
             swig_bump_seed,
             initial_authority.authority_type,
             initial_authority.authority.len() as u16,
-            actions.len() as u8,
         );
         let mut write = Vec::new();
         write.extend_from_slice(

--- a/program/src/actions/add_authority_v1.rs
+++ b/program/src/actions/add_authority_v1.rs
@@ -167,9 +167,7 @@ pub fn add_authority_v1(
     // closure here to avoid borrowing swig_account_data for the whole function so
     // that we can mutate after realloc
 
-    if add_authority_v1.args.num_actions == 0 {
-        return Err(SwigError::InvalidAuthorityMustHaveAtLeastOneAction.into());
-    }
+    // Note: num_actions validation is now done internally in add_role
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
     let swig_data_len = swig_account_data.len();
     let new_authority_type = AuthorityType::try_from(add_authority_v1.args.new_authority_type)?;
@@ -242,7 +240,6 @@ pub fn add_authority_v1(
     swig_builder.add_role(
         new_authority_type,
         add_authority_v1.authority_data,
-        add_authority_v1.args.num_actions,
         add_authority_v1.actions,
     )?;
     Ok(())

--- a/program/src/actions/create_v1.rs
+++ b/program/src/actions/create_v1.rs
@@ -33,7 +33,6 @@ use crate::{
 /// * `authority_type` - Type of authority to be created
 /// * `authority_data_len` - Length of the authority data
 /// * `bump` - Bump seed for PDA derivation
-/// * `num_actions` - Number of actions associated with the authority
 /// * `id` - Unique identifier for the wallet
 #[repr(C, align(8))]
 #[derive(Debug, NoPadding)]
@@ -42,7 +41,7 @@ pub struct CreateV1Args {
     pub authority_type: u16,
     pub authority_data_len: u16,
     pub bump: u8,
-    pub num_actions: u8,
+    _padding: u8,
     pub id: [u8; 32],
 }
 
@@ -54,13 +53,11 @@ impl CreateV1Args {
     /// * `bump` - Bump seed for PDA derivation
     /// * `authority_type` - Type of authority to create
     /// * `authority_data_len` - Length of the authority data
-    /// * `num_actions` - Number of actions to associate
     pub fn new(
         id: [u8; 32],
         bump: u8,
         authority_type: AuthorityType,
         authority_data_len: u16,
-        num_actions: u8,
     ) -> Self {
         Self {
             discriminator: SwigInstruction::CreateV1,
@@ -68,7 +65,7 @@ impl CreateV1Args {
             bump,
             authority_type: authority_type as u16,
             authority_data_len,
-            num_actions,
+            _padding: 0,
         }
     }
 }
@@ -181,11 +178,6 @@ pub fn create_v1(ctx: Context<CreateV1Accounts>, create: &[u8]) -> ProgramResult
     let swig_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
     let mut swig_builder = SwigBuilder::create(swig_data, swig)?;
 
-    swig_builder.add_role(
-        authority_type,
-        create_v1.authority_data,
-        create_v1.args.num_actions,
-        create_v1.actions,
-    )?;
+    swig_builder.add_role(authority_type, create_v1.authority_data, create_v1.actions)?;
     Ok(())
 }

--- a/state-x/src/lib.rs
+++ b/state-x/src/lib.rs
@@ -97,6 +97,8 @@ pub enum SwigStateError {
     RoleNotFound,
     /// Error loading permissions
     PermissionLoadError,
+    /// Adding an authority requires at least one action
+    InvalidAuthorityMustHaveAtLeastOneAction,
 }
 
 /// Error types related to authentication operations.


### PR DESCRIPTION
This pull request removes the unused num_actions instruction argument. We rely on actions.len() instead.