### PR TITLE
feat: add RentDestination permission for close rent recipients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,16 +1370,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -1820,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"

--- a/docs/program_diagrams.md
+++ b/docs/program_diagrams.md
@@ -333,7 +333,7 @@ Four signature schemes, each with a session-key variant (8 authority types total
 
 ---
 
-## Permission System (21 types)
+## Permission System (22 types)
 
 ```
 ┌───────────────────────────────────────────────────────────────────────┐
@@ -350,6 +350,7 @@ Four signature schemes, each with a session-key variant (8 authority types total
 │  │  8  ManageAuthority      Add/remove/update roles                 │ │
 │  │  9  SubAccount           Create/manage sub-accounts              │ │
 │  │ 20  CloseSwigAuthority   Close token accounts and swig account   │ │
+│  │ 21  RentDestination      Valid recipient for close rent refunds  │ │
 │  ├──────────────────────────────────────────────────────────────────┤ │
 │  │ SOL Permissions                                                  │ │
 │  │                                                                  │ │
@@ -381,6 +382,11 @@ Four signature schemes, each with a session-key variant (8 authority types total
 │  └──────────────────────────────────────────────────────────────────┘ │
 └───────────────────────────────────────────────────────────────────────┘
 ```
+
+When at least one authority has `RentDestination`, close-instruction rent refunds
+(`CloseSwigV1`, `CloseTokenAccountV1`) must go to a `RentDestination` authority.
+If no authority has `RentDestination`, close instructions can still refund rent to
+any wallet (legacy behavior).
 
 ### Permission Enforcement Model
 

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -26,8 +26,9 @@ use swig_state::{
         all::All, all_but_manage_authority::AllButManageAuthority,
         close_swig_authority::CloseSwigAuthority, manage_authority::ManageAuthority,
         program::Program, program_all::ProgramAll, program_curated::ProgramCurated,
-        program_scope::ProgramScope, sol_destination_limit::SolDestinationLimit,
-        sol_limit::SolLimit, sol_recurring_destination_limit::SolRecurringDestinationLimit,
+        program_scope::ProgramScope, rent_destination::RentDestination,
+        sol_destination_limit::SolDestinationLimit, sol_limit::SolLimit,
+        sol_recurring_destination_limit::SolRecurringDestinationLimit,
         sol_recurring_limit::SolRecurringLimit, stake_all::StakeAll, stake_limit::StakeLimit,
         stake_recurring_limit::StakeRecurringLimit, sub_account::SubAccount,
         token_destination_limit::TokenDestinationLimit, token_limit::TokenLimit,
@@ -59,6 +60,7 @@ pub enum ClientAction {
     AllButManageAuthority(AllButManageAuthority),
     ManageAuthority(ManageAuthority),
     CloseSwigAuthority(CloseSwigAuthority),
+    RentDestination(RentDestination),
     SubAccount(SubAccount),
     StakeLimit(StakeLimit),
     StakeRecurringLimit(StakeRecurringLimit),
@@ -104,6 +106,7 @@ impl ClientAction {
             ClientAction::CloseSwigAuthority(_) => {
                 (Permission::CloseSwigAuthority, CloseSwigAuthority::LEN)
             },
+            ClientAction::RentDestination(_) => (Permission::RentDestination, RentDestination::LEN),
             ClientAction::SubAccount(_) => (Permission::SubAccount, SubAccount::LEN),
             ClientAction::StakeLimit(_) => (Permission::StakeLimit, StakeLimit::LEN),
             ClientAction::StakeRecurringLimit(_) => {
@@ -138,6 +141,7 @@ impl ClientAction {
             ClientAction::AllButManageAuthority(action) => action.into_bytes(),
             ClientAction::ManageAuthority(action) => action.into_bytes(),
             ClientAction::CloseSwigAuthority(action) => action.into_bytes(),
+            ClientAction::RentDestination(action) => action.into_bytes(),
             ClientAction::SubAccount(action) => action.into_bytes(),
             ClientAction::StakeLimit(action) => action.into_bytes(),
             ClientAction::StakeRecurringLimit(action) => action.into_bytes(),

--- a/program/src/actions/close_swig_v1.rs
+++ b/program/src/actions/close_swig_v1.rs
@@ -27,6 +27,7 @@ use crate::{
         accounts::{CloseSwigV1Accounts, Context},
         SwigInstruction,
     },
+    util::validate_rent_destination_for_close,
 };
 
 /// Arguments for closing a Swig account.
@@ -97,60 +98,65 @@ pub fn close_swig_v1(
 
     let close_ix = CloseSwigV1::from_instruction_bytes(data)?;
 
-    // Load swig account
-    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    // Authenticate and validate permissions first.
+    let wallet_bump = {
+        let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
 
-    if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
-        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
-    }
+        if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+            return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+        }
 
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_unchecked(swig_header)? };
+        let (swig_header, swig_roles) =
+            unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+        let swig = unsafe { Swig::load_unchecked(swig_header)? };
 
-    // Verify swig_wallet_address is the correct PDA
-    let (expected_wallet_address, _wallet_bump) = pinocchio::pubkey::find_program_address(
-        &swig_wallet_address_seeds(ctx.accounts.swig.key().as_ref()),
-        &crate::ID,
-    );
-    if ctx.accounts.swig_wallet_address.key() != &expected_wallet_address {
-        return Err(SwigError::InvalidSeedSwigAccount.into());
-    }
+        // Verify swig_wallet_address is the correct PDA
+        let (expected_wallet_address, _wallet_bump) = pinocchio::pubkey::find_program_address(
+            &swig_wallet_address_seeds(ctx.accounts.swig.key().as_ref()),
+            &crate::ID,
+        );
+        if ctx.accounts.swig_wallet_address.key() != &expected_wallet_address {
+            return Err(SwigError::InvalidSeedSwigAccount.into());
+        }
 
-    // Get and authenticate role
-    let role_opt = Swig::get_mut_role(close_ix.args.role_id, swig_roles)?;
-    if role_opt.is_none() {
-        return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
-    }
-    let role = role_opt.unwrap();
+        let role_opt = Swig::get_mut_role(close_ix.args.role_id, swig_roles)?;
+        if role_opt.is_none() {
+            return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+        }
+        let role = role_opt.unwrap();
 
-    // Authenticate
-    let current_slot = Clock::get()?.slot;
-    if role.authority.session_based() {
-        role.authority.authenticate_session(
-            accounts,
-            close_ix.authority_payload,
-            close_ix.args.into_bytes()?,
-            current_slot,
-        )?;
-    } else {
-        role.authority.authenticate(
-            accounts,
-            close_ix.authority_payload,
-            close_ix.args.into_bytes()?,
-            current_slot,
-        )?;
-    }
+        let current_slot = Clock::get()?.slot;
+        if role.authority.session_based() {
+            role.authority.authenticate_session(
+                accounts,
+                close_ix.authority_payload,
+                close_ix.args.into_bytes()?,
+                current_slot,
+            )?;
+        } else {
+            role.authority.authenticate(
+                accounts,
+                close_ix.authority_payload,
+                close_ix.args.into_bytes()?,
+                current_slot,
+            )?;
+        }
 
-    // Check permissions: must have All, ManageAuthority, or CloseSwigAuthority
-    let has_all = role.get_action::<All>(&[])?.is_some();
-    let has_manage = role.get_action::<ManageAuthority>(&[])?.is_some();
-    let has_close = role.get_action::<CloseSwigAuthority>(&[])?.is_some();
-    if !has_all && !has_manage && !has_close {
-        return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
-    }
+        let has_all = role.get_action::<All>(&[])?.is_some();
+        let has_manage = role.get_action::<ManageAuthority>(&[])?.is_some();
+        let has_close = role.get_action::<CloseSwigAuthority>(&[])?.is_some();
+        if !has_all && !has_manage && !has_close {
+            return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+        }
 
-    // Store swig values before dropping borrow
-    let wallet_bump = swig.wallet_bump;
+        swig.wallet_bump
+    };
+
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_data_unchecked() };
+
+    // Enforce rent destination restriction, if configured by any authority.
+    validate_rent_destination_for_close(&swig_account_data, ctx.accounts.destination.key())?;
+
     let swig_data_len = swig_account_data.len();
 
     // Check that swig account only has rent-exempt minimum (no excess SOL balance)

--- a/program/src/actions/close_token_account_v1.rs
+++ b/program/src/actions/close_token_account_v1.rs
@@ -28,7 +28,7 @@ use crate::{
         SwigInstruction,
     },
     is_swig_v2,
-    util::TokenClose,
+    util::{validate_rent_destination_for_close, TokenClose},
     SPL_TOKEN_2022_ID, SPL_TOKEN_ID,
 };
 
@@ -115,43 +115,48 @@ pub fn close_token_account_v1(
     }
 
     // Get and authenticate role
-    let swig_roles = &swig_account_data[Swig::LEN..];
-    let role_opt = unsafe {
-        let roles_ptr = swig_roles.as_ptr() as *mut u8;
-        let roles_mut = core::slice::from_raw_parts_mut(roles_ptr, swig_roles.len());
-        Swig::get_mut_role(close_ix.args.role_id, roles_mut)?
-    };
+    {
+        let swig_roles = &swig_account_data[Swig::LEN..];
+        let role_opt = unsafe {
+            let roles_ptr = swig_roles.as_ptr() as *mut u8;
+            let roles_mut = core::slice::from_raw_parts_mut(roles_ptr, swig_roles.len());
+            Swig::get_mut_role(close_ix.args.role_id, roles_mut)?
+        };
 
-    if role_opt.is_none() {
-        return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
-    }
-    let role = role_opt.unwrap();
+        if role_opt.is_none() {
+            return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+        }
+        let role = role_opt.unwrap();
 
-    // Authenticate
-    let current_slot = Clock::get()?.slot;
-    if role.authority.session_based() {
-        role.authority.authenticate_session(
-            accounts,
-            close_ix.authority_payload,
-            close_ix.args.into_bytes()?,
-            current_slot,
-        )?;
-    } else {
-        role.authority.authenticate(
-            accounts,
-            close_ix.authority_payload,
-            close_ix.args.into_bytes()?,
-            current_slot,
-        )?;
+        // Authenticate
+        let current_slot = Clock::get()?.slot;
+        if role.authority.session_based() {
+            role.authority.authenticate_session(
+                accounts,
+                close_ix.authority_payload,
+                close_ix.args.into_bytes()?,
+                current_slot,
+            )?;
+        } else {
+            role.authority.authenticate(
+                accounts,
+                close_ix.authority_payload,
+                close_ix.args.into_bytes()?,
+                current_slot,
+            )?;
+        }
+
+        // Check permissions: must have All, ManageAuthority, or CloseSwigAuthority
+        let has_all = role.get_action::<All>(&[])?.is_some();
+        let has_manage = role.get_action::<ManageAuthority>(&[])?.is_some();
+        let has_close = role.get_action::<CloseSwigAuthority>(&[])?.is_some();
+        if !has_all && !has_manage && !has_close {
+            return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+        }
     }
 
-    // Check permissions: must have All, ManageAuthority, or CloseSwigAuthority
-    let has_all = role.get_action::<All>(&[])?.is_some();
-    let has_manage = role.get_action::<ManageAuthority>(&[])?.is_some();
-    let has_close = role.get_action::<CloseSwigAuthority>(&[])?.is_some();
-    if !has_all && !has_manage && !has_close {
-        return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
-    }
+    // Enforce rent destination restriction, if configured by any authority.
+    validate_rent_destination_for_close(swig_account_data, ctx.accounts.destination.key())?;
 
     // Use is_swig_v2 to determine expected authority
     let is_v2 = unsafe { is_swig_v2(swig_account_data) };

--- a/program/src/util/mod.rs
+++ b/program/src/util/mod.rs
@@ -21,6 +21,7 @@ use pinocchio::{
 use swig_state::{
     action::{
         program_scope::{NumericType, ProgramScope},
+        rent_destination::RentDestination,
         Action, Permission,
     },
     authority::AuthorityType,
@@ -28,7 +29,7 @@ use swig_state::{
     read_numeric_field,
     role::RoleMut,
     swig::{Swig, SwigWithRoles},
-    Transmutable,
+    SwigAuthenticateError, Transmutable,
 };
 
 use crate::error::SwigError;
@@ -160,6 +161,40 @@ impl ProgramScopeCache {
                 (*role_id, program_scope)
             })
     }
+}
+
+/// Validates destination restrictions for close instructions.
+///
+/// If at least one authority has the `RentDestination` action, the destination
+/// account must match an authority that has that action. If no authority has
+/// `RentDestination`, any destination is allowed.
+pub(crate) fn validate_rent_destination_for_close(
+    swig_data: &[u8],
+    destination: &Pubkey,
+) -> ProgramResult {
+    let swig_with_roles = SwigWithRoles::from_bytes(swig_data)?;
+    let mut has_restricted_destinations = false;
+    let mut destination_allowed = false;
+
+    for role_id in 0..swig_with_roles.state.role_counter {
+        let Some(role) = swig_with_roles.get_role(role_id)? else {
+            continue;
+        };
+
+        if role.get_action::<RentDestination>(&[])?.is_some() {
+            has_restricted_destinations = true;
+            if role.authority.match_data(destination.as_ref()) {
+                destination_allowed = true;
+                break;
+            }
+        }
+    }
+
+    if has_restricted_destinations && !destination_allowed {
+        return Err(SwigAuthenticateError::PermissionDeniedInvalidRentDestination.into());
+    }
+
+    Ok(())
 }
 
 /// Reads a numeric balance from an account's data based on a `ProgramScope`

--- a/program/tests/close_swig_authority_test.rs
+++ b/program/tests/close_swig_authority_test.rs
@@ -1350,3 +1350,192 @@ fn test_close_swig_succeeds_with_rent_destination_authority() {
         .lamports;
     assert_eq!(destination_after, destination_before + expected_received);
 }
+
+#[test_log::test]
+fn test_close_token_account_succeeds_with_arbitrary_destination_when_no_rent_destination() {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let close_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    context
+        .svm
+        .airdrop(&close_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: close_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::CloseSwigAuthority(CloseSwigAuthority)],
+    )
+    .unwrap();
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_token_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+
+    let destination = Keypair::new();
+    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
+
+    let token_account_rent = context.svm.get_account(&swig_token_ata).unwrap().lamports;
+    let destination_before = context
+        .svm
+        .get_account(&destination.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        close_authority.pubkey(),
+        destination.pubkey(),
+        spl_token::ID,
+        vec![swig_token_ata],
+        1,
+    )
+    .unwrap();
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &close_authority])
+        .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Close token account should allow arbitrary destination when no rent destination action exists: {:?}",
+        result.err()
+    );
+
+    let token_account = context.svm.get_account(&swig_token_ata);
+    let is_closed = token_account.is_none() || token_account.as_ref().unwrap().lamports == 0;
+    assert!(is_closed, "Token account should be closed");
+
+    let destination_after = context
+        .svm
+        .get_account(&destination.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    assert_eq!(destination_after, destination_before + token_account_rent);
+}
+
+#[test_log::test]
+fn test_close_swig_succeeds_with_arbitrary_destination_when_no_rent_destination() {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let close_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    context
+        .svm
+        .airdrop(&close_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: close_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::CloseSwigAuthority(CloseSwigAuthority)],
+    )
+    .unwrap();
+
+    let destination = Keypair::new();
+    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
+
+    let swig_lamports = context.svm.get_account(&swig_pubkey).unwrap().lamports;
+    let wallet_lamports = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    let closed_account_rent = context.svm.minimum_balance_for_rent_exemption(1);
+    let expected_received = swig_lamports + wallet_lamports - closed_account_rent;
+
+    let destination_before = context
+        .svm
+        .get_account(&destination.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let close_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        close_authority.pubkey(),
+        destination.pubkey(),
+        1,
+    )
+    .unwrap();
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &close_authority])
+        .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Close swig should allow arbitrary destination when no rent destination action exists: {:?}",
+        result.err()
+    );
+
+    let swig_account = context.svm.get_account(&swig_pubkey).unwrap();
+    assert_eq!(swig_account.data[0], 255);
+    assert_eq!(swig_account.data.len(), 1);
+
+    let destination_after = context
+        .svm
+        .get_account(&destination.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    assert_eq!(destination_after, destination_before + expected_received);
+}

