### PR TITLE
fixed subaccount toggle

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -495,7 +495,7 @@ pub fn run_command_mode(ctx: &mut SwigCliContext, cmd: Command) -> Result<()> {
                 ctx.wallet
                     .as_mut()
                     .unwrap()
-                    .toggle_sub_account(sub_account, enabled)?;
+                    .toggle_sub_account(sub_account, None, enabled)?;
                 println!(
                     "Sub-account {} successfully!",
                     if enabled { "enabled" } else { "disabled" }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -491,11 +491,13 @@ pub fn run_command_mode(ctx: &mut SwigCliContext, cmd: Command) -> Result<()> {
             )?;
 
             let sub_account = ctx.wallet.as_ref().unwrap().get_sub_account()?;
+            let current_role_id = ctx.wallet.as_ref().unwrap().get_current_role_id()?;
             if let Some(sub_account) = sub_account {
-                ctx.wallet
-                    .as_mut()
-                    .unwrap()
-                    .toggle_sub_account(sub_account, None, enabled)?;
+                ctx.wallet.as_mut().unwrap().toggle_sub_account(
+                    sub_account,
+                    current_role_id,
+                    enabled,
+                )?;
                 println!(
                     "Sub-account {} successfully!",
                     if enabled { "enabled" } else { "disabled" }

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -1087,7 +1087,7 @@ fn toggle_sub_account_interactive(ctx: &mut SwigCliContext) -> Result<()> {
         ctx.wallet
             .as_mut()
             .unwrap()
-            .toggle_sub_account(sub_account, true)?;
+            .toggle_sub_account(sub_account, None, true)?;
     }
 
     Ok(())

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -1083,11 +1083,14 @@ fn toggle_sub_account_interactive(ctx: &mut SwigCliContext) -> Result<()> {
     println!("\n{}", "Toggling sub-account...".bright_blue().bold());
 
     let sub_account = ctx.wallet.as_mut().unwrap().get_sub_account()?;
+
+    let current_role_id = ctx.wallet.as_ref().unwrap().get_current_role_id()?;
+
     if let Some(sub_account) = sub_account {
         ctx.wallet
             .as_mut()
             .unwrap()
-            .toggle_sub_account(sub_account, None, true)?;
+            .toggle_sub_account(sub_account, current_role_id, true)?;
     }
 
     Ok(())

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -2094,6 +2094,7 @@ impl ToggleSubAccountInstruction {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
+        auth_role_id: Option<u32>,
         enabled: bool,
     ) -> anyhow::Result<Instruction> {
         let accounts = vec![
@@ -2103,7 +2104,7 @@ impl ToggleSubAccountInstruction {
             AccountMeta::new_readonly(authority, true),
         ];
 
-        let args = ToggleSubAccountV1Args::new(role_id, enabled);
+        let args = ToggleSubAccountV1Args::new(role_id, auth_role_id, enabled);
         let args_bytes = args
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
@@ -2122,6 +2123,7 @@ impl ToggleSubAccountInstruction {
         current_slot: u64,
         sub_account: Pubkey,
         role_id: u32,
+        auth_role_id: Option<u32>,
         enabled: bool,
     ) -> anyhow::Result<Instruction>
     where
@@ -2133,7 +2135,7 @@ impl ToggleSubAccountInstruction {
             AccountMeta::new(sub_account, false),
         ];
 
-        let args = ToggleSubAccountV1Args::new(role_id, enabled);
+        let args = ToggleSubAccountV1Args::new(role_id, auth_role_id, enabled);
         let args_bytes = args
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
@@ -2180,6 +2182,7 @@ impl ToggleSubAccountInstruction {
         counter: u32,
         sub_account: Pubkey,
         role_id: u32,
+        auth_role_id: Option<u32>,
         enabled: bool,
         public_key: &[u8; 33],
     ) -> anyhow::Result<Vec<Instruction>>
@@ -2194,7 +2197,7 @@ impl ToggleSubAccountInstruction {
             AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
         ];
 
-        let args = ToggleSubAccountV1Args::new(role_id, enabled);
+        let args = ToggleSubAccountV1Args::new(role_id, auth_role_id, enabled);
         let args_bytes = args
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -2094,7 +2094,7 @@ impl ToggleSubAccountInstruction {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
     ) -> anyhow::Result<Instruction> {
         let accounts = vec![
@@ -2123,7 +2123,7 @@ impl ToggleSubAccountInstruction {
         current_slot: u64,
         sub_account: Pubkey,
         role_id: u32,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
     ) -> anyhow::Result<Instruction>
     where
@@ -2182,7 +2182,7 @@ impl ToggleSubAccountInstruction {
         counter: u32,
         sub_account: Pubkey,
         role_id: u32,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
         public_key: &[u8; 33],
     ) -> anyhow::Result<Vec<Instruction>>

--- a/program/src/actions/toggle_sub_account_v1.rs
+++ b/program/src/actions/toggle_sub_account_v1.rs
@@ -12,7 +12,10 @@ use pinocchio::{
 };
 use swig_assertions::*;
 use swig_state::{
-    action::{all::All, sub_account::SubAccount, ActionLoader, Actionable},
+    action::{
+        all::All, manage_authority::ManageAuthority, sub_account::SubAccount, ActionLoader,
+        Actionable,
+    },
     authority::AuthorityType,
     role::RoleMut,
     swig::Swig,
@@ -165,8 +168,8 @@ pub fn toggle_sub_account_v1(
             }
             let mut role = role_opt.unwrap();
             authenticate_authority(&mut role, all_accounts, &toggle_sub_account)?;
-            let all_action = role.get_action::<All>(&[])?;
-            if all_action.is_none() {
+            let manage_authority_action = role.get_action::<ManageAuthority>(&[])?;
+            if manage_authority_action.is_none() {
                 return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
             }
 

--- a/program/tests/all_but_manage_authority_test.rs
+++ b/program/tests/all_but_manage_authority_test.rs
@@ -1193,7 +1193,7 @@ fn test_all_but_manage_authority_cannot_toggle_sub_account() {
         restricted_authority.pubkey(),
         sub_account,
         restricted_role_id,
-        None,
+        restricted_role_id,
         false, // disable
     )
     .unwrap();

--- a/program/tests/all_but_manage_authority_test.rs
+++ b/program/tests/all_but_manage_authority_test.rs
@@ -1193,6 +1193,7 @@ fn test_all_but_manage_authority_cannot_toggle_sub_account() {
         restricted_authority.pubkey(),
         sub_account,
         restricted_role_id,
+        None,
         false, // disable
     )
     .unwrap();

--- a/program/tests/common/mod.rs
+++ b/program/tests/common/mod.rs
@@ -540,6 +540,7 @@ pub fn toggle_sub_account(
     sub_account: &Pubkey,
     authority: &Keypair,
     role_id: u32,
+    auth_role_id: Option<u32>,
     enabled: bool,
 ) -> anyhow::Result<TransactionMetadata> {
     // Create the instruction to toggle a sub-account
@@ -549,6 +550,7 @@ pub fn toggle_sub_account(
         authority.pubkey(),
         *sub_account,
         role_id,
+        auth_role_id,
         enabled,
     )
     .map_err(|e| anyhow::anyhow!("Failed to create toggle sub-account instruction: {:?}", e))?;

--- a/program/tests/common/mod.rs
+++ b/program/tests/common/mod.rs
@@ -540,7 +540,7 @@ pub fn toggle_sub_account(
     sub_account: &Pubkey,
     authority: &Keypair,
     role_id: u32,
-    auth_role_id: Option<u32>,
+    auth_role_id: u32,
     enabled: bool,
 ) -> anyhow::Result<TransactionMetadata> {
     // Create the instruction to toggle a sub-account

--- a/program/tests/sub_account_test.rs
+++ b/program/tests/sub_account_test.rs
@@ -520,9 +520,9 @@ fn test_toggle_sub_account_with_auth_role_id() {
         &mut context,
         &swig_key,
         &sub_account,
-        &root_authority,
+        &manage_authority,
         role_id,
-        root_role_id,
+        manage_authority_role_id,
         false, // disabled
     )
     .unwrap();
@@ -588,9 +588,9 @@ fn test_toggle_sub_account_with_auth_role_id() {
         &mut context,
         &swig_key,
         &sub_account,
-        &manage_authority,
+        &root_authority,
         role_id,
-        manage_authority_role_id,
+        root_role_id,
         true, // enabled
     );
 
@@ -604,9 +604,9 @@ fn test_toggle_sub_account_with_auth_role_id() {
         &mut context,
         &swig_key,
         &sub_account,
-        &root_authority,
+        &manage_authority,
         role_id,
-        root_role_id,
+        manage_authority_role_id,
         true, // enabled
     )
     .unwrap();

--- a/program/tests/sub_account_test.rs
+++ b/program/tests/sub_account_test.rs
@@ -342,7 +342,7 @@ fn test_toggle_sub_account() {
         &sub_account,
         &sub_account_authority,
         role_id,
-        None,
+        1,
         false, // disabled
     )
     .unwrap();
@@ -410,7 +410,7 @@ fn test_toggle_sub_account() {
         &sub_account,
         &sub_account_authority,
         role_id,
-        None,
+        1,
         true, // enabled
     )
     .unwrap();
@@ -522,7 +522,7 @@ fn test_toggle_sub_account_with_auth_role_id() {
         &sub_account,
         &root_authority,
         role_id,
-        Some(root_role_id),
+        root_role_id,
         false, // disabled
     )
     .unwrap();
@@ -590,7 +590,7 @@ fn test_toggle_sub_account_with_auth_role_id() {
         &sub_account,
         &manage_authority,
         role_id,
-        Some(manage_authority_role_id),
+        manage_authority_role_id,
         true, // enabled
     );
 
@@ -606,7 +606,7 @@ fn test_toggle_sub_account_with_auth_role_id() {
         &sub_account,
         &root_authority,
         role_id,
-        Some(root_role_id),
+        root_role_id,
         true, // enabled
     )
     .unwrap();
@@ -719,7 +719,7 @@ fn test_non_root_authority_cannot_disable_sub_account() {
         &sub_account,
         &unauthorized_authority,
         2, // The authority exists but lacks permissions
-        None,
+        1,
         false, // disabled
     );
 

--- a/program/tests/sub_account_test.rs
+++ b/program/tests/sub_account_test.rs
@@ -504,6 +504,25 @@ fn test_toggle_sub_account_with_auth_role_id() {
     )
     .unwrap();
 
+    // let add a new role with sol permission
+    let sol_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&sol_authority.pubkey(), 1_000_000)
+        .unwrap();
+    let sol_authority_role_id = 3;
+    let sol_authority_role = add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: sol_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1000 })],
+    )
+    .unwrap();
+
     // Create the sub-account with the sub-account authority
     let role_id = 1; // The sub-account authority has role_id 1
     let root_role_id = 0;
@@ -588,9 +607,9 @@ fn test_toggle_sub_account_with_auth_role_id() {
         &mut context,
         &swig_key,
         &sub_account,
-        &root_authority,
+        &sol_authority,
         role_id,
-        root_role_id,
+        sol_authority_role_id,
         true, // enabled
     );
 

--- a/program/tests/sub_account_test.rs
+++ b/program/tests/sub_account_test.rs
@@ -342,6 +342,7 @@ fn test_toggle_sub_account() {
         &sub_account,
         &sub_account_authority,
         role_id,
+        None,
         false, // disabled
     )
     .unwrap();
@@ -409,6 +410,203 @@ fn test_toggle_sub_account() {
         &sub_account,
         &sub_account_authority,
         role_id,
+        None,
+        true, // enabled
+    )
+    .unwrap();
+
+    // Verify the sub-account is enabled by checking the SubAccount action
+    let swig_account_data = context.svm.get_account(&swig_key).unwrap();
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_account_data.data).unwrap();
+    let role = swig_with_roles.get_role(role_id).unwrap().unwrap();
+
+    // Find the SubAccount action and verify it's enabled
+    let mut cursor = 0;
+    let mut found_enabled_action = false;
+
+    for _i in 0..role.position.num_actions() {
+        let action_header =
+            unsafe { Action::load_unchecked(&role.actions[cursor..cursor + Action::LEN]) }.unwrap();
+        cursor += Action::LEN;
+
+        if action_header.permission().unwrap() == Permission::SubAccount {
+            let action_data = &role.actions[cursor..cursor + action_header.length() as usize];
+            let sub_account_action = unsafe { SubAccount::load_unchecked(action_data) }.unwrap();
+
+            if sub_account_action.sub_account == sub_account.to_bytes() {
+                assert!(sub_account_action.enabled, "Sub-account should be enabled");
+                found_enabled_action = true;
+                break;
+            }
+        }
+
+        cursor += action_header.length() as usize;
+    }
+
+    context.svm.warp_to_slot(1000);
+    context.svm.expire_blockhash();
+    // Now the transaction should succeed with the enabled sub-account
+    let transfer_amount = 1_000_000;
+    let transfer_ix =
+        system_instruction::transfer(&sub_account, &recipient.pubkey(), transfer_amount);
+
+    let sign_result = sub_account_sign(
+        &mut context,
+        &swig_key,
+        &sub_account,
+        &sub_account_authority,
+        role_id,
+        vec![transfer_ix],
+    )
+    .unwrap();
+
+    // Verify the funds were transferred
+    let recipient_balance = context
+        .svm
+        .get_account(&recipient.pubkey())
+        .unwrap()
+        .lamports;
+    assert_eq!(
+        recipient_balance,
+        1_000_000 + transfer_amount,
+        "Recipient's balance didn't increase by the correct amount"
+    );
+}
+
+// Test toggling a sub-account on and off
+#[test_log::test]
+fn test_toggle_sub_account_with_auth_role_id() {
+    let mut context = setup_test_context().unwrap();
+    let recipient = Keypair::new();
+    context.svm.warp_to_slot(1);
+    // Set up the test environment
+    let (swig_key, root_authority, sub_account_authority, id) =
+        setup_test_with_sub_account_authority(&mut context).unwrap();
+
+    context.svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
+
+    // add a new role to the swig account
+    let manage_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&manage_authority.pubkey(), 1_000_000)
+        .unwrap();
+    let manage_authority_role_id = 2;
+    let new_role = add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: manage_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    // Create the sub-account with the sub-account authority
+    let role_id = 1; // The sub-account authority has role_id 1
+    let root_role_id = 0;
+    let sub_account =
+        create_sub_account(&mut context, &swig_key, &sub_account_authority, role_id, id).unwrap();
+
+    // Fund the sub-account with some SOL
+    let initial_balance = 5_000_000_000;
+    context.svm.airdrop(&sub_account, initial_balance).unwrap();
+
+    // Disable the sub-account using the sub-account authority (which owns the
+    // SubAccount action)
+    let disable_result = toggle_sub_account(
+        &mut context,
+        &swig_key,
+        &sub_account,
+        &root_authority,
+        role_id,
+        Some(root_role_id),
+        false, // disabled
+    )
+    .unwrap();
+
+    // Verify the sub-account is disabled by checking the SubAccount action
+    let swig_account_data = context.svm.get_account(&swig_key).unwrap();
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_account_data.data).unwrap();
+    let role = swig_with_roles.get_role(role_id).unwrap().unwrap();
+
+    // Find the SubAccount action and verify it's disabled
+    let mut cursor = 0;
+    let mut found_disabled_action = false;
+
+    for _i in 0..role.position.num_actions() {
+        let action_header =
+            unsafe { Action::load_unchecked(&role.actions[cursor..cursor + Action::LEN]) }.unwrap();
+        cursor += Action::LEN;
+
+        if action_header.permission().unwrap() == Permission::SubAccount {
+            let action_data = &role.actions[cursor..cursor + action_header.length() as usize];
+            let sub_account_action = unsafe { SubAccount::load_unchecked(action_data) }.unwrap();
+
+            if sub_account_action.sub_account == sub_account.to_bytes() {
+                assert!(
+                    !sub_account_action.enabled,
+                    "Sub-account should be disabled"
+                );
+                found_disabled_action = true;
+                break;
+            }
+        }
+
+        cursor += action_header.length() as usize;
+    }
+
+    assert!(
+        found_disabled_action,
+        "SubAccount action not found or not disabled"
+    );
+
+    // Try to use the disabled sub-account - this should fail
+    let transfer_amount = 1_000_000;
+    let transfer_ix =
+        system_instruction::transfer(&sub_account, &recipient.pubkey(), transfer_amount);
+
+    let sign_result = sub_account_sign(
+        &mut context,
+        &swig_key,
+        &sub_account,
+        &sub_account_authority,
+        role_id,
+        vec![transfer_ix],
+    );
+
+    assert!(
+        sign_result.is_err(),
+        "Transaction should fail with disabled sub-account"
+    );
+    // warp ahead 10 slots
+    context.svm.warp_to_slot(10);
+    // Re-enable the sub-account using the sub-account authority
+    let enable_result = toggle_sub_account(
+        &mut context,
+        &swig_key,
+        &sub_account,
+        &manage_authority,
+        role_id,
+        Some(manage_authority_role_id),
+        true, // enabled
+    );
+
+    assert!(
+        enable_result.is_err(),
+        "Transaction should fail with toggling with non All authority"
+    );
+
+    // Re-enable the sub-account using the sub-account authority
+    let enable_result = toggle_sub_account(
+        &mut context,
+        &swig_key,
+        &sub_account,
+        &root_authority,
+        role_id,
+        Some(root_role_id),
         true, // enabled
     )
     .unwrap();
@@ -520,7 +718,8 @@ fn test_non_root_authority_cannot_disable_sub_account() {
         &swig_key,
         &sub_account,
         &unauthorized_authority,
-        2,     // The authority exists but lacks permissions
+        2, // The authority exists but lacks permissions
+        None,
         false, // disabled
     );
 

--- a/rust-sdk/src/client_role.rs
+++ b/rust-sdk/src/client_role.rs
@@ -126,6 +126,7 @@ pub trait ClientRole {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
+        auth_role_id: Option<u32>,
         enabled: bool,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError>;
@@ -385,6 +386,7 @@ impl ClientRole for Ed25519ClientRole {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
+        auth_role_id: Option<u32>,
         enabled: bool,
         _current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -395,6 +397,7 @@ impl ClientRole for Ed25519ClientRole {
                 payer,
                 sub_account,
                 role_id,
+                auth_role_id,
                 enabled,
             )?,
         ])
@@ -728,6 +731,7 @@ impl ClientRole for Secp256k1ClientRole {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
+        auth_role_id: Option<u32>,
         enabled: bool,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -741,6 +745,7 @@ impl ClientRole for Secp256k1ClientRole {
                 current_slot,
                 sub_account,
                 role_id,
+                auth_role_id,
                 enabled,
             )?,
         ])
@@ -1107,6 +1112,7 @@ impl ClientRole for Secp256r1ClientRole {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
+        auth_role_id: Option<u32>,
         enabled: bool,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -1121,6 +1127,7 @@ impl ClientRole for Secp256r1ClientRole {
             new_odometer,
             sub_account,
             role_id,
+            auth_role_id,
             enabled,
             &self.authority,
         )?;
@@ -1356,6 +1363,7 @@ impl ClientRole for Ed25519SessionClientRole {
         _payer: Pubkey,
         _sub_account: Pubkey,
         _role_id: u32,
+        _auth_role_id: Option<u32>,
         _enabled: bool,
         _current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -1630,6 +1638,7 @@ impl ClientRole for Secp256k1SessionClientRole {
         _payer: Pubkey,
         _sub_account: Pubkey,
         _role_id: u32,
+        _auth_role_id: Option<u32>,
         _enabled: bool,
         _current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -1909,6 +1918,7 @@ impl ClientRole for Secp256r1SessionClientRole {
         _payer: Pubkey,
         _sub_account: Pubkey,
         _role_id: u32,
+        _auth_role_id: Option<u32>,
         _enabled: bool,
         _current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {

--- a/rust-sdk/src/client_role.rs
+++ b/rust-sdk/src/client_role.rs
@@ -126,7 +126,7 @@ pub trait ClientRole {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError>;
@@ -386,7 +386,7 @@ impl ClientRole for Ed25519ClientRole {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
         _current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -731,7 +731,7 @@ impl ClientRole for Secp256k1ClientRole {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -1112,7 +1112,7 @@ impl ClientRole for Secp256r1ClientRole {
         payer: Pubkey,
         sub_account: Pubkey,
         role_id: u32,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -1363,7 +1363,7 @@ impl ClientRole for Ed25519SessionClientRole {
         _payer: Pubkey,
         _sub_account: Pubkey,
         _role_id: u32,
-        _auth_role_id: Option<u32>,
+        _auth_role_id: u32,
         _enabled: bool,
         _current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -1638,7 +1638,7 @@ impl ClientRole for Secp256k1SessionClientRole {
         _payer: Pubkey,
         _sub_account: Pubkey,
         _role_id: u32,
-        _auth_role_id: Option<u32>,
+        _auth_role_id: u32,
         _enabled: bool,
         _current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -1918,7 +1918,7 @@ impl ClientRole for Secp256r1SessionClientRole {
         _payer: Pubkey,
         _sub_account: Pubkey,
         _role_id: u32,
-        _auth_role_id: Option<u32>,
+        _auth_role_id: u32,
         _enabled: bool,
         _current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {

--- a/rust-sdk/src/instruction_builder.rs
+++ b/rust-sdk/src/instruction_builder.rs
@@ -508,6 +508,7 @@ impl SwigInstructionBuilder {
     pub fn toggle_sub_account(
         &self,
         sub_account: Pubkey,
+        auth_role_id: Option<u32>,
         enabled: bool,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {
@@ -516,6 +517,7 @@ impl SwigInstructionBuilder {
             self.payer,
             sub_account,
             self.role_id,
+            auth_role_id,
             enabled,
             current_slot,
         )

--- a/rust-sdk/src/instruction_builder.rs
+++ b/rust-sdk/src/instruction_builder.rs
@@ -508,7 +508,7 @@ impl SwigInstructionBuilder {
     pub fn toggle_sub_account(
         &self,
         sub_account: Pubkey,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError> {

--- a/rust-sdk/src/tests/ix_builder/sub_account_test.rs
+++ b/rust-sdk/src/tests/ix_builder/sub_account_test.rs
@@ -252,7 +252,7 @@ fn test_sub_account_functionality() {
 
     // Test toggling the sub-account (disable/enable)
     let toggle_ix = builder
-        .toggle_sub_account(sub_account, false, None)
+        .toggle_sub_account(sub_account, None, false, None)
         .unwrap();
 
     let msg = v0::Message::try_compile(

--- a/rust-sdk/src/tests/ix_builder/sub_account_test.rs
+++ b/rust-sdk/src/tests/ix_builder/sub_account_test.rs
@@ -252,7 +252,7 @@ fn test_sub_account_functionality() {
 
     // Test toggling the sub-account (disable/enable)
     let toggle_ix = builder
-        .toggle_sub_account(sub_account, None, false, None)
+        .toggle_sub_account(sub_account, 1, false, None)
         .unwrap();
 
     let msg = v0::Message::try_compile(

--- a/rust-sdk/src/tests/wallet/sub_accounts_test.rs
+++ b/rust-sdk/src/tests/wallet/sub_accounts_test.rs
@@ -287,12 +287,12 @@ fn test_sub_account_toggle_operations() {
 
     // Test toggle operations
     let signature = swig_wallet
-        .toggle_sub_account(sub_account, None, false)
+        .toggle_sub_account(sub_account, 1, false)
         .unwrap();
     println!("Disable signature: {:?}", signature);
 
     let signature = swig_wallet
-        .toggle_sub_account(sub_account, None, true)
+        .toggle_sub_account(sub_account, 1, true)
         .unwrap();
     println!("Enable signature: {:?}", signature);
 }
@@ -466,7 +466,7 @@ fn test_sub_account_error_cases() {
     ));
 
     // Try to toggle with unauthorized authority
-    let result = swig_wallet.toggle_sub_account(sub_account, None, false);
+    let result = swig_wallet.toggle_sub_account(sub_account, 1, false);
     assert!(matches!(
         result.unwrap_err(),
         SwigError::TransactionFailedWithLogs { .. }

--- a/rust-sdk/src/tests/wallet/sub_accounts_test.rs
+++ b/rust-sdk/src/tests/wallet/sub_accounts_test.rs
@@ -286,10 +286,14 @@ fn test_sub_account_toggle_operations() {
         .unwrap();
 
     // Test toggle operations
-    let signature = swig_wallet.toggle_sub_account(sub_account, false).unwrap();
+    let signature = swig_wallet
+        .toggle_sub_account(sub_account, None, false)
+        .unwrap();
     println!("Disable signature: {:?}", signature);
 
-    let signature = swig_wallet.toggle_sub_account(sub_account, true).unwrap();
+    let signature = swig_wallet
+        .toggle_sub_account(sub_account, None, true)
+        .unwrap();
     println!("Enable signature: {:?}", signature);
 }
 
@@ -462,7 +466,7 @@ fn test_sub_account_error_cases() {
     ));
 
     // Try to toggle with unauthorized authority
-    let result = swig_wallet.toggle_sub_account(sub_account, false);
+    let result = swig_wallet.toggle_sub_account(sub_account, None, false);
     assert!(matches!(
         result.unwrap_err(),
         SwigError::TransactionFailedWithLogs { .. }

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -582,11 +582,13 @@ impl<'c> SwigWallet<'c> {
     pub fn toggle_sub_account(
         &mut self,
         sub_account: Pubkey,
+        auth_role_id: Option<u32>,
         enabled: bool,
     ) -> Result<Signature, SwigError> {
         let current_slot = self.get_current_slot()?;
         let toggle_instructions = self.instruction_builder.toggle_sub_account(
             sub_account,
+            auth_role_id,
             enabled,
             Some(current_slot),
         )?;

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -582,7 +582,7 @@ impl<'c> SwigWallet<'c> {
     pub fn toggle_sub_account(
         &mut self,
         sub_account: Pubkey,
-        auth_role_id: Option<u32>,
+        auth_role_id: u32,
         enabled: bool,
     ) -> Result<Signature, SwigError> {
         let current_slot = self.get_current_slot()?;


### PR DESCRIPTION
https://github.com/anagrambuild/swig-wallet/blob/bdb161e2e5805e26793bb109820310a1ab5aac90/program/src/actions/toggle_sub_account_v1.rs#L191-L200

- Here if an role with ALL permission is trying to disable the sub accounts, it fails. Inside this else part, it only returns Error.
- In prev impl, there was a check if a role trying to change it, has sub account permission or all, then toggle it. 
- The current implementation adds new arg param for _auth_role_id_ which will be used to point to the roles with ALL action permission. This can also be extended to other actions if needed.

Note: The Test case will fail for the rust SDK as there is another PR which is handling it https://github.com/anagrambuild/swig-wallet/pull/86