### PR TITLE
feat: add UpdateAuthority instruction

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -8,10 +8,14 @@ use solana_sdk::{
 use solana_secp256r1_program::new_secp256r1_instruction_with_signature;
 pub use swig;
 use swig::actions::{
-    add_authority_v1::AddAuthorityV1Args, create_session_v1::CreateSessionV1Args,
-    create_sub_account_v1::CreateSubAccountV1Args, create_v1::CreateV1Args,
-    remove_authority_v1::RemoveAuthorityV1Args, sub_account_sign_v1::SubAccountSignV1Args,
-    toggle_sub_account_v1::ToggleSubAccountV1Args, update_authority_v1::UpdateAuthorityV1Args,
+    add_authority_v1::AddAuthorityV1Args,
+    create_session_v1::CreateSessionV1Args,
+    create_sub_account_v1::CreateSubAccountV1Args,
+    create_v1::CreateV1Args,
+    remove_authority_v1::RemoveAuthorityV1Args,
+    sub_account_sign_v1::SubAccountSignV1Args,
+    toggle_sub_account_v1::ToggleSubAccountV1Args,
+    update_authority_v1::{AuthorityUpdateOperation, UpdateAuthorityV1Args},
     withdraw_from_sub_account_v1::WithdrawFromSubAccountV1Args,
 };
 pub use swig_compact_instructions::*;
@@ -714,9 +718,143 @@ impl RemoveAuthorityInstruction {
         Ok(vec![secp256r1_verify_ix, main_ix])
     }
 }
-
 pub struct UpdateAuthorityInstruction;
 impl UpdateAuthorityInstruction {
+    /// Replace all actions for an authority using Ed25519 signature.
+    pub fn replace_all_with_ed25519_authority(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        authority: Pubkey,
+        acting_role_id: u32,
+        authority_to_update_id: u32,
+        actions: Vec<ClientAction>,
+    ) -> anyhow::Result<Instruction> {
+        Self::build_ed25519_instruction(
+            swig_account,
+            payer,
+            authority,
+            acting_role_id,
+            authority_to_update_id,
+            AuthorityUpdateOperation::ReplaceAll,
+            Self::serialize_actions(actions)?,
+        )
+    }
+
+    /// Add new actions to an existing authority using Ed25519 signature.
+    pub fn add_actions_with_ed25519_authority(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        authority: Pubkey,
+        acting_role_id: u32,
+        authority_to_update_id: u32,
+        actions: Vec<ClientAction>,
+    ) -> anyhow::Result<Instruction> {
+        Self::build_ed25519_instruction(
+            swig_account,
+            payer,
+            authority,
+            acting_role_id,
+            authority_to_update_id,
+            AuthorityUpdateOperation::AddActions,
+            Self::serialize_actions(actions)?,
+        )
+    }
+
+    /// Remove actions by their discriminator/type using Ed25519 signature.
+    pub fn remove_actions_by_type_with_ed25519_authority(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        authority: Pubkey,
+        acting_role_id: u32,
+        authority_to_update_id: u32,
+        action_types: Vec<u8>,
+    ) -> anyhow::Result<Instruction> {
+        Self::build_ed25519_instruction(
+            swig_account,
+            payer,
+            authority,
+            acting_role_id,
+            authority_to_update_id,
+            AuthorityUpdateOperation::RemoveActionsByType,
+            action_types,
+        )
+    }
+
+    /// Remove actions by their index positions using Ed25519 signature.
+    pub fn remove_actions_by_index_with_ed25519_authority(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        authority: Pubkey,
+        acting_role_id: u32,
+        authority_to_update_id: u32,
+        indices: Vec<u16>,
+    ) -> anyhow::Result<Instruction> {
+        let mut index_bytes = Vec::new();
+        for index in indices {
+            index_bytes.extend_from_slice(&index.to_le_bytes());
+        }
+        Self::build_ed25519_instruction(
+            swig_account,
+            payer,
+            authority,
+            acting_role_id,
+            authority_to_update_id,
+            AuthorityUpdateOperation::RemoveActionsByIndex,
+            index_bytes,
+        )
+    }
+
+    fn build_ed25519_instruction(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        authority: Pubkey,
+        acting_role_id: u32,
+        authority_to_update_id: u32,
+        operation: AuthorityUpdateOperation,
+        operation_data: Vec<u8>,
+    ) -> anyhow::Result<Instruction> {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(system_program::ID, false),
+            AccountMeta::new_readonly(authority, true),
+        ];
+
+        // Encode operation type in the first byte of the data
+        let mut encoded_data = Vec::new();
+        encoded_data.push(operation as u8);
+        encoded_data.extend_from_slice(&operation_data);
+
+        let args = UpdateAuthorityV1Args::new(
+            acting_role_id,
+            authority_to_update_id,
+            encoded_data.len() as u16,
+            0, // num_actions will be calculated by the program
+        );
+
+        let mut write = Vec::new();
+        write.extend_from_slice(args.into_bytes().unwrap());
+        write.extend_from_slice(&encoded_data);
+        write.extend_from_slice(&[3]); // Ed25519 authority type
+
+        Ok(Instruction {
+            program_id: Pubkey::from(swig::ID),
+            accounts,
+            data: write,
+        })
+    }
+
+    fn serialize_actions(actions: Vec<ClientAction>) -> anyhow::Result<Vec<u8>> {
+        let mut action_bytes = Vec::new();
+        for action in actions {
+            action
+                .write(&mut action_bytes)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize action {:?}", e))?;
+        }
+        Ok(action_bytes)
+    }
+
+    /// Legacy method for backward compatibility (maps to replace_all).
     pub fn new_with_ed25519_authority(
         swig_account: Pubkey,
         payer: Pubkey,
@@ -755,161 +893,6 @@ impl UpdateAuthorityInstruction {
             accounts,
             data: write,
         })
