### PR TITLE
Replace authority boundary Fix

### DIFF
--- a/program/tests/update_authority_test.rs
+++ b/program/tests/update_authority_test.rs
@@ -132,7 +132,8 @@ fn test_update_authority_ed25519_add_actions() -> anyhow::Result<()> {
         authority_type: AuthorityType::Ed25519,
         authority: second_authority_pubkey.as_ref(),
     };
-    let actions = vec![ClientAction::All(All {})];
+
+    let actions = vec![ClientAction::ManageAuthority(ManageAuthority {})];
 
     let _add_result = add_authority_with_ed25519_root(
         &mut context,
@@ -182,6 +183,17 @@ fn test_update_authority_ed25519_add_actions() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to send transaction {:?}", e))?;
 
     println!("Transaction logs: {:?}", result.logs);
+
+    let swig_account = context.svm.get_account(&swig).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data)
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize swig {:?}", e))?;
+    let role = swig_data.get_role(1).unwrap().unwrap();
+
+    println!("role: {:?}", role.get_all_actions());
+    let role_actions = role.get_all_actions().unwrap();
+    for action in role_actions {
+        println!("action: {:?}", action.permission());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
**Root Cause**: The `perform_replace_all_operation` function in update_authority_v1.rs was copying action data without recalculating the action boundaries. Action boundaries are relative positions that point to where the next action starts within the actions section, but when actions are copied to a new location, these boundaries become invalid.

Specific Issue:
Original Problem: 
- The function was using a simple copy_from_slice() to copy new actions data:
Apply to update_autho...;

What Was Wrong: 
Action boundaries in the copied data were still relative to their original positions, not the new actions section. 

This caused:
Invalid action types (like action_type: 514 instead of valid enum values)
Incorrect boundaries (like boundary: 33686018 instead of reasonable values)

The Fix: 
Replaced the simple copy with a boundary recalculation loop that:
1. Copies each action header individually
2. Recalculates the boundary relative to the new actions section start
3. Updates the boundary bytes in the copied action header
4. Copies the action data separately