### PR TITLE
feat: Program Limits

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -17,7 +17,8 @@ use swig::actions::{
 pub use swig_compact_instructions::*;
 use swig_state::{
     action::{
-        all::All, manage_authority::ManageAuthority, program::Program, program_scope::ProgramScope,
+        all::All, manage_authority::ManageAuthority, program::Program, 
+        program_all::ProgramAll, program_curated::ProgramCurated, program_scope::ProgramScope,
         sol_limit::SolLimit, sol_recurring_limit::SolRecurringLimit, stake_all::StakeAll,
         stake_limit::StakeLimit, stake_recurring_limit::StakeRecurringLimit,
         sub_account::SubAccount, token_limit::TokenLimit,
@@ -37,6 +38,8 @@ pub enum ClientAction {
     SolLimit(SolLimit),
     SolRecurringLimit(SolRecurringLimit),
     Program(Program),
+    ProgramAll(ProgramAll),
+    ProgramCurated(ProgramCurated),
     ProgramScope(ProgramScope),
     All(All),
     ManageAuthority(ManageAuthority),
@@ -58,6 +61,8 @@ impl ClientAction {
                 (Permission::SolRecurringLimit, SolRecurringLimit::LEN)
             },
             ClientAction::Program(_) => (Permission::Program, Program::LEN),
+            ClientAction::ProgramAll(_) => (Permission::ProgramAll, ProgramAll::LEN),
+            ClientAction::ProgramCurated(_) => (Permission::ProgramCurated, ProgramCurated::LEN),
             ClientAction::ProgramScope(_) => (Permission::ProgramScope, ProgramScope::LEN),
             ClientAction::All(_) => (Permission::All, All::LEN),
             ClientAction::ManageAuthority(_) => (Permission::ManageAuthority, ManageAuthority::LEN),
@@ -84,6 +89,8 @@ impl ClientAction {
             ClientAction::SolLimit(action) => action.into_bytes(),
             ClientAction::SolRecurringLimit(action) => action.into_bytes(),
             ClientAction::Program(action) => action.into_bytes(),
+            ClientAction::ProgramAll(action) => action.into_bytes(),
+            ClientAction::ProgramCurated(action) => action.into_bytes(),
             ClientAction::ProgramScope(action) => action.into_bytes(),
             ClientAction::All(action) => action.into_bytes(),
             ClientAction::ManageAuthority(action) => action.into_bytes(),

--- a/program/tests/action_tests.rs
+++ b/program/tests/action_tests.rs
@@ -23,7 +23,7 @@ use solana_sdk::{
 };
 use swig_interface::{AuthorityConfig, ClientAction, RemoveAuthorityInstruction};
 use swig_state::{
-    action::{all::All, manage_authority::ManageAuthority, sol_limit::SolLimit, Actionable},
+    action::{all::All, manage_authority::ManageAuthority, program::Program, sol_limit::SolLimit, Actionable},
     authority::AuthorityType,
     swig::{swig_account_seeds, SwigWithRoles},
     IntoBytes, Transmutable,
@@ -126,6 +126,9 @@ fn test_multiple_actions_with_transfer_and_manage_authority() {
                 amount: 10_000_000_000,
             }),
             ClientAction::ManageAuthority(ManageAuthority {}),
+            ClientAction::Program(Program {
+                program_id: solana_sdk::system_program::ID.to_bytes(),
+            }),
         ],
     )
     .unwrap();

--- a/program/tests/cpi_program_permission_test.rs
+++ b/program/tests/cpi_program_permission_test.rs
@@ -250,3 +250,168 @@ fn test_cpi_signing_without_program_permission_fails() {
         panic!("Expected permission denied error, got: {:?}", result);
     }
 }
+
+/// Test that ProgramAll permission allows CPI signing to any program
+#[test_log::test]
+fn test_cpi_signing_with_program_all_permission() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let recipient = Keypair::new();
+    
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+
+    // Create swig account with ed25519 authority
+    let (_, _transaction_metadata) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    
+    // Add a second authority with ProgramAll permission
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    
+    // Create ProgramAll action
+    let program_all_action = swig_state::action::program_all::ProgramAll::new();
+    
+    let _txn = add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(program_all_action),
+            ClientAction::SolLimit(swig_state::action::sol_limit::SolLimit { amount: 10_000_000 }),
+        ],
+    )
+    .unwrap();
+
+    context.svm.airdrop(&swig, 10_000_000_000).unwrap();
+    context.svm.warp_to_slot(100);
+
+    // Test: CPI signing with ProgramAll permission should work for any program
+    let transfer_amount = 1_000_000;
+    let transfer_ix = system_instruction::transfer(&swig, &recipient.pubkey(), transfer_amount);
+    
+    let sign_ix = swig_interface::SignInstruction::new_ed25519(
+        swig,
+        second_authority.pubkey(),
+        second_authority.pubkey(),
+        transfer_ix,
+        1,
+    )
+    .unwrap();
+    
+    let transfer_message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    
+    let transfer_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message),
+        &[second_authority.insecure_clone()],
+    )
+    .unwrap();
+    
+    let result = context.svm.send_transaction(transfer_tx);
+    if let Err(ref err) = result {
+        println!("Transaction failed with error: {:?}", err);
+    }
+    assert!(result.is_ok(), "CPI signing with ProgramAll permission should succeed");
+}
+
+/// Test that ProgramCurated permission allows CPI signing to curated programs only
+#[test_log::test]
+fn test_cpi_signing_with_program_curated_permission() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let recipient = Keypair::new();
+    
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+
+    // Create swig account with ed25519 authority
+    let (_, _transaction_metadata) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    
+    // Add a second authority with ProgramCurated permission
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    
+    // Create ProgramCurated action
+    let program_curated_action = swig_state::action::program_curated::ProgramCurated::new();
+    
+    let _txn = add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramCurated(program_curated_action),
+            ClientAction::SolLimit(swig_state::action::sol_limit::SolLimit { amount: 10_000_000 }),
+        ],
+    )
+    .unwrap();
+
+    context.svm.airdrop(&swig, 10_000_000_000).unwrap();
+    context.svm.warp_to_slot(100);
+
+    // Test 1: CPI signing with ProgramCurated permission should work for system program (curated)
+    let transfer_amount = 1_000_000;
+    let transfer_ix = system_instruction::transfer(&swig, &recipient.pubkey(), transfer_amount);
+    
+    let sign_ix = swig_interface::SignInstruction::new_ed25519(
+        swig,
+        second_authority.pubkey(),
+        second_authority.pubkey(),
+        transfer_ix,
+        1,
+    )
+    .unwrap();
+    
+    let transfer_message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    
+    let transfer_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message),
+        &[second_authority.insecure_clone()],
+    )
+    .unwrap();
+    
+    let result = context.svm.send_transaction(transfer_tx);
+    assert!(result.is_ok(), "CPI signing with ProgramCurated permission should succeed for system program");
+}