--- a/program/tests/close_swig_authority_test.rs
+++ b/program/tests/close_swig_authority_test.rs
@@ -25,7 +25,7 @@ use swig_state::{
     action::{
         all::All, all_but_manage_authority::AllButManageAuthority,
         close_swig_authority::CloseSwigAuthority, manage_authority::ManageAuthority,
-        program_all::ProgramAll, sol_limit::SolLimit,
+        program_all::ProgramAll, rent_destination::RentDestination, sol_limit::SolLimit,
     },
     authority::AuthorityType,
     swig::swig_wallet_address_seeds,
@@ -953,4 +953,330 @@ fn test_close_swig_denied_with_program_all() {
         result.is_err(),
         "Transaction should fail with ProgramAll (no close permission)"
     );
+}
+
+// =============================================================================
+// RentDestination tests
+// =============================================================================
+
+#[test_log::test]
+fn test_close_token_account_fails_with_non_rent_destination() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let rent_destination_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    context
+        .svm
+        .airdrop(&rent_destination_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: rent_destination_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::RentDestination(RentDestination)],
+    )
+    .unwrap();
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_token_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+
+    let destination = Keypair::new();
+    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
+
+    let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        destination.pubkey(),
+        spl_token::ID,
+        vec![swig_token_ata],
+        0,
+    )
+    .unwrap();
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_err(),
+        "Close token account should fail when destination is not a rent destination authority"
+    );
+}
+
+#[test_log::test]
+fn test_close_token_account_succeeds_with_rent_destination_authority() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let rent_destination_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    context
+        .svm
+        .airdrop(&rent_destination_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: rent_destination_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::RentDestination(RentDestination)],
+    )
+    .unwrap();
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_token_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+
+    let token_account_rent = context.svm.get_account(&swig_token_ata).unwrap().lamports;
+    let destination_before = context
+        .svm
+        .get_account(&rent_destination_authority.pubkey())
+        .unwrap()
+        .lamports;
+
+    let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        rent_destination_authority.pubkey(),
+        spl_token::ID,
+        vec![swig_token_ata],
+        0,
+    )
+    .unwrap();
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Close token account should succeed with rent destination authority: {:?}",
+        result.err()
+    );
+
+    let token_account = context.svm.get_account(&swig_token_ata);
+    let is_closed = token_account.is_none() || token_account.as_ref().unwrap().lamports == 0;
+    assert!(is_closed, "Token account should be closed");
+
+    let destination_after = context
+        .svm
+        .get_account(&rent_destination_authority.pubkey())
+        .unwrap()
+        .lamports;
+    assert_eq!(destination_after, destination_before + token_account_rent);
+}
+
+#[test_log::test]
+fn test_close_swig_fails_with_non_rent_destination() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let rent_destination_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    context
+        .svm
+        .airdrop(&rent_destination_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: rent_destination_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::RentDestination(RentDestination)],
+    )
+    .unwrap();
+
+    let destination = Keypair::new();
+    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
+
+    let close_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        destination.pubkey(),
+        0,
+    )
+    .unwrap();
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_err(),
+        "Close swig should fail when destination is not a rent destination authority"
+    );
+}
+
+#[test_log::test]
+fn test_close_swig_succeeds_with_rent_destination_authority() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let rent_destination_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    context
+        .svm
+        .airdrop(&rent_destination_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: rent_destination_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::RentDestination(RentDestination)],
+    )
+    .unwrap();
+
+    let swig_lamports = context.svm.get_account(&swig_pubkey).unwrap().lamports;
+    let wallet_lamports = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    let closed_account_rent = context.svm.minimum_balance_for_rent_exemption(1);
+    let expected_received = swig_lamports + wallet_lamports - closed_account_rent;
+
+    let destination_before = context
+        .svm
+        .get_account(&rent_destination_authority.pubkey())
+        .unwrap()
+        .lamports;
+
+    let close_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        rent_destination_authority.pubkey(),
+        0,
+    )
+    .unwrap();
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "Close swig should succeed with rent destination authority: {:?}",
+        result.err()
+    );
+
+    let swig_account = context.svm.get_account(&swig_pubkey).unwrap();
+    assert_eq!(swig_account.data[0], 255);
+    assert_eq!(swig_account.data.len(), 1);
+
+    let destination_after = context
+        .svm
+        .get_account(&rent_destination_authority.pubkey())
+        .unwrap()
+        .lamports;
+    assert_eq!(destination_after, destination_before + expected_received);
 }

