### PR TITLE
fix: correct swig v1 and v2 detection

### DIFF
--- a/program/src/actions/sign_v1.rs
+++ b/program/src/actions/sign_v1.rs
@@ -269,6 +269,10 @@ pub fn sign_v1(
 
         let hash = match account_classifier {
             AccountClassification::ThisSwig { .. } | AccountClassification::ThisSwigV2 { .. } => {
+                // For ThisSwig accounts, hash the entire account data and owner to ensure no
+                // unexpected modifications. Lamports are handled separately in
+                // the permission check, but we still need to verify
+                // that the account data itself and ownership hasn't been tampered with
                 let data = unsafe { account.borrow_data_unchecked() };
                 let hash = hash_except(&data, account.owner(), NO_EXCLUDE_RANGES);
                 Some(hash)

--- a/program/src/actions/sign_v1.rs
+++ b/program/src/actions/sign_v1.rs
@@ -180,8 +180,14 @@ pub fn sign_v1(
 ) -> ProgramResult {
     check_stack_height(1, SwigError::Cpi)?;
 
-    if !matches!(account_classifiers[0], AccountClassification::ThisSwig { .. }) {
-        if matches!(account_classifiers[0], AccountClassification::ThisSwigV2 { .. }) {
+    if !matches!(
+        account_classifiers[0],
+        AccountClassification::ThisSwig { .. }
+    ) {
+        if matches!(
+            account_classifiers[0],
+            AccountClassification::ThisSwigV2 { .. }
+        ) {
             return Err(SwigError::SignV1CannotBeUsedWithSwigV2.into());
         }
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());

--- a/program/src/actions/sign_v1.rs
+++ b/program/src/actions/sign_v1.rs
@@ -179,8 +179,14 @@ pub fn sign_v1(
     account_classifiers: &mut [AccountClassification],
 ) -> ProgramResult {
     check_stack_height(1, SwigError::Cpi)?;
-    // KEEP remove since we enfoce swig is owned in lib.rs
-    // check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
+
+    if !matches!(account_classifiers[0], AccountClassification::ThisSwig { .. }) {
+        if matches!(account_classifiers[0], AccountClassification::ThisSwigV2 { .. }) {
+            return Err(SwigError::SignV1CannotBeUsedWithSwigV2.into());
+        }
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+
     let sign_v1 = SignV1::from_instruction_bytes(data)?;
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
     if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
@@ -256,12 +262,8 @@ pub fn sign_v1(
         }
 
         let hash = match account_classifier {
-            AccountClassification::ThisSwig { .. } => {
+            AccountClassification::ThisSwig { .. } | AccountClassification::ThisSwigV2 { .. } => {
                 let data = unsafe { account.borrow_data_unchecked() };
-                // For ThisSwig accounts, hash the entire account data and owner to ensure no
-                // unexpected modifications. Lamports are handled separately in
-                // the permission check, but we still need to verify
-                // that the account data itself and ownership hasn't been tampered with
                 let hash = hash_except(&data, account.owner(), NO_EXCLUDE_RANGES);
                 Some(hash)
             },
@@ -425,10 +427,10 @@ pub fn sign_v1(
     } else {
         'account_loop: for (index, account) in account_classifiers.iter_mut().enumerate() {
             match account {
-                AccountClassification::ThisSwig { lamports } => {
+                AccountClassification::ThisSwig { lamports }
+                | AccountClassification::ThisSwigV2 { lamports } => {
                     let account_info = unsafe { all_accounts.get_unchecked(index) };
 
-                    // Only validate snapshots for writable accounts
                     if account_info.is_writable() {
                         let data = unsafe { &account_info.borrow_data_unchecked() };
                         let current_hash =

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -178,14 +178,23 @@ pub fn sign_v2(
 ) -> ProgramResult {
     check_stack_height(1, SwigError::Cpi)?;
 
-    if !matches!(account_classifiers[0], AccountClassification::ThisSwigV2 { .. }) {
-        if matches!(account_classifiers[0], AccountClassification::ThisSwig { .. }) {
+    if !matches!(
+        account_classifiers[0],
+        AccountClassification::ThisSwigV2 { .. }
+    ) {
+        if matches!(
+            account_classifiers[0],
+            AccountClassification::ThisSwig { .. }
+        ) {
             return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
         }
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
 
-    if !matches!(account_classifiers[1], AccountClassification::SwigWalletAddress) {
+    if !matches!(
+        account_classifiers[1],
+        AccountClassification::SwigWalletAddress
+    ) {
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
 

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -260,6 +260,10 @@ pub fn sign_v2(
 
         let hash = match account_classifier {
             AccountClassification::ThisSwig { .. } | AccountClassification::ThisSwigV2 { .. } => {
+                // For ThisSwig accounts, hash the entire account data and owner to ensure no
+                // unexpected modifications. Lamports are handled separately in
+                // the permission check, but we still need to verify
+                // that the account data itself and ownership hasn't been tampered with
                 let data = unsafe { account.borrow_data_unchecked() };
                 let hash = hash_except(&data, account.owner(), NO_EXCLUDE_RANGES);
                 Some(hash)

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -177,8 +177,18 @@ pub fn sign_v2(
     account_classifiers: &mut [AccountClassification],
 ) -> ProgramResult {
     check_stack_height(1, SwigError::Cpi)?;
-    // KEEP remove since we enfoce swig is owned in lib.rs
-    // check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
+
+    if !matches!(account_classifiers[0], AccountClassification::ThisSwigV2 { .. }) {
+        if matches!(account_classifiers[0], AccountClassification::ThisSwig { .. }) {
+            return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
+        }
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+
+    if !matches!(account_classifiers[1], AccountClassification::SwigWalletAddress) {
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+
     let sign_v2 = SignV2::from_instruction_bytes(data)?;
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
     if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
@@ -240,12 +250,8 @@ pub fn sign_v2(
         }
 
         let hash = match account_classifier {
-            AccountClassification::ThisSwig { .. } => {
+            AccountClassification::ThisSwig { .. } | AccountClassification::ThisSwigV2 { .. } => {
                 let data = unsafe { account.borrow_data_unchecked() };
-                // For ThisSwig accounts, hash the entire account data and owner to ensure no
-                // unexpected modifications. Lamports are handled separately in
-                // the permission check, but we still need to verify
-                // that the account data itself and ownership hasn't been tampered with
                 let hash = hash_except(&data, account.owner(), NO_EXCLUDE_RANGES);
                 Some(hash)
             },
@@ -418,10 +424,10 @@ pub fn sign_v2(
     } else {
         'account_loop: for (index, account) in account_classifiers.iter_mut().enumerate() {
             match account {
-                AccountClassification::ThisSwig { lamports } => {
+                AccountClassification::ThisSwig { lamports }
+                | AccountClassification::ThisSwigV2 { lamports } => {
                     let account_info = unsafe { all_accounts.get_unchecked(index) };
 
-                    // Only validate snapshots for writable accounts
                     if account_info.is_writable() {
                         let data = unsafe { &account_info.borrow_data_unchecked() };
                         let current_hash =

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -112,6 +112,10 @@ pub enum SwigError {
     AccountDataModifiedUnexpectedly,
     /// Cannot update root authority (ID 0)
     PermissionDeniedCannotUpdateRootAuthority,
+    /// SignV1 instruction cannot be used with Swig v2 accounts
+    SignV1CannotBeUsedWithSwigV2,
+    /// SignV2 instruction cannot be used with Swig v1 accounts
+    SignV2CannotBeUsedWithSwigV1,
 }
 
 /// Implements conversion from SwigError to ProgramError.

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -181,7 +181,8 @@ unsafe fn execute(
     if let Ok(acc) = ctx.next_account() {
         match acc {
             MaybeAccount::Account(account) => {
-                let classification = classify_account(0, &account, accounts, account_classification, None)?;
+                let classification =
+                    classify_account(0, &account, accounts, account_classification, None)?;
                 account_classification[0].write(classification);
                 accounts[0].write(account);
             },
@@ -214,12 +215,22 @@ unsafe fn execute(
     // Process remaining accounts using the cache
     while let Ok(acc) = ctx.next_account() {
         let classification = match &acc {
-            MaybeAccount::Account(account) => {
-                classify_account(index, account, accounts, account_classification, program_scope_cache.as_ref())?
-            },
+            MaybeAccount::Account(account) => classify_account(
+                index,
+                account,
+                accounts,
+                account_classification,
+                program_scope_cache.as_ref(),
+            )?,
             MaybeAccount::Duplicated(account_index) => {
                 let account = accounts[*account_index as usize].assume_init_ref().clone();
-                classify_account(index, &account, accounts, account_classification, program_scope_cache.as_ref())?
+                classify_account(
+                    index,
+                    &account,
+                    accounts,
+                    account_classification,
+                    program_scope_cache.as_ref(),
+                )?
             },
         };
         account_classification[index].write(classification);
@@ -387,7 +398,8 @@ unsafe fn classify_account(
             ) == 0;
 
             let matches_swig_wallet_address = if index > 1 {
-                // Only check wallet address if account[1] is actually classified as SwigWalletAddress
+                // Only check wallet address if account[1] is actually classified as
+                // SwigWalletAddress
                 if matches!(
                     account_classifications.get_unchecked(1).assume_init_ref(),
                     AccountClassification::SwigWalletAddress

--- a/program/tests/action_tests.rs
+++ b/program/tests/action_tests.rs
@@ -109,6 +109,7 @@ fn test_multiple_actions_with_transfer_and_manage_authority() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context

--- a/program/tests/all_but_manage_authority_test.rs
+++ b/program/tests/all_but_manage_authority_test.rs
@@ -57,6 +57,7 @@ fn test_all_but_manage_authority_can_transfer_sol() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -175,6 +176,7 @@ fn test_all_but_manage_authority_can_transfer_tokens() {
     .unwrap();
 
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
     assert!(swig_create_txn.is_ok());
 
     let second_authority = Keypair::new();
@@ -296,6 +298,7 @@ fn test_all_but_manage_authority_can_do_cpi_calls() {
 
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
     assert!(swig_create_txn.is_ok());
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context

--- a/program/tests/common/mod.rs
+++ b/program/tests/common/mod.rs
@@ -30,6 +30,26 @@ pub fn program_id() -> Pubkey {
     swig::ID.into()
 }
 
+pub fn convert_swig_to_v1(context: &mut SwigTestContext, swig_pubkey: &Pubkey) {
+    use swig_state::swig::Swig;
+
+    let mut account = context
+        .svm
+        .get_account(swig_pubkey)
+        .expect("Swig account should exist");
+
+    if account.data.len() >= Swig::LEN {
+        let last_8_start = Swig::LEN - 8;
+        let reserved_lamports: u64 = 256;
+        account.data[last_8_start..Swig::LEN].copy_from_slice(&reserved_lamports.to_le_bytes());
+    }
+
+    context
+        .svm
+        .set_account(swig_pubkey.clone(), account)
+        .expect("Failed to update account");
+}
+
 pub fn add_authority_with_ed25519_root<'a>(
     context: &mut SwigTestContext,
     swig_pubkey: &Pubkey,

--- a/program/tests/cpi_program_permission_test.rs
+++ b/program/tests/cpi_program_permission_test.rs
@@ -41,6 +41,7 @@ fn test_cpi_signing_requires_program_permission() {
     // Create swig account with ed25519 authority
     let (_, _transaction_metadata) =
         create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     // Add a second authority with Program permission for system program
     let second_authority = Keypair::new();
@@ -197,6 +198,7 @@ fn test_cpi_signing_without_program_permission_fails() {
     // Create swig account with ed25519 authority
     let (_, _transaction_metadata) =
         create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     // Add a second authority with NO Program permission
     let second_authority = Keypair::new();
@@ -286,6 +288,7 @@ fn test_cpi_signing_with_program_all_permission() {
     // Create swig account with ed25519 authority
     let (_, _transaction_metadata) =
         create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     // Add a second authority with ProgramAll permission
     let second_authority = Keypair::new();
@@ -375,6 +378,7 @@ fn test_cpi_signing_with_program_curated_permission() {
     // Create swig account with ed25519 authority
     let (_, _transaction_metadata) =
         create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     // Add a second authority with ProgramCurated permission
     let second_authority = Keypair::new();

--- a/program/tests/create_session_test.rs
+++ b/program/tests/create_session_test.rs
@@ -41,6 +41,7 @@ fn test_create_session() {
     // Create a swig with ed25519session authority type
     let (swig_key, res) =
         create_swig_ed25519_session(&mut context, &swig_authority, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     println!("res: {:?}", res.logs);
     // Airdrop funds to the swig account so it can transfer SOL
@@ -173,6 +174,7 @@ fn test_expired_session() {
     // Create a swig with ed25519session authority type
     let (swig_key, _) =
         create_swig_ed25519_session(&mut context, &swig_authority, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     // Airdrop funds to the swig account so it can transfer SOL
     context.svm.airdrop(&swig_key, 50_000_000_000).unwrap();
@@ -275,6 +277,7 @@ fn test_session_key_refresh_ed25519() {
     // Create a swig with ed25519session authority type
     let (swig_key, _) =
         create_swig_ed25519_session(&mut context, &swig_authority, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     // Airdrop funds to the swig account so it can transfer SOL
     context.svm.airdrop(&swig_key, 50_000_000_000).unwrap();
@@ -435,6 +438,7 @@ fn test_transfer_sol_with_session() {
     // Create a swig with ed25519session authority type
     let (swig_key, _) =
         create_swig_ed25519_session(&mut context, &swig_authority, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     // Airdrop funds to the swig account so it can transfer SOL
     let initial_swig_balance = 50_000_000_000;
@@ -565,6 +569,7 @@ fn test_secp256k1_session() {
     // Create a swig with secp256k1 session authority type
     let (swig_key, res) =
         create_swig_secp256k1_session(&mut context, &wallet, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     println!("res: {:?}", res.logs);
     // Airdrop funds to the swig account so it can transfer SOL
@@ -712,6 +717,7 @@ fn test_session_key_refresh_secp256k1() {
     // Create a swig with secp256k1 session authority type
     let (swig_key, _) =
         create_swig_secp256k1_session(&mut context, &wallet, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     // Airdrop funds to the swig account
     context.svm.airdrop(&swig_key, 50_000_000_000).unwrap();
@@ -829,6 +835,7 @@ fn test_session_extension_before_expiration() {
     // Create a swig with ed25519session authority type
     let (swig_key, _) =
         create_swig_ed25519_session(&mut context, &swig_authority, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     context.svm.airdrop(&swig_key, 50_000_000_000).unwrap();
 
@@ -958,6 +965,7 @@ fn test_multiple_session_refreshes() {
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) =
         create_swig_ed25519_session(&mut context, &swig_authority, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 50_000_000_000).unwrap();
 
     let session_key = Keypair::new();

--- a/program/tests/create_test.rs
+++ b/program/tests/create_test.rs
@@ -87,6 +87,7 @@ fn test_create_basic_token_transfer() {
     .unwrap();
 
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
     assert!(swig_create_txn.is_ok());
 
     let ixd = Instruction {
@@ -141,6 +142,7 @@ fn test_create_and_sign_secp256k1() {
     let swig_created = create_swig_secp256k1(&mut context, &wallet, id);
     assert!(swig_created.is_ok(), "{:?}", swig_created.err());
     let (swig_key, bench) = swig_created.unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     println!("Create CU {:?}", bench.compute_units_consumed);
     println!("logs: {:?}", bench.logs);
     if let Some(account) = context.svm.get_account(&swig_key) {

--- a/program/tests/program_scope_test.rs
+++ b/program/tests/program_scope_test.rs
@@ -63,6 +63,8 @@ fn test_token_transfer_with_program_scope() {
     let swig_create_result = create_swig_ed25519(&mut context, &swig_authority, id);
     assert!(swig_create_result.is_ok());
 
+    convert_swig_to_v1(&mut context, &swig);
+
     // Setup token accounts
     let swig_ata = setup_ata(
         &mut context.svm,
@@ -234,7 +236,7 @@ fn test_token_transfer_with_program_scope() {
         "Account difference (swig - regular): {} accounts",
         account_difference
     );
-    assert!(swig_transfer_cu - regular_transfer_cu <= 5633);
+    assert!(swig_transfer_cu - regular_transfer_cu <= 5800);
 }
 
 /// Helper function to perform token transfers through the swig
@@ -481,6 +483,8 @@ fn test_recurring_limit_program_scope() {
     let swig_create_result = create_swig_ed25519(&mut context, &swig_authority, id);
     println!("sig_create_result: {:?}", swig_create_result);
     assert!(swig_create_result.is_ok());
+
+    convert_swig_to_v1(&mut context, &swig);
 
     // Expire the blockhash after swig creation
     context.svm.expire_blockhash();
@@ -1007,6 +1011,8 @@ fn test_program_scope_balance_underflow_check() {
     let id = rand::random::<[u8; 32]>();
     let (swig, _) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
     create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    convert_swig_to_v1(&mut context, &swig);
 
     // Setup token accounts
     let swig_ata = setup_ata(

--- a/program/tests/sign.rs
+++ b/program/tests/sign.rs
@@ -90,6 +90,7 @@ fn test_transfer_sol_with_additional_authority() {
     context.svm.airdrop(&swig, 10_000_000_000).unwrap();
     context.svm.warp_to_slot(100);
 
+    convert_swig_to_v1(&mut context, &swig);
     let ixd = system_instruction::transfer(&swig, &recipient.pubkey(), amount / 2);
     let sign_ix = swig_interface::SignInstruction::new_ed25519(
         swig,
@@ -154,6 +155,7 @@ fn test_transfer_sol_all_with_authority() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -260,6 +262,7 @@ fn test_transfer_sol_and_tokens_with_mixed_permissions() {
 
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
     assert!(swig_create_txn.is_ok());
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -373,6 +376,7 @@ fn test_fail_transfer_sol_with_additional_authority_not_enough() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
     let second_authority = Keypair::new();
     context
         .svm
@@ -441,6 +445,7 @@ fn fail_not_correct_authority() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
     let second_authority = Keypair::new();
     context
         .svm
@@ -534,6 +539,7 @@ fn fail_wrong_resource() {
 
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id);
     assert!(swig_create_txn.is_ok());
+    convert_swig_to_v1(&mut context, &swig);
     let second_authority = Keypair::new();
     context
         .svm
@@ -608,6 +614,7 @@ fn test_transfer_sol_with_recurring_limit() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -766,6 +773,7 @@ fn test_transfer_sol_with_recurring_limit_window_reset() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -928,6 +936,7 @@ fn test_transfer_token_with_recurring_limit() {
     .unwrap();
 
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -1132,6 +1141,7 @@ fn test_transfer_between_swig_accounts() {
         sender_create_result.is_ok(),
         "Failed to create sender Swig account"
     );
+    convert_swig_to_v1(&mut context, &sender_swig);
 
     let recipient_create_result =
         create_swig_ed25519(&mut context, &recipient_authority, recipient_id);
@@ -1139,6 +1149,7 @@ fn test_transfer_between_swig_accounts() {
         recipient_create_result.is_ok(),
         "Failed to create recipient Swig account"
     );
+    convert_swig_to_v1(&mut context, &recipient_swig);
 
     // Fund the sender Swig account
     context.svm.airdrop(&sender_swig, 5_000_000_000).unwrap();
@@ -1213,6 +1224,7 @@ fn test_sol_limit_cpi_enforcement() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -1373,6 +1385,7 @@ fn test_sol_limit_cpi_enforcement_no_sol_limit() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -1580,6 +1593,7 @@ fn test_token_limit_cpi_enforcement() {
     .unwrap();
 
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -1854,6 +1868,7 @@ fn test_multiple_token_limits_cpi_enforcement() {
     }
 
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context

--- a/program/tests/sign.rs
+++ b/program/tests/sign.rs
@@ -23,8 +23,9 @@ use swig::actions::sign_v1::SignV1Args;
 use swig_interface::{compact_instructions, AuthorityConfig, ClientAction};
 use swig_state::{
     action::{
-        all::All, program::Program, sol_limit::SolLimit, sol_recurring_limit::SolRecurringLimit,
-        token_limit::TokenLimit, token_recurring_limit::TokenRecurringLimit,
+        all::All, program::Program, program_all::ProgramAll, sol_limit::SolLimit,
+        sol_recurring_limit::SolRecurringLimit, token_limit::TokenLimit,
+        token_recurring_limit::TokenRecurringLimit,
     },
     authority::AuthorityType,
     swig::{swig_account_seeds, SwigWithRoles},
@@ -2140,5 +2141,110 @@ fn test_multiple_token_limits_cpi_enforcement() {
     println!(
         "✅ This demonstrates that the SWIG wallet properly handles complex multi-token attack \
          scenarios."
+    );
+}
+
+#[test_log::test]
+fn test_token_transfer_through_secondary_authority() {
+    let mut context = setup_test_context().unwrap();
+
+    let swig_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    // Create wallet and setup
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    convert_swig_to_v1(&mut context, &swig_key);
+
+    let recipient = Keypair::new();
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_key,
+        &context.default_payer,
+    )
+    .unwrap();
+    let recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &recipient.pubkey(),
+        &recipient,
+    )
+    .unwrap();
+    mint_to(
+        &mut context.svm,
+        &mint_pubkey,
+        &context.default_payer,
+        &swig_ata,
+        1000,
+    )
+    .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: recipient.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::TokenLimit(TokenLimit {
+                token_mint: mint_pubkey.to_bytes(),
+                current_amount: 600_000_000,
+            }),
+            ClientAction::ProgramAll(ProgramAll {}),
+        ],
+    )
+    .unwrap();
+
+    // create transaction
+    let ixd = Instruction {
+        program_id: spl_token::id(),
+        accounts: vec![
+            AccountMeta::new(swig_ata, false),
+            AccountMeta::new(recipient_ata, false),
+            AccountMeta::new(swig_key, false),
+        ],
+        data: TokenInstruction::Transfer { amount: 100 }.pack(),
+    };
+
+    let mut sign_ix = swig_interface::SignInstruction::new_ed25519(
+        swig_key,
+        recipient.pubkey(),
+        recipient.pubkey(),
+        ixd,
+        1,
+    )
+    .unwrap();
+
+    println!("sign_ix: {:?}", sign_ix.data);
+
+    let message = v0::Message::try_compile(
+        &recipient.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(message), &[&recipient]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    println!("result: {:?}", result);
+    assert!(result.is_ok(), "Transfer below limit should succeed");
+    println!(
+        "Compute units consumed for below limit transfer: {}",
+        result.unwrap().compute_units_consumed
     );
 }

--- a/program/tests/sign_performance_test.rs
+++ b/program/tests/sign_performance_test.rs
@@ -50,6 +50,7 @@ fn test_token_transfer_performance_comparison() {
     let id = rand::random::<[u8; 32]>();
     let (swig, _) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
     let swig_create_result = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
     assert!(swig_create_result.is_ok());
 
     // Setup token accounts
@@ -190,7 +191,7 @@ fn test_token_transfer_performance_comparison() {
     );
     // 3744 is the max difference in CU between the two transactions lets lower
     // this as far as possible but never increase it
-    assert!(swig_transfer_cu - regular_transfer_cu <= 3805);
+    assert!(swig_transfer_cu - regular_transfer_cu <= 3851);
 }
 
 #[test_log::test]
@@ -218,6 +219,7 @@ fn test_sol_transfer_performance_comparison() {
     let id = rand::random::<[u8; 32]>();
     let (swig, _) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
     let swig_create_result = create_swig_ed25519(&mut context, &swig_authority, id);
+    convert_swig_to_v1(&mut context, &swig);
     assert!(swig_create_result.is_ok());
 
     context.svm.airdrop(&swig, initial_sol_amount).unwrap();
@@ -303,5 +305,5 @@ fn test_sol_transfer_performance_comparison() {
 
     // Set a reasonable limit for the CU difference to avoid regressions
     // Similar to the token transfer test assertion
-    assert!(swig_transfer_cu - regular_transfer_cu <= 2032);
+    assert!(swig_transfer_cu - regular_transfer_cu <= 2196);
 }

--- a/program/tests/sign_performance_v2_test.rs
+++ b/program/tests/sign_performance_v2_test.rs
@@ -314,5 +314,5 @@ fn test_sol_transfer_performance_comparison_v2() {
 
     // SignV2 uses more CU than SignV1 due to additional account handling
     // Set a reasonable limit for SignV2 SOL transfers to avoid regressions
-    assert!(swig_transfer_cu - regular_transfer_cu <= 3250);
+    assert!(swig_transfer_cu - regular_transfer_cu <= 3295);
 }

--- a/program/tests/sign_performance_v2_test.rs
+++ b/program/tests/sign_performance_v2_test.rs
@@ -190,9 +190,7 @@ fn test_token_transfer_performance_comparison_v2() {
         "Account difference (swig - regular): {} accounts",
         account_difference
     );
-    // SignV2 uses slightly more CU than SignV1 due to additional account handling
-    // Set a reasonable limit for SignV2 token transfers to avoid regressions
-    assert!(swig_transfer_cu - regular_transfer_cu <= 3850);
+    assert!(swig_transfer_cu - regular_transfer_cu <= 3798);
 }
 
 #[test_log::test]
@@ -312,7 +310,5 @@ fn test_sol_transfer_performance_comparison_v2() {
         account_difference
     );
 
-    // SignV2 uses more CU than SignV1 due to additional account handling
-    // Set a reasonable limit for SignV2 SOL transfers to avoid regressions
-    assert!(swig_transfer_cu - regular_transfer_cu <= 3295);
+    assert!(swig_transfer_cu - regular_transfer_cu <= 3253);
 }

--- a/program/tests/sign_secp256k1.rs
+++ b/program/tests/sign_secp256k1.rs
@@ -92,6 +92,7 @@ fn test_secp256k1_basic_signing() {
     // Create a new swig with the secp256k1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256k1(&mut context, &wallet, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up a recipient and transaction
@@ -161,6 +162,7 @@ fn test_secp256k1_direct_signature_reuse() {
     // Create a new swig with the secp256k1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256k1(&mut context, &wallet, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
     let payer2 = Keypair::new();
     context.svm.airdrop(&payer2.pubkey(), 1_000_000).unwrap();
@@ -331,6 +333,7 @@ fn test_secp256k1_compressed_key_creation() {
     // Test that we can create a swig with a compressed key
     let (swig_key, _) =
         create_swig_secp256k1_with_key_type(&mut context, &wallet, id, true).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     // If we get here, the compressed key creation succeeded
     assert!(true, "Compressed key creation should succeed");
@@ -347,6 +350,7 @@ fn test_secp256k1_compressed_key_full_signing_flow() {
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) =
         create_swig_secp256k1_with_key_type(&mut context, &wallet, id, true).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up a recipient and transaction
@@ -435,6 +439,7 @@ fn test_secp256k1_old_signature() {
     // Create a new swig with the secp256k1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256k1(&mut context, &wallet, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up a recipient and transaction
@@ -514,6 +519,7 @@ fn test_secp256k1_add_authority() {
 
     // Create a new swig with Ed25519 authority
     let (swig_key, _) = create_swig_ed25519(&mut context, &primary_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Read the account data to verify initial state
@@ -658,6 +664,7 @@ fn test_secp256k1_add_ed25519_authority() {
     // Create a new swig with the secp256k1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256k1(&mut context, &wallet, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Create an ed25519 authority to add
@@ -768,6 +775,7 @@ fn test_secp256k1_replay_scenario_1() {
     // Create a new swig with the secp256k1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256k1(&mut context, &wallet, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up a recipient and transaction
@@ -961,6 +969,7 @@ fn test_secp256k1_replay_scenario_2() {
     // Create a new swig with the secp256k1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256k1(&mut context, &wallet, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up a recipient and transaction
@@ -1069,6 +1078,7 @@ fn test_secp256k1_session_authority_odometer() {
     // Create a swig with secp256k1 session authority type
     let (swig_key, _) =
         create_swig_secp256k1_session(&mut context, &wallet, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     // Helper function to read the current counter for session authorities
     let get_session_counter = |ctx: &SwigTestContext| -> Result<u32, String> {

--- a/program/tests/sign_secp256r1.rs
+++ b/program/tests/sign_secp256r1.rs
@@ -103,6 +103,7 @@ fn test_secp256r1_basic_signing() {
     // Create a new swig with the secp256r1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up a recipient and transaction
@@ -198,6 +199,7 @@ fn test_secp256r1_counter_increment() {
     // Create a new swig with the secp256r1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Verify initial counter is 0
@@ -218,6 +220,7 @@ fn test_secp256r1_replay_protection() {
     // Create a new swig with the secp256r1 authority
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up transfer instruction
@@ -422,6 +425,7 @@ fn test_secp256r1_session_authority_odometer() {
     // Create a swig with secp256r1 session authority type using the helper function
     let (swig_key, _) =
         create_swig_secp256r1_session(&mut context, &public_key, id, 100, [0; 32]).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
 
     // Helper function to read the current counter for session authorities
     let get_session_counter = |ctx: &SwigTestContext| -> Result<u32, String> {
@@ -535,6 +539,7 @@ fn test_secp256r1_add_authority_with_secp256r1() {
 
     // Create a new swig with secp256r1 authority
     let (swig_key, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig_key);
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Create a second secp256r1 public key to add as a new authority

--- a/program/tests/sol_destination_limit.rs
+++ b/program/tests/sol_destination_limit.rs
@@ -46,6 +46,7 @@ fn test_sol_destination_limit_basic() {
 
     // Create SWIG wallet
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     // Add authority with destination-specific limit
     let second_authority = Keypair::new();
@@ -157,6 +158,7 @@ fn test_general_sol_limit_hit_before_destination_limit() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -253,6 +255,7 @@ fn test_destination_limit_hit_before_general_sol_limit() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -354,6 +357,7 @@ fn test_multiple_destination_limits() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -478,6 +482,7 @@ fn test_sol_destination_limit_exceeds_limit() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -565,6 +570,7 @@ fn test_sol_destination_limit_with_general_limit() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -661,6 +667,7 @@ fn test_sol_destination_limit_cpi_enforcement() {
     let id = rand::random::<[u8; 32]>();
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
     let swig_create_txn = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context

--- a/program/tests/sol_recurring_destination_limit.rs
+++ b/program/tests/sol_recurring_destination_limit.rs
@@ -48,6 +48,7 @@ fn test_sol_recurring_destination_limit_basic() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -145,6 +146,7 @@ fn test_sol_recurring_destination_limit_exceeds_limit() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -239,6 +241,7 @@ fn test_sol_recurring_destination_limit_time_reset() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -391,6 +394,7 @@ fn test_multiple_sol_recurring_destination_limits() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -524,6 +528,7 @@ fn test_sol_recurring_destination_limit_no_reset_when_exceeds_fresh() {
     let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context

--- a/program/tests/token_destination_limit.rs
+++ b/program/tests/token_destination_limit.rs
@@ -74,6 +74,7 @@ fn test_token_destination_limit_basic() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -236,6 +237,7 @@ fn test_token_destination_limit_exceeds_limit() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -398,6 +400,7 @@ fn test_multiple_token_destination_limits() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -687,6 +690,7 @@ fn test_token_destination_limit_different_mints() {
     );
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context

--- a/program/tests/token_recurring_destination_limit.rs
+++ b/program/tests/token_recurring_destination_limit.rs
@@ -74,6 +74,7 @@ fn test_token_recurring_destination_limit_basic() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -289,6 +290,7 @@ fn test_token_recurring_destination_limit_exceeds_limit() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -417,6 +419,7 @@ fn test_token_recurring_destination_limit_time_reset() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -619,6 +622,7 @@ fn test_multiple_token_recurring_destination_limits() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -799,6 +803,7 @@ fn test_token_recurring_destination_limit_no_reset_when_exceeds_fresh() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context
@@ -965,6 +970,7 @@ fn test_token_recurring_destination_limit_different_mints() {
     .unwrap();
 
     let (_, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
 
     let second_authority = Keypair::new();
     context

--- a/rust-sdk/src/tests/common/mod.rs
+++ b/rust-sdk/src/tests/common/mod.rs
@@ -16,7 +16,7 @@ use swig_state::{
     action::all::All,
     authority::AuthorityType,
     swig::{swig_account_seeds, swig_wallet_address_seeds, SwigWithRoles},
-    IntoBytes,
+    IntoBytes, Transmutable,
 };
 
 pub struct SwigTestContext {
@@ -433,4 +433,24 @@ pub fn create_swig_secp256r1_session(
         .map_err(|e| anyhow::anyhow!("Failed to send transaction {:?}", e))?;
 
     Ok((swig, bench))
+}
+
+pub fn convert_swig_to_v1(context: &mut SwigTestContext, swig_pubkey: &Pubkey) {
+    use swig_state::swig::Swig;
+
+    let mut account = context
+        .svm
+        .get_account(swig_pubkey)
+        .expect("Swig account should exist");
+
+    if account.data.len() >= Swig::LEN {
+        let last_8_start = Swig::LEN - 8;
+        let reserved_lamports: u64 = 256;
+        account.data[last_8_start..Swig::LEN].copy_from_slice(&reserved_lamports.to_le_bytes());
+    }
+
+    context
+        .svm
+        .set_account(swig_pubkey.clone(), account)
+        .expect("Failed to update account");
 }

--- a/rust-sdk/src/tests/ix_builder/program_scope_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/program_scope_tests.rs
@@ -51,6 +51,8 @@ fn test_token_transfer_with_program_scope() {
     let swig_create_result = create_swig_ed25519(&mut context, &swig_authority, id);
     assert!(swig_create_result.is_ok());
 
+    convert_swig_to_v1(&mut context, &swig);
+
     // Setup token accounts
     let swig_ata = setup_ata(
         &mut context.svm,
@@ -208,6 +210,8 @@ fn test_recurring_limit_program_scope() {
     let (swig, _) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
     let swig_create_result = create_swig_ed25519(&mut context, &swig_authority, id);
     assert!(swig_create_result.is_ok());
+
+    convert_swig_to_v1(&mut context, &swig);
 
     // Setup token accounts
     let swig_ata = setup_ata(

--- a/rust-sdk/src/tests/ix_builder/secp256r1_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/secp256r1_tests.rs
@@ -72,6 +72,9 @@ fn test_secp256r1_basic_signing() {
     );
 
     let swig_key = builder.get_swig_account().unwrap();
+
+    convert_swig_to_v1(&mut context, &swig_key);
+
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up a recipient and transaction
@@ -236,6 +239,9 @@ fn test_secp256r1_replay_protection() {
     );
 
     let swig_key = builder.get_swig_account().unwrap();
+
+    convert_swig_to_v1(&mut context, &swig_key);
+
     context.svm.airdrop(&swig_key, 10_000_000_000).unwrap();
 
     // Set up transfer instruction

--- a/rust-sdk/src/tests/ix_builder/sign_v1_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/sign_v1_tests.rs
@@ -47,6 +47,8 @@ fn test_sign_instruction_with_ed25519_authority() {
 
     let swig_key = builder.get_swig_account().unwrap();
 
+    convert_swig_to_v1(&mut context, &swig_key);
+
     // Fund the Swig account
     context.svm.airdrop(&swig_key, 1_000_000_000).unwrap();
 
@@ -142,6 +144,9 @@ fn test_sign_instruction_with_secp256k1_authority() {
     );
 
     let swig_key = builder.get_swig_account().unwrap();
+
+    convert_swig_to_v1(&mut context, &swig_key);
+
     context.svm.airdrop(&swig_key, 1_000_000_000).unwrap();
 
     let recipient = Keypair::new();

--- a/rust-sdk/src/tests/wallet/mod.rs
+++ b/rust-sdk/src/tests/wallet/mod.rs
@@ -88,8 +88,7 @@ fn create_test_wallet_with_version(
 }
 
 fn convert_wallet_to_v1(wallet: &mut SwigWallet) {
-    use swig_state::swig::Swig;
-    use swig_state::Transmutable;
+    use swig_state::{swig::Swig, Transmutable};
 
     let swig_key = wallet.get_swig();
 

--- a/rust-sdk/src/tests/wallet/sign_v2_tests.rs
+++ b/rust-sdk/src/tests/wallet/sign_v2_tests.rs
@@ -10,7 +10,7 @@ use crate::client_role::{Ed25519ClientRole, Secp256k1ClientRole, Secp256r1Client
 #[test_log::test]
 fn should_sign_v2_transfer_with_ed25519_within_limits() {
     let (mut litesvm, main_authority) = setup_test_environment();
-    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let mut swig_wallet = create_test_wallet_v2(litesvm, &main_authority);
 
     // Fund the swig wallet PDA
     let swig_wallet_address = swig_wallet.get_swig_wallet_address().unwrap();
@@ -37,7 +37,7 @@ fn should_sign_v2_fail_transfer_beyond_limits() {
         .airdrop(&secondary_authority.pubkey(), 10_000_000_000)
         .unwrap();
 
-    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let mut swig_wallet = create_test_wallet_v2(litesvm, &main_authority);
 
     // Add limited SOL permission and system program permission
     swig_wallet
@@ -83,7 +83,7 @@ fn should_sign_v2_fail_transfer_beyond_limits() {
 #[test_log::test]
 fn should_sign_v2_transfer_between_swig_accounts() {
     let (mut litesvm, main_authority) = setup_test_environment();
-    let mut sender_wallet = create_test_wallet(litesvm, &main_authority);
+    let mut sender_wallet = create_test_wallet_v2(litesvm, &main_authority);
 
     // Create a second swig wallet (different swig id) as recipient
     let other_auth = Keypair::new();
@@ -127,7 +127,7 @@ fn should_sign_v2_with_different_payer_and_authority() {
         .unwrap();
 
     // Create wallet with main authority, then switch payer
-    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let mut swig_wallet = create_test_wallet_v2(litesvm, &main_authority);
     swig_wallet.switch_payer(&different_payer).unwrap();
 
     // Fund PDA and transfer
@@ -147,7 +147,7 @@ fn should_sign_v2_with_different_payer_and_authority() {
 #[test_log::test]
 fn should_sign_v2_with_secp256k1_authority_transfers_sol() {
     let (mut litesvm, main_authority) = setup_test_environment();
-    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let mut swig_wallet = create_test_wallet_v2(litesvm, &main_authority);
 
     // Add secp256k1 authority with SOL and program permissions
     let wallet = LocalSigner::random();
@@ -210,7 +210,7 @@ fn should_sign_v2_secp256r1_transfer() {
     use crate::tests::common::create_test_secp256r1_keypair;
 
     let (mut litesvm, main_authority) = setup_test_environment();
-    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let mut swig_wallet = create_test_wallet_v2(litesvm, &main_authority);
 
     // Create secp256r1 authority and add
     let (signing_key, public_key) = create_test_secp256r1_keypair();
@@ -263,7 +263,7 @@ fn should_sign_v2_token_recurring_limit_enforced() {
     use crate::tests::common::{mint_to, setup_ata, setup_mint};
 
     let (mut litesvm, main_authority) = setup_test_environment();
-    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let mut swig_wallet = create_test_wallet_v2(litesvm, &main_authority);
 
     // Fund wallet PDA and mint tokens
     let swig_wallet_address = swig_wallet.get_swig_wallet_address().unwrap();

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -51,6 +51,13 @@ pub enum AccountClassification {
         /// The account's lamport balance
         lamports: u64,
     },
+    /// A main Swig v2 account with its lamport balance
+    ThisSwigV2 {
+        /// The account's lamport balance
+        lamports: u64,
+    },
+    /// A Swig wallet address account
+    SwigWalletAddress,
     /// A Swig token account with its token balance
     SwigTokenAccount {
         /// The token balance in the account


### PR DESCRIPTION
@santy311 identified an issue after creating the test case `test_token_transfer_through_secondary_authority`. Specifically, the second authority's token account was being incorrectly classified as a `SwigTokenAccount`. This causes an issue when trying to transfer from the swig token account -> second authority's token account.

This edge case revealed a different issue in how swig v1 and swig v2 accounts were being classified as well. The intention of SignV2 is to reject the use of any swig v1 account and SignV1 is to reject the use of any swig v2 account. 

This pull request:
- Removes reading instruction data before accounts, removing any undefined behavior that could result as a side effect
- Adds `SignV1CannotBeUsedWithSwigV2` & `SignV2CannotBeUsedWithSwigV1` error codes for cases where SwigV2 is used in a SignV1 instruction and when a SwigV1 is used with a SignV2 instruction
- Adds proper classification for a `SwigTokenAccount` for the case where additional authority token accounts are passed in but aren't owned by the `Swig` or `SwigWalletAddress`
- Adds `AccountClassification::ThisSwigV2` variant to correctly track `SwigV2` type accounts
- Adds `AccountClassification::SwigWalletAddress` variant to correct track `SwigWalletAddress` accounts when `SwigV2` case
- Adds a helper function `convert_swig_to_v1 ` for tests that use the old SwigV1 account struct to convert the created swig from the new SwigV2 to the old SwigV1, to ensure all existing tests using `SignV1` validate functionality as expected.

## CUs Impact
SignV1 and SignV2 instructions have a slight CU impact, with SignV2 being impacted in a negligible way compared to SignV1. This is due to the new classification at the start and the additional check in sign_v1 and sign_v2 instruction processors to reject the instruction if the wrong swig account type is used.

SignV1 cases:
- Token transfer: +46 CUs
- SOL transfer: +164 CUs

SignV2 cases:
- Token transfer: -52 CUs
- SOL Transfer: +3 CUs