-    }
-
-    pub fn new_with_secp256k1_authority<F>(
-        swig_account: Pubkey,
-        payer: Pubkey,
-        mut authority_payload_fn: F,
-        current_slot: u64,
-        counter: u32,
-        acting_role_id: u32,
-        authority_to_update_id: u32,
-        actions: Vec<ClientAction>,
-    ) -> anyhow::Result<Instruction>
-    where
-        F: FnMut(&[u8]) -> [u8; 65],
-    {
-        let accounts = vec![
-            AccountMeta::new(swig_account, false),
-            AccountMeta::new(payer, true),
-            AccountMeta::new_readonly(system_program::ID, false),
-        ];
-        let mut action_bytes = Vec::new();
-        let num_actions = actions.len() as u8;
-        for action in actions {
-            action
-                .write(&mut action_bytes)
-                .map_err(|e| anyhow::anyhow!("Failed to serialize action {:?}", e))?;
-        }
-        let args = UpdateAuthorityV1Args::new(
-            acting_role_id,
-            authority_to_update_id,
-            action_bytes.len() as u16,
-            num_actions,
-        );
-        let arg_bytes = args
-            .into_bytes()
-            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
-
-        let mut account_payload_bytes = Vec::new();
-        for account in &accounts {
-            account_payload_bytes
-                .extend_from_slice(accounts_payload_from_meta(account).into_bytes().unwrap());
-        }
-
-        let mut signature_bytes = Vec::new();
-        signature_bytes.extend_from_slice(arg_bytes);
-        signature_bytes.extend_from_slice(&action_bytes);
-        let nonced_payload = prepare_secp256k1_payload(
-            current_slot,
-            counter,
-            &signature_bytes,
-            &account_payload_bytes,
-            &[],
-        );
-        let signature = authority_payload_fn(&nonced_payload);
-        let mut authority_payload = Vec::new();
-        authority_payload.extend_from_slice(&current_slot.to_le_bytes());
-        authority_payload.extend_from_slice(&counter.to_le_bytes());
-        authority_payload.extend_from_slice(&signature);
-
-        Ok(Instruction {
-            program_id: Pubkey::from(swig::ID),
-            accounts,
-            data: [arg_bytes, &action_bytes, &authority_payload].concat(),
-        })
-    }
-
-    pub fn new_with_secp256r1_authority<F>(
-        swig_account: Pubkey,
-        payer: Pubkey,
-        mut authority_payload_fn: F,
-        current_slot: u64,
-        counter: u32,
-        acting_role_id: u32,
-        authority_to_update_id: u32,
-        actions: Vec<ClientAction>,
-        public_key: &[u8; 33],
-    ) -> anyhow::Result<Vec<Instruction>>
-    where
-        F: FnMut(&[u8]) -> [u8; 64],
-    {
-        let accounts = vec![
-            AccountMeta::new(swig_account, false),
-            AccountMeta::new(payer, true),
-            AccountMeta::new_readonly(system_program::ID, false),
-            AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
-        ];
-
-        let mut action_bytes = Vec::new();
-        let num_actions = actions.len() as u8;
-        for action in actions {
-            action
-                .write(&mut action_bytes)
-                .map_err(|e| anyhow::anyhow!("Failed to serialize action {:?}", e))?;
-        }
-
-        let args = UpdateAuthorityV1Args::new(
-            acting_role_id,
-            authority_to_update_id,
-            action_bytes.len() as u16,
-            num_actions,
-        );
-        let args_bytes = args
-            .into_bytes()
-            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
-
-        // Create the message hash for secp256r1 authentication
-        let mut account_payload_bytes = Vec::new();
-        for account in &accounts {
-            account_payload_bytes.extend_from_slice(
-                accounts_payload_from_meta(account)
-                    .into_bytes()
-                    .map_err(|e| anyhow::anyhow!("Failed to serialize account meta {:?}", e))?,
-            );
-        }
-
-        let mut data_to_besigned_bytes = Vec::new();
-        data_to_besigned_bytes.extend_from_slice(args_bytes);
-        data_to_besigned_bytes.extend_from_slice(&action_bytes);
-
-        // Compute message hash (keccak for secp256r1 compatibility)
-        let slot_bytes = current_slot.to_le_bytes();
-        let counter_bytes = counter.to_le_bytes();
-        let message_hash = keccak::hash(
-            &[
-                &data_to_besigned_bytes,
-                &account_payload_bytes,
-                &slot_bytes[..],
-                &counter_bytes[..],
-            ]
-            .concat(),
-        )
-        .to_bytes();
-
-        // Get signature from authority function
-        let signature = authority_payload_fn(&message_hash);
-        // Create secp256r1 verify instruction
-        let secp256r1_verify_ix =
-            new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
-        // For secp256r1, the authority payload includes slot, counter, instruction
-        // index, and padding Must be at least 17 bytes to satisfy
-        // secp256r1_authority_authenticate() requirements
-        let instruction_sysvar_index = 3; // Instructions sysvar is at index 3
-        let mut authority_payload = Vec::new();
-        authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8 bytes
-        authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4 bytes
-        authority_payload.push(instruction_sysvar_index as u8); // 1 byte: index of instruction sysvar
-        authority_payload.extend_from_slice(&[0u8; 4]); // 4 bytes padding to meet 17 byte minimum
-
-        let main_ix = Instruction {
-            program_id: Pubkey::from(swig::ID),
-            accounts,
-            data: [args_bytes, &action_bytes, &authority_payload].concat(),
-        };
-
-        Ok(vec![secp256r1_verify_ix, main_ix])
     }
 }
 