--- a/program/tests/close_swig_authority_test.rs
+++ b/program/tests/close_swig_authority_test.rs
@@ -962,16 +962,34 @@ fn test_close_swig_denied_with_program_all() {
 #[test_log::test]
 fn test_close_token_account_fails_with_non_rent_destination() {
     let mut context = setup_test_context().unwrap();
-    let authority = Keypair::new();
+    let root_authority = Keypair::new();
+    let close_authority = Keypair::new();
     let rent_destination_authority = Keypair::new();
     let id = rand::random::<[u8; 32]>();
 
-    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
 
     let (swig_wallet_address, _) = Pubkey::find_program_address(
         &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
         &program_id(),
     );
+
+    context
+        .svm
+        .airdrop(&close_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: close_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::CloseSwigAuthority(CloseSwigAuthority)],
+    )
+    .unwrap();
 
     context
         .svm
@@ -981,7 +999,7 @@ fn test_close_token_account_fails_with_non_rent_destination() {
     add_authority_with_ed25519_root(
         &mut context,
         &swig_pubkey,
-        &authority,
+        &root_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
             authority: rent_destination_authority.pubkey().as_ref(),
@@ -999,17 +1017,14 @@ fn test_close_token_account_fails_with_non_rent_destination() {
     )
     .unwrap();
 
-    let destination = Keypair::new();
-    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
-
     let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
         swig_pubkey,
         swig_wallet_address,
-        authority.pubkey(),
-        destination.pubkey(),
+        close_authority.pubkey(),
+        close_authority.pubkey(),
         spl_token::ID,
         vec![swig_token_ata],
-        0,
+        1,
     )
     .unwrap();
 
@@ -1026,28 +1041,47 @@ fn test_close_token_account_fails_with_non_rent_destination() {
         .unwrap(),
     );
 
-    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &close_authority])
+        .unwrap();
 
     let result = context.svm.send_transaction(tx);
     assert!(
         result.is_err(),
-        "Close token account should fail when destination is not a rent destination authority"
+        "Close token account should fail when destination only has close permission"
     );
 }
 
 #[test_log::test]
 fn test_close_token_account_succeeds_with_rent_destination_authority() {
     let mut context = setup_test_context().unwrap();
-    let authority = Keypair::new();
+    let root_authority = Keypair::new();
+    let close_authority = Keypair::new();
     let rent_destination_authority = Keypair::new();
     let id = rand::random::<[u8; 32]>();
 
-    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
 
     let (swig_wallet_address, _) = Pubkey::find_program_address(
         &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
         &program_id(),
     );
+
+    context
+        .svm
+        .airdrop(&close_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: close_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::CloseSwigAuthority(CloseSwigAuthority)],
+    )
+    .unwrap();
 
     context
         .svm