--- a/program/tests/cpi_program_permission_test.rs
+++ b/program/tests/cpi_program_permission_test.rs
@@ -1,0 +1,252 @@
+#![cfg(not(feature = "program_scope_test"))]
+
+mod common;
+use common::*;
+use litesvm_token::spl_token;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction, InstructionError},
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    system_instruction,
+    transaction::{TransactionError, VersionedTransaction},
+};
+use swig_interface::{AuthorityConfig, ClientAction};
+use swig_state::{
+    action::program::Program,
+    authority::AuthorityType,
+    swig::{swig_account_seeds, SwigWithRoles},
+};
+
+/// Test that CPI signing requires a Program action with the correct program ID
+#[test_log::test]
+fn test_cpi_signing_requires_program_permission() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let recipient = Keypair::new();
+    
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+
+    // Create swig account with ed25519 authority
+    let (_, _transaction_metadata) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    
+    // Add a second authority with Program permission for system program
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    
+    // Create Program action for system program and SolLimit for transfers
+    let system_program_action = Program {
+        program_id: solana_sdk::system_program::ID.to_bytes(),
+    };
+    
+    let _txn = add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::Program(system_program_action),
+            ClientAction::SolLimit(swig_state::action::sol_limit::SolLimit { amount: 10_000_000 }),
+        ],
+    )
+    .unwrap();
+
+    context.svm.airdrop(&swig, 10_000_000_000).unwrap();
+    context.svm.warp_to_slot(100);
+
+    // Test 1: CPI signing with correct Program permission should succeed
+    let transfer_amount = 1_000_000;
+    let transfer_ix = system_instruction::transfer(&swig, &recipient.pubkey(), transfer_amount);
+    
+    let sign_ix = swig_interface::SignInstruction::new_ed25519(
+        swig,
+        second_authority.pubkey(),
+        second_authority.pubkey(),
+        transfer_ix,
+        1, // Second authority should be role_id 1
+    )
+    .unwrap();
+    
+    let transfer_message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    
+    let transfer_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message),
+        &[second_authority.insecure_clone()],
+    )
+    .unwrap();
+    
+    let result = context.svm.send_transaction(transfer_tx);
+    if result.is_err() {
+        println!("Transaction failed: {:?}", result);
+    }
+    assert!(result.is_ok(), "CPI signing with correct Program permission should succeed");
+
+    // Test 2: Add authority without Program permission for a different program
+    let third_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&third_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    
+    // Create Program action for a different program (SPL Token program)
+    let token_program_action = Program {
+        program_id: spl_token::ID.to_bytes(),
+    };
+    
+    let _txn = add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: third_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::Program(token_program_action),
+            ClientAction::SolLimit(swig_state::action::sol_limit::SolLimit { amount: 10_000_000 }),
+        ],
+    )
+    .unwrap();
+
+    // Test 3: CPI signing with wrong Program permission should fail
+    let transfer_ix2 = system_instruction::transfer(&swig, &recipient.pubkey(), transfer_amount);
+    
+    let sign_ix2 = swig_interface::SignInstruction::new_ed25519(
+        swig,
+        third_authority.pubkey(),
+        third_authority.pubkey(),
+        transfer_ix2,
+        2, // Third authority should be role_id 2
+    )
+    .unwrap();
+    
+    let transfer_message2 = v0::Message::try_compile(
+        &third_authority.pubkey(),
+        &[sign_ix2],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    
+    let transfer_tx2 = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message2),
+        &[third_authority.insecure_clone()],
+    )
+    .unwrap();
+    
+    let result2 = context.svm.send_transaction(transfer_tx2);
+    assert!(result2.is_err(), "CPI signing with wrong Program permission should fail");
+    
+    // Verify it's the expected permission error
+    if let Err(failed_tx) = result2 {
+        println!("Got expected error: {:?}", failed_tx.err);
+    } else {
+        panic!("Expected permission denied error, got: {:?}", result2);
+    }
+}
+
+/// Test that authorities without any Program permission cannot CPI sign
+#[test_log::test]
+fn test_cpi_signing_without_program_permission_fails() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let recipient = Keypair::new();
+    
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+
+    // Create swig account with ed25519 authority
+    let (_, _transaction_metadata) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    
+    // Add a second authority with NO Program permission
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    
+    // Add authority with SolLimit permission only (no Program permission)
+    let _txn = add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(swig_state::action::sol_limit::SolLimit { amount: 10_000_000 })],
+    )
+    .unwrap();
+
+    context.svm.airdrop(&swig, 10_000_000_000).unwrap();
+    context.svm.warp_to_slot(100);
+
+    // Test: CPI signing without Program permission should fail
+    let transfer_amount = 1_000_000;
+    let transfer_ix = system_instruction::transfer(&swig, &recipient.pubkey(), transfer_amount);
+    
+    let sign_ix = swig_interface::SignInstruction::new_ed25519(
+        swig,
+        second_authority.pubkey(),
+        second_authority.pubkey(),
+        transfer_ix,
+        1, // Second authority should be role_id 1
+    )
+    .unwrap();
+    
+    let transfer_message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    
+    let transfer_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message),
+        &[second_authority.insecure_clone()],
+    )
+    .unwrap();
+    
+    let result = context.svm.send_transaction(transfer_tx);
+    assert!(result.is_err(), "CPI signing without Program permission should fail");
+    
+    // Verify it's the expected permission error
+    if let Err(failed_tx) = result {
+        println!("Got expected error: {:?}", failed_tx.err);
+    } else {
+        panic!("Expected permission denied error, got: {:?}", result);
+    }
+}

