### PR TITLE
fix: Sub Account All permission

### DIFF
--- a/program/src/actions/update_authority_v1.rs
+++ b/program/src/actions/update_authority_v1.rs
@@ -380,7 +380,7 @@ fn perform_replace_all_operation(
 }
 
 /// Performs an add-actions operation on an authority.
-fn perform_add_actions_operation(
+pub fn perform_add_actions_operation(
     swig_roles: &mut [u8],
     swig_data_len: usize,
     authority_offset: usize,

--- a/program/tests/sub_account_test.rs
+++ b/program/tests/sub_account_test.rs
@@ -336,6 +336,12 @@ fn test_sub_account_sign_with_all_permission() {
     let sub_account =
         create_sub_account(&mut context, &swig_key, &root_authority, role_id, id).unwrap();
 
+    let swig_data = context.svm.get_account(&swig_key).unwrap();
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data.data).unwrap();
+    let role = swig_with_roles.get_role(role_id).unwrap().unwrap();
+    let sub_account_action = role.get_all_actions_of_type::<SubAccount>().unwrap();
+    assert!(sub_account_action[0].sub_account == sub_account.to_bytes());
+
     // Fund the sub-account with some SOL
     let initial_balance = 5_000_000_000;
     context.svm.airdrop(&sub_account, initial_balance).unwrap();

--- a/state/src/action/sub_account.rs
+++ b/state/src/action/sub_account.rs
@@ -25,7 +25,7 @@ pub struct SubAccount {
     pub bump: u8,
     /// Whether the sub-account is enabled
     pub enabled: bool,
-    _padding: [u8; 2],
+    pub _padding: [u8; 2],
     /// ID of the role associated with this sub-account
     pub role_id: u32,
     /// ID of the parent Swig account


### PR DESCRIPTION
The issue arises when an authority with `All` permission is creating a sub account and trying to sign through it.

In the sub account creation flow:
1. authenticate and authorize by checking if a role has subaccounts or All permission.
2. if subacc action is present, then the subaccount value is updated like [here](https://github.com/anagrambuild/swig-wallet/blob/b53f060510dd6902aec96887034965d30db62b0a/program/src/actions/create_sub_account_v1.rs#L239C5-L248C6) 

> But for the role with all permission, the subaccount action is not present and the program skips it.

In the sub account sign flow:
after authentication, the `sub_account_action` is fetched and checked it it matches the passed sub account and proceeds

Here the role which had All, does not have sub_account action. Hence when the program could not find any sub_account action and it threw InvalidSwigSubAccountSwigIdMismatch , ie error 0x27.

---
Fix:

When a sub account is created, if the role has an All action but no sub account. Then sub account is created for the role.
Test case covered in https://github.com/anagrambuild/swig-wallet/blob/7fbfa2c93236a92f3f09655d1f3c3ca8f67df3a2/program/tests/sub_account_test.rs#L317