@@ -1057,7 +1091,7 @@ fn test_close_token_account_succeeds_with_rent_destination_authority() {
     add_authority_with_ed25519_root(
         &mut context,
         &swig_pubkey,
-        &authority,
+        &root_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
             authority: rent_destination_authority.pubkey().as_ref(),
@@ -1085,11 +1119,11 @@ fn test_close_token_account_succeeds_with_rent_destination_authority() {
     let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
         swig_pubkey,
         swig_wallet_address,
-        authority.pubkey(),
+        close_authority.pubkey(),
         rent_destination_authority.pubkey(),
         spl_token::ID,
         vec![swig_token_ata],
-        0,
+        1,
     )
     .unwrap();
 
@@ -1106,7 +1140,8 @@ fn test_close_token_account_succeeds_with_rent_destination_authority() {
         .unwrap(),
     );
 
-    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &close_authority])
+        .unwrap();
 
     let result = context.svm.send_transaction(tx);
     assert!(
@@ -1130,16 +1165,34 @@ fn test_close_token_account_succeeds_with_rent_destination_authority() {
 #[test_log::test]
 fn test_close_swig_fails_with_non_rent_destination() {
     let mut context = setup_test_context().unwrap();
-    let authority = Keypair::new();
+    let root_authority = Keypair::new();
+    let close_authority = Keypair::new();
     let rent_destination_authority = Keypair::new();
     let id = rand::random::<[u8; 32]>();
 
-    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
 
     let (swig_wallet_address, _) = Pubkey::find_program_address(
         &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
         &program_id(),
     );
+
+    context
+        .svm
+        .airdrop(&close_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: close_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::CloseSwigAuthority(CloseSwigAuthority)],
+    )
+    .unwrap();
 
     context
         .svm
@@ -1149,7 +1202,7 @@ fn test_close_swig_fails_with_non_rent_destination() {
     add_authority_with_ed25519_root(
         &mut context,
         &swig_pubkey,
-        &authority,
+        &root_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
             authority: rent_destination_authority.pubkey().as_ref(),
@@ -1158,15 +1211,12 @@ fn test_close_swig_fails_with_non_rent_destination() {
     )
     .unwrap();
 
-    let destination = Keypair::new();
-    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
-
     let close_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
         swig_pubkey,
         swig_wallet_address,
-        authority.pubkey(),
-        destination.pubkey(),
-        0,
+        close_authority.pubkey(),
+        close_authority.pubkey(),
+        1,
     )
     .unwrap();
 
@@ -1183,28 +1233,47 @@ fn test_close_swig_fails_with_non_rent_destination() {
         .unwrap(),
     );
 
-    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &close_authority])
+        .unwrap();
 
     let result = context.svm.send_transaction(tx);
     assert!(
         result.is_err(),
-        "Close swig should fail when destination is not a rent destination authority"
+        "Close swig should fail when destination only has close permission"
     );
 }
 
 #[test_log::test]
 fn test_close_swig_succeeds_with_rent_destination_authority() {
     let mut context = setup_test_context().unwrap();
-    let authority = Keypair::new();
+    let root_authority = Keypair::new();
+    let close_authority = Keypair::new();
     let rent_destination_authority = Keypair::new();
     let id = rand::random::<[u8; 32]>();
 
-    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
 
     let (swig_wallet_address, _) = Pubkey::find_program_address(
         &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
         &program_id(),
     );
+
+    context
+        .svm
+        .airdrop(&close_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: close_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::CloseSwigAuthority(CloseSwigAuthority)],
+    )
+    .unwrap();
 
     context
         .svm