--- a/program/tests/sign.rs
+++ b/program/tests/sign.rs
@@ -20,7 +20,7 @@ use solana_sdk::{
 use swig_interface::{AuthorityConfig, ClientAction};
 use swig_state::{
     action::{
-        all::All, sol_limit::SolLimit, sol_recurring_limit::SolRecurringLimit,
+        all::All, program::Program, sol_limit::SolLimit, sol_recurring_limit::SolRecurringLimit,
         token_limit::TokenLimit, token_recurring_limit::TokenRecurringLimit,
     },
     authority::AuthorityType,
@@ -75,7 +75,12 @@ fn test_transfer_sol_with_additional_authority() {
             authority_type: AuthorityType::Ed25519,
             authority: second_authority.pubkey().as_ref(),
         },
-        vec![ClientAction::SolLimit(SolLimit { amount: amount / 2 })],
+        vec![
+            ClientAction::SolLimit(SolLimit { amount: amount / 2 }),
+            ClientAction::Program(Program {
+                program_id: solana_sdk::system_program::ID.to_bytes(),
+            }),
+        ],
     )
     .unwrap();
     println!("add authority txn {:?}", transaction_metadata.logs);
@@ -375,7 +380,12 @@ fn test_fail_transfer_sol_with_additional_authority_not_enough() {
             authority_type: AuthorityType::Ed25519,
             authority: second_authority.pubkey().as_ref(),
         },
-        vec![ClientAction::SolLimit(SolLimit { amount: 1000 })],
+        vec![
+            ClientAction::SolLimit(SolLimit { amount: 1000 }),
+            ClientAction::Program(Program {
+                program_id: solana_sdk::system_program::ID.to_bytes(),
+            }),
+        ],
     )
     .unwrap();
     context.svm.airdrop(&swig, 10_000_000_000).unwrap();
