### PR TITLE
WIP: Decode Swig Instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,9 +4784,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -8063,6 +8063,8 @@ dependencies = [
  "openssl",
  "rand 0.8.5",
  "secp256k1",
+ "serde",
+ "serde_json",
  "solana-account-decoder-client-types",
  "solana-client",
  "solana-program",

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -25,6 +25,8 @@ litesvm-token = "0.6.1"
 spl-associated-token-account = "7.0.0"
 spl-token = "8.0.0"
 solana-account-decoder-client-types = "2.0"
+serde = "1.0.219"
+serde_json = "1.0.141"
 
 [dev-dependencies]
 test-log = "0.2"

--- a/rust-sdk/src/decoder.rs
+++ b/rust-sdk/src/decoder.rs
@@ -1,12 +1,16 @@
 use crate::{
     types::{Permission, UpdateAuthorityData},
-    Ed25519ClientRole, SwigInstructionBuilder,
+    wallet::TOKEN_22_PROGRAM_ID,
+    Ed25519ClientRole, SwigInstructionBuilder, SwigWallet,
 };
+use solana_account_decoder_client_types::{UiAccount, UiAccountData, UiAccountEncoding};
+use solana_client::rpc_request::TokenAccountsFilter;
 use solana_program::{
     decode_error::DecodeError,
     program_error::{PrintProgramError, ProgramError},
 };
-use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey, transaction::VersionedTransaction};
+use spl_token::ID as TOKEN_PROGRAM_ID;
 use swig_state::authority::AuthorityType;
 
 use crate::SwigError;
@@ -44,8 +48,18 @@ pub enum InstructionType {
     WithdrawToken,
 }
 
+impl fmt::Display for InstructionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let InstructionType::Sign { .. } = self {
+            write!(f, "Sign")
+        } else {
+            write!(f, "{:?}", self)
+        }
+    }
+}
+
 #[derive(Debug)]