@@ -1214,7 +1283,7 @@ fn test_close_swig_succeeds_with_rent_destination_authority() {
     add_authority_with_ed25519_root(
         &mut context,
         &swig_pubkey,
-        &authority,
+        &root_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
             authority: rent_destination_authority.pubkey().as_ref(),
@@ -1241,9 +1310,9 @@ fn test_close_swig_succeeds_with_rent_destination_authority() {
     let close_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
         swig_pubkey,
         swig_wallet_address,
-        authority.pubkey(),
+        close_authority.pubkey(),
         rent_destination_authority.pubkey(),
-        0,
+        1,
     )
     .unwrap();
 
@@ -1260,7 +1329,8 @@ fn test_close_swig_succeeds_with_rent_destination_authority() {
         .unwrap(),
     );
 
-    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &close_authority])
+        .unwrap();
 
     let result = context.svm.send_transaction(tx);
     assert!(

--- a/rust-sdk/src/tests/wallet/helper_tests.rs
+++ b/rust-sdk/src/tests/wallet/helper_tests.rs
@@ -29,6 +29,32 @@ fn should_get_current_authority_permissions() {
 }
 
 #[test_log::test]
+fn should_get_current_authority_permissions_with_rent_destination() {
+    let (mut litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let rent_destination_authority = Keypair::new();
+
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &rent_destination_authority.pubkey().to_bytes(),
+            vec![Permission::RentDestination],
+        )
+        .unwrap();
+
+    swig_wallet
+        .switch_authority(
+            1,
+            Box::new(Ed25519ClientRole::new(rent_destination_authority.pubkey())),
+            Some(&rent_destination_authority),
+        )
+        .unwrap();
+
+    let permissions = swig_wallet.get_current_authority_permissions().unwrap();
+    assert_eq!(permissions, vec![Permission::RentDestination]);
+}
+
+#[test_log::test]
 fn should_get_role_id_for_authority() {
     let (mut litesvm, main_authority) = setup_test_environment();
     let mut swig_wallet = create_test_wallet(litesvm, &main_authority);

--- a/rust-sdk/src/types.rs
+++ b/rust-sdk/src/types.rs
@@ -9,6 +9,7 @@ use swig_state::{
         program_all::ProgramAll,
         program_curated::ProgramCurated,
         program_scope::{NumericType, ProgramScope, ProgramScopeType},
+        rent_destination::RentDestination,
         sol_destination_limit::SolDestinationLimit,
         sol_limit::SolLimit,
         sol_recurring_destination_limit::SolRecurringDestinationLimit,
@@ -164,6 +165,10 @@ pub enum Permission {
     /// This grants access to all wallet operations but excludes the ability
     /// to add, remove, or modify authorities/subaccounts.
     AllButManageAuthority,
+
+    /// Permission that marks this authority as a valid rent destination for
+    /// close instructions.
+    RentDestination,
 }
 
 impl Permission {
@@ -332,6 +337,9 @@ impl Permission {
                     actions.push(ClientAction::AllButManageAuthority(
                         AllButManageAuthority {},
                     ));
+                },
+                Permission::RentDestination => {
+                    actions.push(ClientAction::RentDestination(RentDestination {}));
                 },
             }
         }
@@ -573,6 +581,13 @@ impl Permission {
             permissions.push(Permission::AllButManageAuthority);
         }
 
+        if swig_state::role::Role::get_action::<RentDestination>(role, &[])
+            .map_err(|_| SwigError::InvalidSwigData)?
+            .is_some()
+        {
+            permissions.push(Permission::RentDestination);
+        }
+
         Ok(permissions)
     }
 
@@ -649,6 +664,7 @@ impl Permission {
             },
             Permission::StakeAll => 12,
             Permission::AllButManageAuthority => 15,
+            Permission::RentDestination => 21,
         }
     }
 }