@@ -608,12 +618,17 @@ fn test_transfer_sol_with_recurring_limit() {
             authority_type: AuthorityType::Ed25519,
             authority: second_authority.pubkey().as_ref(),
         },
-        vec![ClientAction::SolRecurringLimit(SolRecurringLimit {
-            recurring_amount: 500,
-            window: 100,
-            last_reset: 0,
-            current_amount: 500,
-        })],
+        vec![
+            ClientAction::SolRecurringLimit(SolRecurringLimit {
+                recurring_amount: 500,
+                window: 100,
+                last_reset: 0,
+                current_amount: 500,
+            }),
+            ClientAction::Program(Program {
+                program_id: solana_sdk::system_program::ID.to_bytes(),
+            }),
+        ],
     )
     .unwrap();
 
@@ -789,13 +804,18 @@ fn test_transfer_token_with_recurring_limit() {
             authority_type: AuthorityType::Ed25519,
             authority: second_authority.pubkey().as_ref(),
         },
-        vec![ClientAction::TokenRecurringLimit(TokenRecurringLimit {
-            token_mint: mint_pubkey.to_bytes().try_into().unwrap(),
-            window: 100,
-            limit: 500,
-            current: 500,
-            last_reset: 0,
-        })],
+        vec![
+            ClientAction::TokenRecurringLimit(TokenRecurringLimit {
+                token_mint: mint_pubkey.to_bytes().try_into().unwrap(),
+                window: 100,
+                limit: 500,
+                current: 500,
+                last_reset: 0,
+            }),
+            ClientAction::Program(Program {
+                program_id: spl_token::id().to_bytes(),
+            }),
+        ],
     )
     .unwrap();
 