--- a/program/src/actions/mod.rs
+++ b/program/src/actions/mod.rs
@@ -13,6 +13,7 @@ pub mod remove_authority_v1;
 pub mod sign_v1;
 pub mod sub_account_sign_v1;
 pub mod toggle_sub_account_v1;
+pub mod update_authority_v1;
 pub mod withdraw_from_sub_account_v1;
 
 use num_enum::FromPrimitive;
@@ -21,14 +22,15 @@ use pinocchio::{account_info::AccountInfo, msg, program_error::ProgramError, Pro
 use self::{
     add_authority_v1::*, create_session_v1::*, create_sub_account_v1::*, create_v1::*,
     remove_authority_v1::*, sign_v1::*, sub_account_sign_v1::*, toggle_sub_account_v1::*,
-    withdraw_from_sub_account_v1::*,
+    update_authority_v1::*, withdraw_from_sub_account_v1::*,
 };
 use crate::{
     instruction::{
         accounts::{
             AddAuthorityV1Accounts, CreateSessionV1Accounts, CreateSubAccountV1Accounts,
             CreateV1Accounts, RemoveAuthorityV1Accounts, SignV1Accounts, SubAccountSignV1Accounts,
-            ToggleSubAccountV1Accounts, WithdrawFromSubAccountV1Accounts,
+            ToggleSubAccountV1Accounts, UpdateAuthorityV1Accounts,
+            WithdrawFromSubAccountV1Accounts,
         },
         SwigInstruction,
     },
@@ -64,6 +66,7 @@ pub fn process_action(
         SwigInstruction::SignV1 => process_sign_v1(accounts, account_classification, data),
         SwigInstruction::AddAuthorityV1 => process_add_authority_v1(accounts, data),
         SwigInstruction::RemoveAuthorityV1 => process_remove_authority_v1(accounts, data),
+        SwigInstruction::UpdateAuthorityV1 => process_update_authority_v1(accounts, data),
         SwigInstruction::CreateSessionV1 => process_create_session_v1(accounts, data),
         SwigInstruction::CreateSubAccountV1 => process_create_sub_account_v1(accounts, data),
         SwigInstruction::WithdrawFromSubAccountV1 => {
@@ -110,6 +113,14 @@ fn process_add_authority_v1(accounts: &[AccountInfo], data: &[u8]) -> ProgramRes
 fn process_remove_authority_v1(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let account_ctx = RemoveAuthorityV1Accounts::context(accounts)?;
     remove_authority_v1(account_ctx, data, accounts)
+}
+
+/// Processes an UpdateAuthorityV1 instruction.
+///
+/// Updates an existing authority in the wallet with new permissions.
+fn process_update_authority_v1(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
+    let account_ctx = UpdateAuthorityV1Accounts::context(accounts)?;
+    update_authority_v1(account_ctx, data, accounts)
 }
 
 /// Processes a CreateSessionV1 instruction.

--- a/program/src/actions/update_authority_v1.rs
+++ b/program/src/actions/update_authority_v1.rs
@@ -1,0 +1,382 @@
+/// Module for updating existing authorities in a Swig wallet.
+/// This module implements functionality to update authority roles by adding
+/// or removing specific permissions while maintaining proper authentication.
+use no_padding::NoPadding;
+use pinocchio::{
+    account_info::AccountInfo,
+    msg,
+    program_error::ProgramError,
+    sysvars::{clock::Clock, rent::Rent, Sysvar},
+    ProgramResult,
+};
+use pinocchio_system::instructions::Transfer;
+use swig_assertions::{check_bytes_match, check_self_owned};
+use swig_state::{
+    action::{all::All, manage_authority::ManageAuthority, Action},
+    authority::{authority_type_to_length, AuthorityType},
+    role::Position,
+    swig::{Swig, SwigBuilder},
+    Discriminator, IntoBytes, SwigAuthenticateError, SwigStateError, Transmutable, TransmutableMut,
+};
+
+use crate::{
+    error::SwigError,
+    instruction::{
+        accounts::{Context, UpdateAuthorityV1Accounts},
+        SwigInstruction,
+    },
+};
+
+/// Calculates the actual number of actions in the provided actions data.
+///
+/// This function iterates through the actions data and counts the number of
+/// valid actions by parsing action headers and their boundaries.
+///
+/// # Arguments
+/// * `actions_data` - Raw bytes containing action data
+///
+/// # Returns
+/// * `Result<u8, ProgramError>` - The number of actions found, or error if
+///   invalid data
+fn calculate_num_actions(actions_data: &[u8]) -> Result<u8, ProgramError> {
+    let mut cursor = 0;
+    let mut count = 0u8;
+
+    while cursor < actions_data.len() {
+        if cursor + Action::LEN > actions_data.len() {
+            break;
+        }
+
+        let action_header =
+            unsafe { Action::load_unchecked(&actions_data[cursor..cursor + Action::LEN])? };
+        cursor += Action::LEN;
+
+        let action_len = action_header.length() as usize;
+        if cursor + action_len > actions_data.len() {
+            return Err(SwigStateError::InvalidAuthorityMustHaveAtLeastOneAction.into());
+        }
+
+        cursor += action_len;
+        count += 1;
+
+        // Prevent overflow
+        if count == u8::MAX {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+    }
+
+    if count == 0 {
+        return Err(SwigStateError::InvalidAuthorityMustHaveAtLeastOneAction.into());
+    }
+
+    Ok(count)
+}
+
+/// Struct representing the complete update authority instruction data.
+///
+/// # Fields
+/// * `args` - The update authority arguments
+/// * `data_payload` - Raw data payload
+/// * `authority_payload` - Authority-specific payload data
+/// * `actions` - Actions data for the authority update
+pub struct UpdateAuthorityV1<'a> {
+    pub args: &'a UpdateAuthorityV1Args,
+    data_payload: &'a [u8],
+    authority_payload: &'a [u8],
+    actions: &'a [u8],
+}
+
+/// Arguments for updating an existing authority in a Swig wallet.
+///
+/// # Fields
+/// * `instruction` - The instruction type identifier
+/// * `actions_data_len` - Length of the actions data
+/// * `num_actions` - Number of actions for the authority update
+/// * `_padding` - Padding bytes for alignment
+/// * `acting_role_id` - ID of the role performing the update
+/// * `authority_to_update_id` - ID of the authority to update
+#[repr(C, align(8))]
+#[derive(Debug, NoPadding)]
+pub struct UpdateAuthorityV1Args {
+    pub instruction: SwigInstruction,
+    pub actions_data_len: u16,
+    pub num_actions: u8,
+    _padding: [u8; 3],
+    pub acting_role_id: u32,
+    pub authority_to_update_id: u32,
+}
+
+impl Transmutable for UpdateAuthorityV1Args {
+    const LEN: usize = core::mem::size_of::<Self>();
+}
+
+impl UpdateAuthorityV1Args {
+    /// Creates a new instance of UpdateAuthorityV1Args.
+    ///
+    /// # Arguments
+    /// * `acting_role_id` - ID of the role performing the update
+    /// * `authority_to_update_id` - ID of the authority to update
+    /// * `actions_data_len` - Length of the actions data
+    /// * `num_actions` - Number of actions for the authority update
+    pub fn new(
+        acting_role_id: u32,
+        authority_to_update_id: u32,
+        actions_data_len: u16,
+        num_actions: u8,
+    ) -> Self {
+        Self {
+            instruction: SwigInstruction::UpdateAuthorityV1,
+            acting_role_id,
+            authority_to_update_id,
+            actions_data_len,
+            num_actions,
+            _padding: [0; 3],
+        }
+    }
+}
+
+impl IntoBytes for UpdateAuthorityV1Args {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+impl<'a> UpdateAuthorityV1<'a> {
+    /// Parses the instruction data bytes into an UpdateAuthorityV1 instance.
+    ///
+    /// # Arguments
+    /// * `data` - Raw instruction data bytes
+    ///
+    /// # Returns
+    /// * `Result<Self, ProgramError>` - Parsed instruction or error
+    pub fn from_instruction_bytes(data: &'a [u8]) -> Result<Self, ProgramError> {
+        if data.len() < UpdateAuthorityV1Args::LEN {
+            return Err(SwigError::InvalidSwigUpdateAuthorityInstructionDataTooShort.into());
+        }
+
+        let (inst, rest) = data.split_at(UpdateAuthorityV1Args::LEN);
+        let args = unsafe { UpdateAuthorityV1Args::load_unchecked(inst)? };
+        let (actions_payload, authority_payload) = rest.split_at(args.actions_data_len as usize);
+
+        Ok(Self {
+            args,
+            actions: actions_payload,
+            authority_payload,
+            data_payload: &data[..UpdateAuthorityV1Args::LEN + args.actions_data_len as usize],
+        })
+    }
+}
+
+/// Updates an existing authority in a Swig wallet.
+///
+/// This function handles the complete flow of updating an authority:
+/// 1. Validates the acting role's permissions
+/// 2. Authenticates the request
+/// 3. Verifies the authority exists and can be updated
+/// 4. Updates the authority's actions/permissions
+/// 5. Handles account reallocation if needed
+///
+/// # Arguments
+/// * `ctx` - The account context for updating authority
+/// * `update` - Raw update authority instruction data
+/// * `all_accounts` - All accounts involved in the operation
+///
+/// # Returns
+/// * `ProgramResult` - Success or error status
+pub fn update_authority_v1(
+    ctx: Context<UpdateAuthorityV1Accounts>,
+    update: &[u8],
+    all_accounts: &[AccountInfo],
+) -> ProgramResult {
+    check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
+    check_bytes_match(
+        ctx.accounts.system_program.key(),
+        &pinocchio_system::ID,
+        32,
+        SwigError::InvalidSystemProgram,
+    )?;
+
+    let update_authority_v1 = UpdateAuthorityV1::from_instruction_bytes(update).map_err(|e| {
+        msg!("UpdateAuthorityV1 Args Error: {:?}", e);
+        ProgramError::InvalidInstructionData
+    })?;
+
+    // Cannot update root authority (ID 0)
+    if update_authority_v1.args.authority_to_update_id == 0 {
+        return Err(SwigAuthenticateError::PermissionDeniedCannotUpdateRootAuthority.into());
+    }
+
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    let swig_data_len = swig_account_data.len();
+
+    if swig_account_data[0] != Discriminator::SwigAccount as u8 {
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+
+    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+    let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+
+    // Get and validate acting role
+    let acting_role = Swig::get_mut_role(update_authority_v1.args.acting_role_id, swig_roles)?;
+    if acting_role.is_none() {
+        return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+    }
+    let acting_role = acting_role.unwrap();
+
+    // Authenticate the caller
+    let clock = Clock::get()?;
+    let slot = clock.slot;
+
+    if acting_role.authority.session_based() {
+        acting_role.authority.authenticate_session(
+            all_accounts,
+            update_authority_v1.authority_payload,
+            update_authority_v1.data_payload,
+            slot,
+        )?;
+    } else {
+        acting_role.authority.authenticate(
+            all_accounts,
+            update_authority_v1.authority_payload,
+            update_authority_v1.data_payload,
+            slot,
+        )?;
+    }
+
+    // Check permissions - same as add/remove authority
+    let all = acting_role.get_action::<All>(&[])?;
+    let manage_authority = acting_role.get_action::<ManageAuthority>(&[])?;
+
+    if all.is_none() && manage_authority.is_none() {
+        return Err(SwigAuthenticateError::PermissionDeniedToManageAuthority.into());
+    }
+
+    // Verify the authority to update exists and calculate size difference
+    let (current_actions_size, authority_offset, actions_offset) = {
+        let mut cursor = 0;
+        let mut found = false;
+        let mut auth_offset = 0;
+        let mut act_offset = 0;
+        let mut current_size = 0;
+
+        for _i in 0..swig.roles {
+            let position =
+                unsafe { Position::load_unchecked(&swig_roles[cursor..cursor + Position::LEN])? };
+
+            if position.id() == update_authority_v1.args.authority_to_update_id {
+                found = true;
+                auth_offset = cursor;
+                act_offset = cursor + Position::LEN + position.authority_length() as usize;
+                current_size = position.boundary() as usize - act_offset;
+                break;
+            }
+            cursor = position.boundary() as usize;
+        }
+
+        if !found {
+            return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+        }
+
+        (current_size, auth_offset, act_offset)
+    };
+
+    let new_actions_size = update_authority_v1.actions.len();
+    let size_diff = new_actions_size as i64 - current_actions_size as i64;
+
+    let new_reserved_lamports = if size_diff != 0 {
+        let new_size = (swig_data_len as i64 + size_diff) as usize;
+        let aligned_size =
+            core::alloc::Layout::from_size_align(new_size, core::mem::size_of::<u64>())
+                .map_err(|_| SwigError::InvalidAlignment)?
+                .pad_to_align()
+                .size();
+
+        ctx.accounts.swig.realloc(aligned_size, false)?;
+
+        let cost = Rent::get()?
+            .minimum_balance(aligned_size)
+            .checked_sub(swig.reserved_lamports)
+            .unwrap_or_default();
+
+        if cost > 0 {
+            Transfer {
+                from: ctx.accounts.payer,
+                to: ctx.accounts.swig,
+                lamports: cost,
+            }
+            .invoke()?;
+        }
+
+        swig.reserved_lamports + cost
+    } else {
+        swig.reserved_lamports
+    };
+
+    // Update the authority with new actions in place
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+    let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+    swig.reserved_lamports = new_reserved_lamports;
+
+    // Update the role's actions in place
+    if size_diff != 0 {
+        // Need to shift data if size changed
+        let role_end = actions_offset + current_actions_size;
+        // Calculate remaining data based on original data size, not new buffer size
+        let original_data_len = (swig_data_len as i64 - Swig::LEN as i64) as usize;
+        let remaining_data_len = original_data_len - role_end;
+
+        if size_diff > 0 {
+            // Growing: shift data to the right
+            if remaining_data_len > 0 {
+                let new_role_end = (role_end as i64 + size_diff) as usize;
+                // Ensure we don't exceed buffer bounds
+                if new_role_end + remaining_data_len <= swig_roles.len() {
+                    swig_roles.copy_within(role_end..role_end + remaining_data_len, new_role_end);
+                } else {
+                    return Err(SwigError::StateError.into());
+                }
+            }
+        } else {
+            // Shrinking: shift data to the left
+            if remaining_data_len > 0 {
+                let new_role_end = (role_end as i64 + size_diff) as usize;
+                swig_roles.copy_within(role_end..role_end + remaining_data_len, new_role_end);
+            }
+        }
+
+        // Update boundaries of all roles after this one
+        let mut cursor = 0;
+        for _i in 0..swig.roles {
+            let position = unsafe {
+                Position::load_mut_unchecked(&mut swig_roles[cursor..cursor + Position::LEN])?
+            };
+
+            if position.boundary() as usize > role_end {
+                position.boundary = (position.boundary() as i64 + size_diff) as u32;
+            }
+
+            // Update the position for the role we're updating
+            if position.id() == update_authority_v1.args.authority_to_update_id {
+                position.boundary = (position.boundary() as i64 + size_diff) as u32;
+                position.num_actions = calculate_num_actions(update_authority_v1.actions)? as u16;
+            }
+
+            cursor = position.boundary() as usize;
+        }
+    } else {
+        // Same size: just update the position's num_actions
+        let position = unsafe {
+            Position::load_mut_unchecked(
+                &mut swig_roles[authority_offset..authority_offset + Position::LEN],
+            )?
+        };
+        position.num_actions = calculate_num_actions(update_authority_v1.actions)? as u16;
+    }
+
+    // Copy the new actions data
+    swig_roles[actions_offset..actions_offset + new_actions_size]
+        .copy_from_slice(update_authority_v1.actions);
+
+    Ok(())
+}

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -56,6 +56,8 @@ pub enum SwigError {
     InvalidSwigRemoveAuthorityInstructionDataTooShort,
     /// Add authority instruction data is too short
     InvalidSwigAddAuthorityInstructionDataTooShort,
+    /// Update authority instruction data is too short
+    InvalidSwigUpdateAuthorityInstructionDataTooShort,
     /// Create instruction data is too short
     InvalidSwigCreateInstructionDataTooShort,
     /// Create session instruction data is too short
@@ -108,6 +110,8 @@ pub enum SwigError {
     /// Account data was modified in unexpected ways during instruction
     /// execution
     AccountDataModifiedUnexpectedly,
+    /// Cannot update root authority (ID 0)
+    PermissionDeniedCannotUpdateRootAuthority,
 }
 
 /// Implements conversion from SwigError to ProgramError.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -54,6 +54,17 @@ pub enum SwigInstruction {
     #[account(2, name="system_program", desc="the system program")]
     RemoveAuthorityV1 = 2,
 
+    /// Updates an existing authority in the wallet.
+    ///
+    /// Required accounts:
+    /// 1. `[writable, signer]` Swig wallet account
+    /// 2. `[writable, signer]` Payer account
+    /// 3. System program account
+    #[account(0, writable, signer, name="swig", desc="the swig smart wallet")]
+    #[account(1, writable, signer, name="payer", desc="the payer")]
+    #[account(2, name="system_program", desc="the system program")]
+    UpdateAuthorityV1 = 3,
+
     /// Signs and executes a transaction.
     ///
     /// The instruction data includes:

--- a/program/tests/update_authority_test.rs
+++ b/program/tests/update_authority_test.rs
@@ -1,0 +1,416 @@
+#![cfg(not(feature = "program_scope_test"))]
+// This feature flag ensures these tests are only run when the
+// "program_scope_test" feature is not enabled. This allows us to isolate
+// and run only program_scope tests or only the regular tests.
+
+mod common;
+
+use common::*;
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer};
+use swig_interface::{AuthorityConfig, ClientAction, UpdateAuthorityInstruction};
+use swig_state::{
+    action::{all::All, manage_authority::ManageAuthority, sol_limit::SolLimit},
+    authority::AuthorityType,
+    swig::SwigWithRoles,
+};
+
+/// Helper function to update authority with Ed25519 root authority
+pub fn update_authority_with_ed25519_root(
+    context: &mut SwigTestContext,
+    swig_pubkey: &Pubkey,
+    existing_ed25519_authority: &Keypair,
+    authority_to_update_id: u32,
+    new_actions: Vec<ClientAction>,
+) -> anyhow::Result<litesvm::types::TransactionMetadata> {
+    context.svm.expire_blockhash();
+    let payer_pubkey = context.default_payer.pubkey();
+    let swig_account = context
+        .svm
+        .get_account(swig_pubkey)
+        .ok_or(anyhow::anyhow!("Swig account not found"))?;
+    let swig = SwigWithRoles::from_bytes(&swig_account.data)
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize swig {:?}", e))?;
+    let role_id = swig
+        .lookup_role_id(existing_ed25519_authority.pubkey().as_ref())
+        .map_err(|e| anyhow::anyhow!("Failed to lookup role id {:?}", e))?
+        .unwrap();
+
+    let update_authority_ix = UpdateAuthorityInstruction::new_with_ed25519_authority(
+        *swig_pubkey,
+        context.default_payer.pubkey(),
+        existing_ed25519_authority.pubkey(),
+        role_id,
+        authority_to_update_id,
+        new_actions,
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to create update authority instruction {:?}", e))?;
+
+    let msg = solana_sdk::message::v0::Message::try_compile(
+        &payer_pubkey,
+        &[
+            solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(10000000),
+            update_authority_ix,
+        ],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = solana_sdk::transaction::VersionedTransaction::try_new(
+        solana_sdk::message::VersionedMessage::V0(msg),
+        &[
+            context.default_payer.insecure_clone(),
+            existing_ed25519_authority.insecure_clone(),
+        ],
+    )
+    .unwrap();
+
+    let bench = context
+        .svm
+        .send_transaction(tx)
+        .map_err(|e| anyhow::anyhow!("Failed to send transaction {:?}", e))?;
+    Ok(bench)
+}
+
+#[test_log::test]
+fn test_update_authority_basic() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a swig wallet with the root authority
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    // Add a second authority with ManageAuthority permission
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    // Verify the second authority was added
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig.state.roles, 2);
+
+    let role_1 = swig.get_role(1).unwrap().unwrap();
+    assert_eq!(role_1.position.num_actions(), 1);
+
+    // Update the second authority to have different permissions
+    update_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        1, // Update authority with ID 1
+        vec![
+            ClientAction::SolLimit(SolLimit { amount: 1000000 }),
+            ClientAction::ManageAuthority(ManageAuthority {}),
+        ],
+    )
+    .unwrap();
+
+    // Verify the authority was updated
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig.state.roles, 2); // Still 2 roles
+    assert_eq!(swig.state.role_counter, 2); // Role counter should not change
+
+    let updated_role = swig.get_role(1).unwrap().unwrap();
+    assert_eq!(updated_role.position.num_actions(), 2); // Now has 2 actions
+
+    // Verify the authority type and data remain the same
+    assert_eq!(
+        updated_role.authority.authority_type(),
+        AuthorityType::Ed25519
+    );
+    assert_eq!(
+        updated_role.authority.identity().unwrap(),
+        second_authority.pubkey().as_ref()
+    );
+}
+
+#[test_log::test]
+fn test_update_authority_cannot_update_root() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a swig wallet with the root authority
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    // Try to update the root authority (ID 0) - should fail
+    let result = update_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        0, // Try to update root authority
+        vec![ClientAction::SolLimit(SolLimit { amount: 1000000 })],
+    );
+
+    // Verify the operation failed
+    assert!(result.is_err(), "Updating root authority should fail");
+}
+
+#[test_log::test]
+fn test_update_authority_nonexistent_authority() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a swig wallet with the root authority
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    // Try to update a non-existent authority (ID 999) - should fail
+    let result = update_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        999, // Non-existent authority ID
+        vec![ClientAction::SolLimit(SolLimit { amount: 1000000 })],
+    );
+
+    // Verify the operation failed
+    assert!(
+        result.is_err(),
+        "Updating non-existent authority should fail"
+    );
+}
+
+#[test_log::test]
+fn test_update_authority_permission_check() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a swig wallet with the root authority
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    // Add a second authority without ManageAuthority permission
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 500000 })], /* Only SolLimit, no
+                                                                    * ManageAuthority */
+    )
+    .unwrap();
+
+    // Add a third authority
+    let third_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&third_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: third_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    // Try to update the third authority using the second authority (which lacks
+    // ManageAuthority permission)
+    let result = update_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &second_authority, // Using second authority without ManageAuthority permission
+        2,                 // Update third authority
+        vec![ClientAction::SolLimit(SolLimit { amount: 1000000 })],
+    );
+
+    // Verify the operation failed due to lack of permission
+    assert!(
+        result.is_err(),
+        "Updating authority without ManageAuthority permission should fail"
+    );
+}
+
+#[test_log::test]
+fn test_update_authority_with_zero_actions() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a swig wallet with the root authority
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    // Add a second authority
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    // Try to update the second authority with zero actions - should fail
+    let result = update_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        1,      // Update second authority
+        vec![], // Empty actions vector
+    );
+
+    // Verify the operation failed
+    assert!(
+        result.is_err(),
+        "Updating authority with zero actions should fail"
+    );
+}
+
+#[test_log::test]
+fn test_update_authority_size_change() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+
+    // Create a swig wallet with the root authority
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    // Add a second authority with one action
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    // Add a third authority
+    let third_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&third_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: third_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 500000 })],
+    )
+    .unwrap();
+
+    // Update the second authority to have more actions (size increase)
+    update_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        1, // Update second authority
+        vec![
+            ClientAction::ManageAuthority(ManageAuthority {}),
+            ClientAction::SolLimit(SolLimit { amount: 1000000 }),
+            ClientAction::All(All {}),
+        ],
+    )
+    .unwrap();
+
+    // Verify all authorities are still accessible and correct
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig.state.roles, 3);
+
+    // Check that all roles are still accessible
+    let role_0 = swig.get_role(0).unwrap().unwrap();
+    let role_1 = swig.get_role(1).unwrap().unwrap();
+    let role_2 = swig.get_role(2).unwrap().unwrap();
+
+    // Verify the updated role has the correct number of actions
+    assert_eq!(role_1.position.num_actions(), 3);
+
+    // Verify the third authority wasn't affected
+    assert_eq!(role_2.position.num_actions(), 1);
+    assert_eq!(
+        role_2.authority.identity().unwrap(),
+        third_authority.pubkey().as_ref()
+    );
+}

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -129,6 +129,8 @@ pub enum SwigAuthenticateError {
     PermissionDeniedInsufficientBalance,
     /// Cannot remove root authority
     PermissionDeniedCannotRemoveRootAuthority,
+    /// Cannot update root authority
+    PermissionDeniedCannotUpdateRootAuthority,
     /// Session has expired
     PermissionDeniedSessionExpired,
     /// Invalid Secp256k1 signature


### PR DESCRIPTION
This PR implements a new `UpdateAuthority` instruction that allows updating existing authority actions/permissions in Swig wallets. This provides a more efficient alternative to removing and re-adding authorities when only action/permission changes are needed.

This new instruction allows you to:
1. Replace all actions
2. Add actions
3. Remove actions by type
4. Remove actions by index

The root authority is protected from this new instruction.