--- a/rust-sdk/src/types.rs
+++ b/rust-sdk/src/types.rs
@@ -716,3 +716,35 @@ impl UpdateAuthorityData {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rent_destination_converts_to_client_action() {
+        let actions = Permission::to_client_actions(vec![Permission::RentDestination]);
+
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(&actions[0], ClientAction::RentDestination(_)));
+    }
+
+    #[test]
+    fn rent_destination_action_type_matches_program_discriminator() {
+        assert_eq!(Permission::RentDestination.to_action_type(), 21);
+    }
+
+    #[test]
+    fn remove_actions_by_type_uses_rent_destination_action_type() {
+        let update_data =
+            UpdateAuthorityData::RemoveActionsByType(vec![Permission::RentDestination]);
+
+        let interface_data = update_data.to_interface_data();
+        match interface_data {
+            InterfaceUpdateAuthorityData::RemoveActionsByType(action_types) => {
+                assert_eq!(action_types, vec![21]);
+            },
+            _ => panic!("expected RemoveActionsByType update payload"),
+        }
+    }
+}

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -635,64 +635,24 @@ impl<'c> SwigWallet<'c> {
         let swig_pubkey = self.get_swig_account()?;
 
         #[cfg(not(all(feature = "rust_sdk_test", test)))]
-        let swig_account = self.rpc_client.get_account(&swig_pubkey)?;
-        #[cfg(all(feature = "rust_sdk_test", test))]
-        let swig_account = self.litesvm.get_account(&swig_pubkey).unwrap();
-
-        #[cfg(not(all(feature = "rust_sdk_test", test)))]
         let swig_data = self.rpc_client.get_account_data(&swig_pubkey)?;
         #[cfg(all(feature = "rust_sdk_test", test))]
         let swig_data = self.litesvm.get_account(&swig_pubkey).unwrap().data;
         let swig_with_roles =
-            SwigWithRoles::from_bytes(&swig_data).map_err(|e| SwigError::InvalidSwigData)?;
+            SwigWithRoles::from_bytes(&swig_data).map_err(|_| SwigError::InvalidSwigData)?;
 
-        let mut permissions: Vec<Permission> = Vec::new();
-        for i in 0..swig_with_roles.state.role_counter {
-            let role = swig_with_roles.get_role(i).unwrap();
-            if let Some(role) = role {
-                if role
-                    .authority
-                    .match_data(self.instruction_builder.get_current_authority()?.as_ref())
-                {
-                    if (Role::get_action::<All>(&role, &[])
-                        .map_err(|_| SwigError::AuthorityNotFound)?)
-                    .is_some()
-                    {
-                        permissions.push(Permission::All);
-                    }
-                    // Sol Limit
-                    if let Some(action) = Role::get_action::<SolLimit>(&role, &[])
-                        .map_err(|_| SwigError::AuthorityNotFound)?
-                    {
-                        permissions.push(Permission::Sol {
-                            amount: action.amount,
-                            recurring: None,
-                        });
-                    }
-                    // Sol Recurring
-                    if let Some(action) = Role::get_action::<SolRecurringLimit>(&role, &[])
-                        .map_err(|_| SwigError::AuthorityNotFound)?
-                    {
-                        permissions.push(Permission::Sol {
-                            amount: action.recurring_amount,
-                            recurring: Some(RecurringConfig {
-                                window: action.window,
-                                last_reset: action.last_reset,
-                                current_amount: action.current_amount,
-                            }),
-                        });
-                    }
-                    // Manage Authority
-                    if (Role::get_action::<ManageAuthority>(&role, &[])
-                        .map_err(|_| SwigError::AuthorityNotFound)?)
-                    .is_some()
-                    {
-                        println!("\t\tManage Authority permission exists");
-                    }
-                }
-            }
-        }
-        Ok(permissions)
+        let current_authority = self.instruction_builder.get_current_authority()?;
+        let role_id = swig_with_roles
+            .lookup_role_id(current_authority.as_ref())
+            .map_err(|_| SwigError::InvalidSwigData)?
+            .ok_or(SwigError::AuthorityNotFound)?;
+
+        let role = swig_with_roles
+            .get_role(role_id)
+            .map_err(|_| SwigError::InvalidSwigData)?
+            .ok_or(SwigError::AuthorityNotFound)?;
+
+        Permission::from_role(&role)
     }
 
     /// Displays detailed information about the Swig wallet