--- a/state/src/action/mod.rs
+++ b/state/src/action/mod.rs
@@ -8,6 +8,8 @@
 pub mod all;
 pub mod manage_authority;
 pub mod program;
+pub mod program_all;
+pub mod program_curated;
 pub mod program_scope;
 pub mod sol_limit;
 pub mod sol_recurring_limit;
@@ -22,6 +24,8 @@ use manage_authority::ManageAuthority;
 use no_padding::NoPadding;
 use pinocchio::program_error::ProgramError;
 use program::Program;
+use program_all::ProgramAll;
+use program_curated::ProgramCurated;
 use program_scope::ProgramScope;
 use sol_limit::SolLimit;
 use sol_recurring_limit::SolRecurringLimit;
@@ -130,6 +134,10 @@ pub enum Permission {
     StakeRecurringLimit = 11,
     /// Permission to perform all stake operations
     StakeAll = 12,
+    /// Permission to interact with any program (unrestricted CPI)
+    ProgramAll = 13,
+    /// Permission to interact with curated programs only
+    ProgramCurated = 14,
 }
 
 impl TryFrom<u16> for Permission {
@@ -139,7 +147,7 @@ impl TryFrom<u16> for Permission {
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
             // SAFETY: `value` is guaranteed to be in the range of the enum variants.
-            0..=12 => Ok(unsafe { core::mem::transmute::<u16, Permission>(value) }),
+            0..=14 => Ok(unsafe { core::mem::transmute::<u16, Permission>(value) }),
             _ => Err(SwigStateError::PermissionLoadError.into()),
         }
     }
@@ -196,6 +204,8 @@ impl ActionLoader {
             Permission::StakeLimit => StakeLimit::valid_layout(data),
             Permission::StakeRecurringLimit => StakeRecurringLimit::valid_layout(data),
             Permission::StakeAll => StakeAll::valid_layout(data),
+            Permission::ProgramAll => ProgramAll::valid_layout(data),
+            Permission::ProgramCurated => ProgramCurated::valid_layout(data),
             _ => Ok(false),
         }
     }

