### PR TITLE
Patch: Recurring Limit resets to window start

### DIFF
--- a/state/src/action/program_scope.rs
+++ b/state/src/action/program_scope.rs
@@ -313,7 +313,8 @@ impl ProgramScope {
                 if current_slot.saturating_sub(self.last_reset) > self.window {
                     // Reset the spent amount to zero for the new window
                     self.current_amount = 0;
-                    self.last_reset = current_slot;
+                    // reset the last reset to the start of the current window
+                    self.last_reset = (current_slot / self.window) * self.window;
                 }
 
                 // Check if the requested amount plus what's already spent would exceed the

--- a/state/src/action/sol_recurring_limit.rs
+++ b/state/src/action/sol_recurring_limit.rs
@@ -46,7 +46,8 @@ impl SolRecurringLimit {
             && lamport_diff <= self.recurring_amount
         {
             self.current_amount = self.recurring_amount;
-            self.last_reset = current_slot;
+            // reset the last reset to the start of the current window
+            self.last_reset = (current_slot / self.window) * self.window;
         }
         if lamport_diff > self.current_amount {
             return Err(ProgramError::InsufficientFunds);

--- a/state/src/action/stake_recurring_limit.rs
+++ b/state/src/action/stake_recurring_limit.rs
@@ -48,7 +48,8 @@ impl StakeRecurringLimit {
             && stake_amount_diff <= self.recurring_amount
         {
             self.current_amount = self.recurring_amount;
-            self.last_reset = current_slot;
+            // reset the last reset to the start of the current window
+            self.last_reset = (current_slot / self.window) * self.window;
         }
         if stake_amount_diff > self.current_amount {
             return Err(ProgramError::InsufficientFunds);

--- a/state/src/action/token_recurring_limit.rs
+++ b/state/src/action/token_recurring_limit.rs
@@ -48,7 +48,8 @@ impl TokenRecurringLimit {
     pub fn run(&mut self, amount: u64, current_slot: u64) -> Result<(), ProgramError> {
         if current_slot.saturating_sub(self.last_reset) > self.window && amount <= self.limit {
             self.current = self.limit;
-            self.last_reset = current_slot;
+            // reset the last reset to the start of the current window
+            self.last_reset = (current_slot / self.window) * self.window;
         }
         if amount > self.current {
             return Err(ProgramError::InsufficientFunds);


### PR DESCRIPTION
1. Instead of resetting to current slot, it resets to window start
2. added test case for verifying the last reset