### PR TITLE
fix: SignV2 wallet address rent check

### DIFF
--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -7,7 +7,6 @@ use core::mem::MaybeUninit;
 use no_padding::NoPadding;
 use pinocchio::{
     account_info::AccountInfo,
-    msg,
     program_error::ProgramError,
     pubkey::Pubkey,
     sysvars::{clock::Clock, Sysvar},
@@ -458,21 +457,24 @@ pub fn sign_v2(
                     let account_data = unsafe { account_info.borrow_data_unchecked() };
                     let rent_exempt_minimum =
                         pinocchio::sysvars::rent::Rent::get()?.minimum_balance(account_data.len());
-                    msg!("current_lamports: {}", current_lamports);
-                    msg!(
-                        "swig wallet balance: {}",
-                        ctx.accounts.swig_wallet_address.lamports()
-                    );
-                    msg!("rent_exempt_minimum: {}", rent_exempt_minimum);
-                    msg!(
-                        "wallet rent exempt minimum: {}",
-                        pinocchio::sysvars::rent::Rent::get()?
-                            .minimum_balance(ctx.accounts.swig_wallet_address.data_len())
-                    );
-                    if current_lamports < rent_exempt_minimum {
-                        return Err(
-                            SwigAuthenticateError::PermissionDeniedInsufficientBalance.into()
-                        );
+
+                    // Make sure that the withdrawal
+                    if matches!(account, AccountClassification::ThisSwigV2 { .. }) {
+                        let swig_wallet_balance = ctx.accounts.swig_wallet_address.lamports();
+                        let swig_wallet_rent_exempt_minimum =
+                            pinocchio::sysvars::rent::Rent::get()?
+                                .minimum_balance(ctx.accounts.swig_wallet_address.data_len());
+                        if swig_wallet_balance < swig_wallet_rent_exempt_minimum {
+                            return Err(
+                                SwigAuthenticateError::PermissionDeniedInsufficientBalance.into()
+                            );
+                        }
+                    } else if matches!(account, AccountClassification::ThisSwig { .. }) {
+                        if current_lamports < rent_exempt_minimum {
+                            return Err(
+                                SwigAuthenticateError::PermissionDeniedInsufficientBalance.into()
+                            );
+                        }
                     }
 
                     if total_sol_spent > 0 {

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -7,6 +7,7 @@ use core::mem::MaybeUninit;
 use no_padding::NoPadding;
 use pinocchio::{
     account_info::AccountInfo,
+    msg,
     program_error::ProgramError,
     pubkey::Pubkey,
     sysvars::{clock::Clock, Sysvar},
@@ -457,6 +458,17 @@ pub fn sign_v2(
                     let account_data = unsafe { account_info.borrow_data_unchecked() };
                     let rent_exempt_minimum =
                         pinocchio::sysvars::rent::Rent::get()?.minimum_balance(account_data.len());
+                    msg!("current_lamports: {}", current_lamports);
+                    msg!(
+                        "swig wallet balance: {}",
+                        ctx.accounts.swig_wallet_address.lamports()
+                    );
+                    msg!("rent_exempt_minimum: {}", rent_exempt_minimum);
+                    msg!(
+                        "wallet rent exempt minimum: {}",
+                        pinocchio::sysvars::rent::Rent::get()?
+                            .minimum_balance(ctx.accounts.swig_wallet_address.data_len())
+                    );
                     if current_lamports < rent_exempt_minimum {
                         return Err(
                             SwigAuthenticateError::PermissionDeniedInsufficientBalance.into()

--- a/program/tests/sign_v2.rs
+++ b/program/tests/sign_v2.rs
@@ -2326,3 +2326,150 @@ fn test_sign_v2_token_transfer_through_secondary_authority() {
         result.unwrap().compute_units_consumed
     );
 }
+
+#[test_log::test]
+fn test_sign_v2_minimum_rent_check() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let different_payer = Keypair::new(); // This is the key difference - payer != authority
+    let recipient = Keypair::new();
+
+    // Setup accounts - fund both authority and payer
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 20_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&different_payer.pubkey(), 20_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    // Create the swig account using the authority
+    let (_, _transaction_metadata) =
+        create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    let secondary_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&secondary_authority.pubkey(), 1_000_000);
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: secondary_authority.pubkey().to_bytes().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::SolLimit(SolLimit { amount: 100000000 }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, 1_000_000_000)
+        .unwrap();
+
+    // Create a simple transfer instruction from swig_wallet_address
+    let transfer_amount = 898775040; // swig wallet balance - swig config rent min
+    let transfer_ix =
+        system_instruction::transfer(&swig_wallet_address, &recipient.pubkey(), transfer_amount);
+
+    // Create SignV2 instruction signed by the swig authority
+    let sign_v2_ix = SignV2Instruction::new_ed25519(
+        swig,
+        swig_wallet_address,
+        secondary_authority.pubkey(),
+        transfer_ix,
+        1, // role_id 0 for root authority
+    )
+    .unwrap();
+
+    // Build and execute transaction - payer signs but authority is different
+    let transfer_message = v0::Message::try_compile(
+        &different_payer.pubkey(),
+        &[sign_v2_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let transfer_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(transfer_message),
+        &[&different_payer, &secondary_authority],
+    )
+    .unwrap();
+
+    let initial_recipient_balance = context
+        .svm
+        .get_account(&recipient.pubkey())
+        .unwrap()
+        .lamports;
+    let initial_swig_wallet_address_balance = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .unwrap()
+        .lamports;
+
+    // Execute the transaction
+    let result = context.svm.send_transaction(transfer_tx);
+
+    if result.is_err() {
+        println!("Transaction failed: {:?}", result.err());
+        assert!(
+            false,
+            "SignV2 transaction with different payer and authority should succeed"
+        );
+    } else {
+        let txn = result.unwrap();
+        println!(
+            "SignV2 Transfer with different payer/authority successful - CU consumed: {:?}",
+            txn.compute_units_consumed
+        );
+        println!("Logs: {}", txn.pretty_logs());
+    }
+
+    // Verify the transfer was successful
+    let final_recipient_balance = context
+        .svm
+        .get_account(&recipient.pubkey())
+        .unwrap()
+        .lamports;
+    let final_swig_wallet_address_balance = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .unwrap()
+        .lamports;
+
+    assert_eq!(
+        final_recipient_balance,
+        initial_recipient_balance + transfer_amount,
+        "Recipient should have received the transfer amount"
+    );
+
+    assert_eq!(
+        final_swig_wallet_address_balance,
+        initial_swig_wallet_address_balance - transfer_amount,
+        "Swig wallet address account should have the transfer amount deducted"
+    );
+
+    println!(
+        "✅ SignV2 test passed: Successfully transferred {} lamports with different payer ({}) \
+         and authority ({})",
+        transfer_amount,
+        different_payer.pubkey().to_string()[..8].to_string(),
+        swig_authority.pubkey().to_string()[..8].to_string()
+    );
+}


### PR DESCRIPTION
The sign_v2 instruction allows for the transfer of swig wallet's rent amount as well. The existing check was redundant for v2 as it did not require the check as the swig account stays the same. 

Instead this patch updates the code to enforce a check on the signV2 to make sure that the rent amount of the swig wallet address is untouched.