--- a/state/src/action/mod.rs
+++ b/state/src/action/mod.rs
@@ -13,6 +13,7 @@ pub mod program;
 pub mod program_all;
 pub mod program_curated;
 pub mod program_scope;
+pub mod rent_destination;
 pub mod sol_destination_limit;
 pub mod sol_limit;
 pub mod sol_recurring_destination_limit;
@@ -35,6 +36,7 @@ use program::Program;
 use program_all::ProgramAll;
 use program_curated::ProgramCurated;
 use program_scope::ProgramScope;
+use rent_destination::RentDestination;
 use sol_destination_limit::SolDestinationLimit;
 use sol_limit::SolLimit;
 use sol_recurring_destination_limit::SolRecurringDestinationLimit;
@@ -167,6 +169,8 @@ pub enum Permission {
     TokenRecurringDestinationLimit = 19,
     /// Permission to close token accounts and the swig account
     CloseSwigAuthority = 20,
+    /// Marks an authority as a valid rent destination for close instructions
+    RentDestination = 21,
 }
 
 impl TryFrom<u16> for Permission {
@@ -176,7 +180,7 @@ impl TryFrom<u16> for Permission {
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
             // SAFETY: `value` is guaranteed to be in the range of the enum variants.
-            0..=20 => Ok(unsafe { core::mem::transmute::<u16, Permission>(value) }),
+            0..=21 => Ok(unsafe { core::mem::transmute::<u16, Permission>(value) }),
             _ => Err(SwigStateError::PermissionLoadError.into()),
         }
     }