--- a/state/src/action/program_all.rs
+++ b/state/src/action/program_all.rs
@@ -1,0 +1,65 @@
+//! Program All action type.
+//!
+//! This module defines the ProgramAll action type which grants permission to
+//! interact with any program in the Swig wallet system (unrestricted CPI access).
+
+use no_padding::NoPadding;
+use pinocchio::program_error::ProgramError;
+
+use super::{Actionable, Permission};
+use crate::{IntoBytes, Transmutable, TransmutableMut};
+
+/// Represents permission to interact with any program (unrestricted CPI access).
+///
+/// This action grants the authority the ability to make CPI calls to any program
+/// without restrictions. This is the most permissive program permission and should
+/// be used with caution.
+#[derive(NoPadding)]
+#[repr(C, align(8))]
+pub struct ProgramAll {
+    /// Reserved bytes for future use and alignment
+    pub _reserved: [u8; 32],
+}
+
+impl ProgramAll {
+    /// Creates a new ProgramAll permission
+    pub fn new() -> Self {
+        Self {
+            _reserved: [0; 32],
+        }
+    }
+}
+
+impl Default for ProgramAll {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Transmutable for ProgramAll {
+    /// Size of the ProgramAll struct in bytes (32 bytes for alignment)
+    const LEN: usize = 32;
+}
+
+impl IntoBytes for ProgramAll {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+impl TransmutableMut for ProgramAll {}
+
+impl<'a> Actionable<'a> for ProgramAll {
+    /// This action represents the ProgramAll permission type
+    const TYPE: Permission = Permission::ProgramAll;
+    /// Only one ProgramAll permission can exist per role
+    const REPEATABLE: bool = false;
+
+    /// Always returns true since this grants access to all programs.
+    ///
+    /// # Arguments
+    /// * `_data` - The program ID to check against (ignored for ProgramAll)
+    fn match_data(&self, _data: &[u8]) -> bool {
+        true
+    }
+}

--- a/state/src/action/program_curated.rs
+++ b/state/src/action/program_curated.rs
@@ -1,0 +1,96 @@
+//! Program Curated action type.
+//!
+//! This module defines the ProgramCurated action type which grants permission to
+//! interact with a curated list of popular programs in the Swig wallet system.
+
+use no_padding::NoPadding;
+use pinocchio::program_error::ProgramError;
+
+use super::{Actionable, Permission};
+use crate::{IntoBytes, Transmutable, TransmutableMut};
+
+/// Curated program IDs that are commonly used and considered safe
+const CURATED_PROGRAMS: &[[u8; 32]] = &[
+    // System Program (11111111111111111111111111111111)
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    // SPL Token Program (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
+    [6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169],
+    // SPL Token 2022 Program (TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb)
+    [6, 221, 246, 225, 238, 117, 143, 222, 138, 60, 137, 215, 166, 35, 250, 133, 224, 81, 209, 114, 91, 157, 99, 29, 94, 145, 213, 104, 233, 4, 16, 238],
+    // Staking Program (Stake11111111111111111111111111111111111111)
+    [6, 161, 216, 23, 145, 55, 84, 42, 152, 52, 55, 189, 254, 42, 122, 178, 85, 86, 165, 18, 7, 142, 233, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+];
+
+/// Represents permission to interact with curated programs.
+///
+/// This action grants the authority the ability to make CPI calls to a predefined
+/// list of popular and commonly used programs. This provides a balance between
+/// security and functionality.
+#[derive(NoPadding)]
+#[repr(C, align(8))]
+pub struct ProgramCurated {
+    /// Reserved bytes for future use and alignment
+    pub _reserved: [u8; 32],
+}
+
+impl ProgramCurated {
+    /// Creates a new ProgramCurated permission
+    pub fn new() -> Self {
+        Self {
+            _reserved: [0; 32],
+        }
+    }
+
+    /// Checks if a program ID is in the curated list
+    pub fn is_curated_program(program_id: &[u8; 32]) -> bool {
+        CURATED_PROGRAMS.iter().any(|curated| curated == program_id)
+    }
+
+    /// Returns the list of curated program IDs
+    pub fn get_curated_programs() -> &'static [[u8; 32]] {
+        CURATED_PROGRAMS
+    }
+}
+
+impl Default for ProgramCurated {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Transmutable for ProgramCurated {
+    /// Size of the ProgramCurated struct in bytes (32 bytes for alignment)
+    const LEN: usize = 32;
+}
+
+impl IntoBytes for ProgramCurated {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+impl TransmutableMut for ProgramCurated {}
+
+impl<'a> Actionable<'a> for ProgramCurated {
+    /// This action represents the ProgramCurated permission type
+    const TYPE: Permission = Permission::ProgramCurated;
+    /// Only one ProgramCurated permission can exist per role
+    const REPEATABLE: bool = false;
+
+    /// Checks if the provided program ID is in the curated list.
+    ///
+    /// # Arguments
+    /// * `data` - The program ID to check against (first 32 bytes)
+    fn match_data(&self, data: &[u8]) -> bool {
+        if data.len() < 32 {
+            return false;
+        }
+        
+        let program_id: [u8; 32] = match data[0..32].try_into() {
+            Ok(id) => id,
+            Err(_) => return false,
+        };
+        
+        Self::is_curated_program(&program_id)
+    }
+}


### PR DESCRIPTION
This PR adds new restrictions based on the requirement that we will restrict any cpi instructions that require the swig as a signer. Specifically, swig should be a deny-by-default protocol and then you can allow an authority to sign cpis with the swig if you have `All` (all should always allow for everything), `ProgramAll`, `Program(ProgramId)`, or `ProgramCurated` as an action/permission on your authority.