-pub struct DecodedInstruction {
+pub struct DecodedTransaction {
     /// The type of SWIG instruction
     pub instruction_type: InstructionType,
     /// Human-readable description of what the instruction does
@@ -54,44 +68,21 @@ pub struct DecodedInstruction {
     pub role_id: u32,
     /// Authority type used
     pub authority_type: AuthorityType,
-    /// Decoded compact instructions
-    pub compact_instructions: Option<Vec<DecodedCompactInstruction>>,
     /// Additional instruction-specific data
     pub data: Option<serde_json::Value>,
     /// Fee payer
     pub fee_payer: String,
+    /// Summary of account changes
+    pub account_summary: Option<Vec<AccountChange>>,
 }
 
-/// JSON response structure for decoded compact instructions
 #[derive(Debug)]
-pub struct DecodedCompactInstruction {
-    /// Program ID as string
-    pub program_id: String,
-    /// Human-readable program name (if known)
-    pub program_name: Option<String>,
-    /// Decoded instruction type (if known)
-    pub instruction_type: Option<String>,
-    /// Human-readable description of what this instruction does
-    pub description: Option<String>,
-    /// Account metadata
-    pub accounts: Vec<DecodedAccount>,
-    /// Decoded instruction data (if known)
-    pub data: Option<serde_json::Value>,
-    /// Raw instruction data as base64
-    pub raw_data: String,
-}
-
-/// JSON response structure for decoded accounts
-#[derive(Debug)]
-pub struct DecodedAccount {
-    /// Account public key as string
-    pub pubkey: String,
-    /// Human-readable account name/role
-    pub name: Option<String>,
-    /// Whether this account is a signer
-    pub is_signer: bool,
-    /// Whether this account is writable
-    pub is_writable: bool,
+pub struct AccountChange {
+    pub account_id: String,
+    pub account_name: Option<String>,
+    pub pre_balance: u64,
+    pub post_balance: u64,
+    pub balance_change: i64,
 }
 
 pub fn authority_type_to_string(authority_type: AuthorityType) -> String {
@@ -106,24 +97,263 @@ pub fn authority_type_to_string(authority_type: AuthorityType) -> String {
     }
 }
 
-impl DecodedInstruction {
+impl DecodedTransaction {
     pub fn new(
         instruction_type: InstructionType,
         description: String,
-        role_id: u32,
-        authority_type: AuthorityType,
-        compact_instructions: Option<Vec<DecodedCompactInstruction>>,
-        data: Option<serde_json::Value>,
-        fee_payer: String,
+        swig_wallet: &mut SwigWallet,
+        tx: VersionedTransaction,
     ) -> Self {
+        let account_summary = get_account_summary(swig_wallet, tx).unwrap();
+
         Self {
             instruction_type,
             description,
-            role_id,
-            authority_type,
-            compact_instructions,
-            data,
-            fee_payer,
+            role_id: swig_wallet.current_role.role_id,
+            authority_type: swig_wallet.current_role.authority_type.clone(),
+            data: None,
+            fee_payer: swig_wallet.get_fee_payer().to_string(),
+            account_summary: Some(account_summary),
         }
     }
+}
+
+use std::fmt;
+
+impl fmt::Display for DecodedTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "\nSWIG Transaction Decoded")?;
+        writeln!(f, "========================")?;
+        writeln!(f, "Description: {}", self.description)?;
+        writeln!(f, "Instruction Type: {}", self.instruction_type)?;
+        writeln!(f, "Role ID: {}", self.role_id)?;
+        writeln!(
+            f,
+            "Authority Type: {}",
+            authority_type_to_string(self.authority_type.clone())
+        )?;
+        writeln!(f, "Fee Payer: {}", self.fee_payer)?;
+
+        if let Some(data) = &self.data {
+            writeln!(
+                f,
+                "Additional Data: {}",
+                serde_json::to_string_pretty(data).unwrap_or_else(|_| "Invalid JSON".to_string())
+            )?;
+        }
+
+        if let Some(account_summary) = &self.account_summary {
+            if !account_summary.is_empty() {
+                writeln!(f, "\nAccount Changes:")?;
+                writeln!(f, "----------------")?;
+                for change in account_summary {
+                    let account_name = change.account_name.as_deref().unwrap_or("Unknown");
+                    let change_sign = if change.balance_change >= 0 { "+" } else { "" };
+                    writeln!(
+                        f,
+                        "{} ({}): {}  → {} ({} {}{})",
+                        account_name,
+                        change.account_id,
+                        change.pre_balance,
+                        change.post_balance,
+                        change_sign,
+                        change.balance_change,
+                        "tokens"
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn get_account_summary(
+    swig_wallet: &mut SwigWallet,
+    tx: VersionedTransaction,
+) -> Result<Vec<AccountChange>, SwigError> {
+    let initial_accounts = capture_pre_accounts(swig_wallet, &tx)?;
+    let post_accounts = capture_post_accounts(swig_wallet, &tx)?;
+
+    let account_summary = compare_account_balances(&initial_accounts, &post_accounts);
+    Ok(account_summary)
+}
+
+fn capture_post_accounts(
+    swig_wallet: &mut SwigWallet,
+    tx: &solana_sdk::transaction::VersionedTransaction,
+) -> Result<Vec<(solana_sdk::pubkey::Pubkey, u64, bool)>, SwigError> {
+    let mut balances = Vec::new();
+
+    #[cfg(not(all(feature = "rust_sdk_test", test)))]
+    {
+        let simulation_result = swig_wallet
+            .rpc_client
+            .simulate_transaction(&tx.clone())
+            .unwrap();
+
+        // Extract account keys from the transaction
+        let account_keys = match &tx.message {
+            solana_sdk::message::VersionedMessage::V0(msg) => &msg.account_keys,
+            solana_sdk::message::VersionedMessage::Legacy(msg) => &msg.account_keys,
+        };
+
+        // Get post-transaction accounts
+        if let Some(accounts) = simulation_result.value.accounts {
+            for (i, account_opt) in accounts.iter().enumerate() {
+                if let Some(account) = account_opt {
+                    let pubkey = account_keys[i];
+                    if account.owner == TOKEN_PROGRAM_ID.to_string() {
+                        // For token accounts, we need to parse the data differently
+                        // The balance is stored in the account data at specific offsets
+                        match &account.data {
+                            solana_account_decoder_client_types::UiAccountData::Binary(
+                                data,
+                                encoding,
+                            ) => {
+                                if UiAccountEncoding::Base58 == *encoding && data.len() >= 72 {
+                                    let base58_data = bs58::decode(data).into_vec().unwrap();
+                                    let balance =
+                                        u64::from_le_bytes(base58_data[64..72].try_into().unwrap());
+                                    balances.push((pubkey, balance, false));
+                                }
+                            },
+                            _ => {
+                                // For non-binary data, use lamports as fallback
+                                balances.push((pubkey, account.lamports, false));
+                            },
+                        }
+                    } else {
+                        balances.push((pubkey, account.lamports, false));
+                    }
+                }
+            }
+        }
+    }
+    #[cfg(all(feature = "rust_sdk_test", test))]
+    {
+        use solana_sdk::account::ReadableAccount;
+        let result = swig_wallet
+            .litesvm()
+            .simulate_transaction(tx.clone())
+            .unwrap();
+        let post_accounts = result.post_accounts;
+
+        for (pubkey, final_account) in post_accounts {
+            if *final_account.owner() == TOKEN_PROGRAM_ID {
+                let balance = u64::from_le_bytes(final_account.data()[64..72].try_into().unwrap());
+                balances.push((pubkey, balance, false));
+            } else {
+                balances.push((pubkey, final_account.lamports(), false));
+            }
+        }
+    }
+
+    Ok(balances)
+}
+
+/// Capture the current balances of all accounts that will be affected by the transaction
+fn capture_pre_accounts(
+    swig_wallet: &mut SwigWallet,
+    tx: &solana_sdk::transaction::VersionedTransaction,
+) -> Result<Vec<(solana_sdk::pubkey::Pubkey, u64, bool)>, SwigError> {
+    let mut balances = Vec::new();
+
+    // Extract account keys and their writable status from the transaction
+    let (account_keys, writable_accounts) = match &tx.message {
+        solana_sdk::message::VersionedMessage::V0(msg) => {
+            let writable = msg.header.num_required_signatures as usize
+                + msg.header.num_readonly_signed_accounts as usize;
+            let readonly = msg.account_keys.len() - writable;
+            let writable_accounts: std::collections::HashSet<_> =
+                msg.account_keys[..writable].iter().collect();
+            (&msg.account_keys, writable_accounts)
+        },
+        solana_sdk::message::VersionedMessage::Legacy(msg) => {
+            let writable = msg.header.num_required_signatures as usize
+                + msg.header.num_readonly_signed_accounts as usize;
+            let readonly = msg.account_keys.len() - writable;
+            let writable_accounts: std::collections::HashSet<_> =
+                msg.account_keys[..writable].iter().collect();
+            (&msg.account_keys, writable_accounts)
+        },
+    };
+
+    for pubkey in account_keys {
+        #[cfg(not(all(feature = "rust_sdk_test", test)))]
+        {
+            // RPC client returns Result<Account, ClientError>
+            match swig_wallet.rpc_client.get_account(&pubkey) {
+                Ok(account) => {
+                    if account.owner == TOKEN_PROGRAM_ID {
+                        let balance = u64::from_le_bytes(account.data[64..72].try_into().unwrap());
+                        balances.push((*pubkey, balance, writable_accounts.contains(pubkey)));
+                    } else {
+                        balances.push((
+                            *pubkey,
+                            account.lamports,
+                            writable_accounts.contains(pubkey),
+                        ));
+                    }
+                },
+                Err(_) => {
+                    // Account doesn't exist, treat as having 0 balance
+                    balances.push((*pubkey, 0, writable_accounts.contains(pubkey)));
+                },
+            }
+        }
+        #[cfg(all(feature = "rust_sdk_test", test))]
+        {
+            // Litesvm returns Option<Account>
+            match swig_wallet.litesvm().get_account(&pubkey) {
+                Some(account) => {
+                    if account.owner == TOKEN_PROGRAM_ID {
+                        let balance = u64::from_le_bytes(account.data[64..72].try_into().unwrap());
+                        balances.push((*pubkey, balance, writable_accounts.contains(pubkey)));
+                    } else {
+                        balances.push((
+                            *pubkey,
+                            account.lamports,
+                            writable_accounts.contains(pubkey),
+                        ));
+                    }
+                },
+                None => {
+                    // Account doesn't exist, treat as having 0 balance
+                    balances.push((*pubkey, 0, writable_accounts.contains(pubkey)));
+                },
+            }
+        }
+    }
+
+    Ok(balances)
+}
+
+/// Compare initial and final account balances and show the changes
+fn compare_account_balances(
+    initial_balances: &[(solana_sdk::pubkey::Pubkey, u64, bool)],
+    final_balances: &[(solana_sdk::pubkey::Pubkey, u64, bool)],
+) -> Vec<AccountChange> {
+    let mut account_changes = Vec::new();
+
+    // Create a map of initial balances for quick lookup
+    let initial_map: std::collections::HashMap<_, _> = initial_balances
+        .iter()
+        .map(|(pk, bal, writable)| (*pk, (*bal, *writable)))
+        .collect();
+
+    for (pubkey, final_balance, writable) in final_balances {
+        let (initial_balance, _) = initial_map.get(pubkey).copied().unwrap_or((0, false));
+        let change = *final_balance as i64 - initial_balance as i64;
+
+        account_changes.push(AccountChange {
+            account_id: pubkey.to_string(),
+            account_name: None, // Could be enhanced to provide meaningful names
+            pre_balance: initial_balance,
+            post_balance: *final_balance,
+            balance_change: change,
+        });
+    }
+
+    account_changes
 }

--- a/rust-sdk/src/decoder.rs
+++ b/rust-sdk/src/decoder.rs
@@ -1,0 +1,129 @@
+use crate::{
+    types::{Permission, UpdateAuthorityData},
+    Ed25519ClientRole, SwigInstructionBuilder,
+};
+use solana_program::{
+    decode_error::DecodeError,
+    program_error::{PrintProgramError, ProgramError},
+};
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+use swig_state::authority::AuthorityType;
+
+use crate::SwigError;
+
+#[derive(Debug)]
+pub enum InstructionType {
+    CreateSwig {
+        swig_id: [u8; 32],
+        new_authority_type: AuthorityType,
+        new_authority: Vec<u8>,
+        permissions: Vec<Permission>,
+    },
+    AddAuthority {
+        new_authority_type: AuthorityType,
+        new_authority: Vec<u8>,
+        permissions: Vec<Permission>,
+    },
+    RemoveAuthority {
+        authority_to_remove_id: u32,
+    },
+    UpdateAuthority {
+        authority_to_replace_id: u32,
+        update_data: UpdateAuthorityData,
+    },
+    Sign {
+        inner_instructions: Vec<Instruction>,
+    },
+    CreateSubAccount,
+    CreateSession,
+    SignWithSubAccount,
+    WithdrawFromSubAccount,
+    WithdrawTokenFromSubAccount,
+    ToggleSubAccount,
+    WithdrawSol,
+    WithdrawToken,
+}
+
+#[derive(Debug)]
+pub struct DecodedInstruction {
+    /// The type of SWIG instruction
+    pub instruction_type: InstructionType,
+    /// Human-readable description of what the instruction does
+    pub description: String,
+    /// Role ID used for this instruction
+    pub role_id: u32,
+    /// Authority type used
+    pub authority_type: AuthorityType,
+    /// Decoded compact instructions
+    pub compact_instructions: Option<Vec<DecodedCompactInstruction>>,
+    /// Additional instruction-specific data
+    pub data: Option<serde_json::Value>,
+    /// Fee payer
+    pub fee_payer: String,
+}
+
+/// JSON response structure for decoded compact instructions
+#[derive(Debug)]
+pub struct DecodedCompactInstruction {
+    /// Program ID as string
+    pub program_id: String,
+    /// Human-readable program name (if known)
+    pub program_name: Option<String>,
+    /// Decoded instruction type (if known)
+    pub instruction_type: Option<String>,
+    /// Human-readable description of what this instruction does
+    pub description: Option<String>,
+    /// Account metadata
+    pub accounts: Vec<DecodedAccount>,
+    /// Decoded instruction data (if known)
+    pub data: Option<serde_json::Value>,
+    /// Raw instruction data as base64
+    pub raw_data: String,
+}
+
+/// JSON response structure for decoded accounts
+#[derive(Debug)]
+pub struct DecodedAccount {
+    /// Account public key as string
+    pub pubkey: String,
+    /// Human-readable account name/role
+    pub name: Option<String>,
+    /// Whether this account is a signer
+    pub is_signer: bool,
+    /// Whether this account is writable
+    pub is_writable: bool,
+}
+
+pub fn authority_type_to_string(authority_type: AuthorityType) -> String {
+    match authority_type {
+        AuthorityType::Ed25519 => "Ed25519".to_string(),
+        AuthorityType::Secp256k1 => "Secp256k1".to_string(),
+        AuthorityType::Secp256r1 => "Secp256r1".to_string(),
+        AuthorityType::Ed25519Session => "Ed25519Session".to_string(),
+        AuthorityType::Secp256k1Session => "Secp256k1Session".to_string(),
+        AuthorityType::Secp256r1Session => "Secp256r1Session".to_string(),
+        AuthorityType::None => "None".to_string(),
+    }
+}
+
+impl DecodedInstruction {
+    pub fn new(
+        instruction_type: InstructionType,
+        description: String,
+        role_id: u32,
+        authority_type: AuthorityType,
+        compact_instructions: Option<Vec<DecodedCompactInstruction>>,
+        data: Option<serde_json::Value>,
+        fee_payer: String,
+    ) -> Self {
+        Self {
+            instruction_type,
+            description,
+            role_id,
+            authority_type,
+            compact_instructions,
+            data,
+            fee_payer,
+        }
+    }
+}

--- a/rust-sdk/src/lib.rs
+++ b/rust-sdk/src/lib.rs
@@ -1,5 +1,6 @@
 // Public modules
 pub mod client_role;
+pub mod decoder;
 pub mod error;
 pub mod instruction_builder;
 pub mod types;

--- a/rust-sdk/src/tests/wallet/decoder_tests.rs
+++ b/rust-sdk/src/tests/wallet/decoder_tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+use crate::types::UpdateAuthorityData;
+
+#[test_log::test]
+fn should_decode_create_swig_instruction() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // Verify wallet was created successfully
+    assert!(swig_wallet.get_swig_account().is_ok());
+    assert_eq!(swig_wallet.get_role_count().unwrap(), 1);
+    assert_eq!(swig_wallet.get_current_role_id().unwrap(), 0);
+
+    let swig_pubkey = swig_wallet.get_swig_account().unwrap();
+    let swig_data = swig_wallet.litesvm().get_account(&swig_pubkey).unwrap();
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data.data).unwrap();
+
+    assert_eq!(swig_with_roles.state.id, [0; 32]);
+
+    swig_wallet
+        .litesvm()
+        .airdrop(&swig_pubkey, 10_000_000_000)
+        .unwrap();
+
+    let secondary_authority = Keypair::new();
+    let (tx, decoded_instruction) = swig_wallet
+        .build_add_authority_transaction(
+            AuthorityType::Ed25519,
+            &secondary_authority.pubkey().to_bytes(),
+            vec![Permission::All {}],
+        )
+        .unwrap();
+
+    println!("added decoded_instruction: {:?}", decoded_instruction);
+
+    // update the authority
+    let update_data = UpdateAuthorityData::ReplaceAll(vec![Permission::Sol {
+        amount: 10_000_000_000,
+        recurring: None,
+    }]);
+
+    let (tx, decoded_instruction) = swig_wallet
+        .build_update_authority_transaction(1, update_data)
+        .unwrap();
+
+    println!("updated decoded_instruction: {:?}", decoded_instruction);
+
+    // Remove the authority
+    let (tx, decoded_instruction) = swig_wallet.build_remove_authority_transaction(1).unwrap();
+
+    println!("removed decoded_instruction: {:?}", decoded_instruction);
+
+    // Sign a transaction
+    use solana_sdk::system_instruction;
+    let inner_ix = system_instruction::transfer(
+        &swig_wallet.get_swig_account().unwrap(),
+        &secondary_authority.pubkey(),
+        100_000_000,
+    );
+
+    let (tx, decoded_instruction) = swig_wallet
+        .build_sign_transaction(vec![inner_ix], None)
+        .unwrap();
+
+    println!("signed decoded_instruction: {:?}", decoded_instruction);
+
+    let result = swig_wallet.litesvm().simulate_transaction(tx);
+    println!("result: {:?}", result);
+}

--- a/rust-sdk/src/tests/wallet/mod.rs
+++ b/rust-sdk/src/tests/wallet/mod.rs
@@ -1,5 +1,6 @@
 pub mod authority_tests;
 pub mod creation_tests;
+pub mod decoder_tests;
 pub mod helper_tests;
 pub mod program_scope_test;
 pub mod secp256r1_test;

--- a/state/src/authority/mod.rs
+++ b/state/src/authority/mod.rs
@@ -112,7 +112,7 @@ pub trait AuthorityInfo: IntoBytes {
 }
 
 /// Represents different types of authorities supported by the system.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[repr(u16)]
 pub enum AuthorityType {
     /// No authority (invalid state)


### PR DESCRIPTION
This is an ask from Anchorage. They need to be able to decode swig transactions to show to users what is going on in the instruction. They are building an open sourced visual signing system with their infra and want to make sure when building in swig functionality they can properly decode swig transactions to display each instruction to the user properly.

This PR introduces transaction decoding and simulation capabilities to the SWIG Rust SDK, enhancing the devex with better transaction visibility and debugging tools.

1. Transaction Decoder
New decoder.rs module with comprehensive SWIG instruction decoding

- DecodedTransaction struct providing human-readable transaction information including:
- Instruction type identification (CreateSwig, AddAuthority, Sign, etc.)
- Role ID and authority type tracking
- InstructionType enum covering all SWIG operations:
 
2. Transaction Simulation

- Account balance tracking with AccountChange struct showing pre/post transaction states
- Balance change analysis for all accounts involved in transactions
- Account summary generation providing detailed balance impact information
- Integration with existing wallet functionality for seamless simulation workflow