@@ -241,6 +245,7 @@ impl ActionLoader {
             Permission::ProgramCurated => ProgramCurated::valid_layout(data),
             Permission::AllButManageAuthority => AllButManageAuthority::valid_layout(data),
             Permission::CloseSwigAuthority => CloseSwigAuthority::valid_layout(data),
+            Permission::RentDestination => RentDestination::valid_layout(data),
             Permission::TokenDestinationLimit => TokenDestinationLimit::valid_layout(data),
             Permission::TokenRecurringDestinationLimit => {
                 TokenRecurringDestinationLimit::valid_layout(data)
@@ -265,5 +270,18 @@ impl ActionLoader {
             cursor = action.boundary() as usize;
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rent_destination_permission_roundtrip() {
+        let action = Action::new(Permission::RentDestination, 0, Action::LEN as u32);
+        let bytes = action.into_bytes().unwrap();
+        let loaded = unsafe { Action::load_unchecked(bytes) }.unwrap();
+        assert_eq!(loaded.permission().unwrap(), Permission::RentDestination);
     }
 }

--- a/state/src/action/rent_destination.rs
+++ b/state/src/action/rent_destination.rs
@@ -1,0 +1,37 @@
+//! Rent destination action type.
+//!
+//! This module defines the RentDestination action type which marks an authority
+//! as a valid rent destination for close instructions.
+
+use pinocchio::program_error::ProgramError;
+
+use super::{Actionable, Permission};
+use crate::{IntoBytes, Transmutable, TransmutableMut};
+
+/// Marker action designating an authority as a valid rent destination.
+///
+/// This action contains no payload. Its presence alone indicates that the
+/// authority is allowed to receive rent refunds during close operations.
+#[repr(C)]
+pub struct RentDestination;
+
+impl Transmutable for RentDestination {
+    const LEN: usize = 0;
+}
+
+impl TransmutableMut for RentDestination {}
+
+impl IntoBytes for RentDestination {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(&[])
+    }
+}
+
+impl<'a> Actionable<'a> for RentDestination {
+    const TYPE: Permission = Permission::RentDestination;
+    const REPEATABLE: bool = false;
+
+    fn match_data(&self, _data: &[u8]) -> bool {
+        true
+    }
+}

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -191,6 +191,8 @@ pub enum SwigAuthenticateError {
     PermissionDeniedProgramExecInvalidWalletAccount,
     /// Program execution cannot be the Swig program
     PermissionDeniedProgramExecCannotBeSwig,
+    /// Destination must match an authority configured as rent destination
+    PermissionDeniedInvalidRentDestination,
 }
 
 impl From<SwigStateError> for ProgramError {


### PR DESCRIPTION
## Summary
- add a zero-length `RentDestination` permission/action and wire it through state, interface, and Rust SDK mappings.
- enforce close rent-recipient checks for `CloseSwigV1` and `CloseTokenAccountV1`: when any role has `RentDestination`, destination must match a `RentDestination` authority; when none exist, keep legacy behavior and allow any destination.
- keep close authority checks independent from rent-recipient checks so the closer and rent recipient can be different roles.
- add integration coverage for restricted and unrestricted destination behavior, including separate closer vs recipient roles.
- document the new permission and close behavior in `docs/program_diagrams.md`.
- pin lockfile dependency resolution (`blake3` to `1.8.2`) to keep `cargo build-sbf --arch v1` working with the current toolchain.

## Validation
- `cargo fmt --all`
- `cargo build-sbf --arch v1`
- `cargo nextest run --config-file nextest.toml --profile ci -p swig --test close_swig_authority_test`
- `cargo nextest run --config-file nextest.toml --profile ci --all --workspace --no-fail-fast` (run earlier on this branch before final test-only additions)