### PR TITLE
chore: bump workspace packages to v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "no-padding"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -9417,7 +9417,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swig"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9462,7 +9462,7 @@ dependencies = [
 
 [[package]]
 name = "swig-assertions"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "pinocchio 0.9.0",
  "pinocchio-pubkey 0.3.0",
@@ -9471,7 +9471,7 @@ dependencies = [
 
 [[package]]
 name = "swig-cli"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9501,7 +9501,7 @@ dependencies = [
 
 [[package]]
 name = "swig-compact-instructions"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "bs58",
  "pinocchio 0.9.0",
@@ -9511,7 +9511,7 @@ dependencies = [
 
 [[package]]
 name = "swig-interface"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "swig-sdk"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9557,7 +9557,7 @@ dependencies = [
 
 [[package]]
 name = "swig-state"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "agave-precompiles",
  "hex",
@@ -9750,7 +9750,7 @@ dependencies = [
 
 [[package]]
 name = "test-program-authority"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "solana-program",
  "solana-program-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "3.0.0"
 authors = ["SWIG Team"]
 documentation = "https://build.onswig.com"
 

--- a/program/idl.json
+++ b/program/idl.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "3.0.0",
   "name": "swig",
   "instructions": [
     {


### PR DESCRIPTION
## Summary
- bump the workspace package version from `2.0.0` to `3.0.0`
- update workspace crate entries in `Cargo.lock` so all local crates resolve to `3.0.0`
- regenerate `program/idl.json` via `cargo build --workspace --locked` so the IDL version matches

## Validation
- `cargo build --workspace --locked`