### PR TITLE
Feat(program): Program Exec Odometer

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -608,6 +608,68 @@ impl AddAuthorityInstruction {
 
         Ok(vec![preceding_instruction, main_ix])
     }
+
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        acting_role_id: u32,
+        new_authority_config: AuthorityConfig,
+        actions: Vec<ClientAction>,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let mut action_bytes = Vec::new();
+        let num_actions = actions.len() as u8;
+        for action in actions {
+            action
+                .write(&mut action_bytes)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize action {:?}", e))?;
+        }
+
+        let args = AddAuthorityV1Args::new(
+            acting_role_id,
+            new_authority_config.authority_type,
+            new_authority_config.authority.len() as u16,
+            action_bytes.len() as u16,
+            num_actions,
+        );
+
+        let arg_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
+        );
+
+        let main_ix = Instruction {
+            program_id: Pubkey::from(swig::ID),
+            accounts,
+            data: [
+                arg_bytes,
+                new_authority_config.authority,
+                &action_bytes,
+                &authority_payload,
+            ]
+            .concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
 }
 
 pub struct SignV2Instruction;
@@ -1231,6 +1293,46 @@ impl RemoveAuthorityInstruction {
 
         Ok(vec![preceding_instruction, main_ix])
     }
+
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        acting_role_id: u32,
+        authority_to_remove_id: u32,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let args = RemoveAuthorityV1Args::new(acting_role_id, authority_to_remove_id, 1);
+        let arg_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
+        );
+
+        let main_ix = Instruction {
+            program_id: Pubkey::from(swig::ID),
+            accounts,
+            data: [arg_bytes, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
 }
 pub enum UpdateAuthorityData {
     ReplaceAll(Vec<ClientAction>),
@@ -1649,6 +1751,58 @@ impl UpdateAuthorityInstruction {
 
         Ok(vec![preceding_instruction, main_ix])
     }
+
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        acting_role_id: u32,
+        authority_to_update_id: u32,
+        update_data: UpdateAuthorityData,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let (operation, operation_data) = update_data.to_operation_and_data()?;
+
+        let mut encoded_data = Vec::new();
+        encoded_data.push(operation as u8);
+        encoded_data.extend_from_slice(&operation_data);
+
+        let args = UpdateAuthorityV1Args::new(
+            acting_role_id,
+            authority_to_update_id,
+            encoded_data.len() as u16,
+            0,
+        );
+        let arg_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
+        );
+
+        let main_ix = Instruction {
+            program_id: Pubkey::from(swig::ID),
+            accounts,
+            data: [arg_bytes, &encoded_data, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
 }
 
 pub struct CreateSessionInstruction;
@@ -1891,6 +2045,48 @@ impl CreateSessionInstruction {
 
         Ok(vec![preceding_instruction, main_ix])
     }
+
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        role_id: u32,
+        session_duration: u64,
+        session_key: Pubkey,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let create_session_args =
+            CreateSessionV1Args::new(role_id, session_duration, session_key.to_bytes());
+        let args_bytes = create_session_args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
+        );
+
+        let main_ix = Instruction {
+            program_id: Pubkey::from(swig::ID),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
 }
 
 // Sub-account instruction structures
@@ -2122,6 +2318,48 @@ impl CreateSubAccountInstruction {
             instruction_sysvar_index,
             Some(target_ix_index),
             None,
+        );
+
+        let main_ix = Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
+
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        sub_account: Pubkey,
+        role_id: u32,
+        sub_account_bump: u8,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let args = CreateSubAccountV1Args::new(role_id, sub_account_bump);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
         );
 
         let main_ix = Instruction {
@@ -2614,6 +2852,50 @@ impl WithdrawFromSubAccountInstruction {
         Ok(vec![preceding_instruction, main_ix])
     }
 
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        sub_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        role_id: u32,
+        amount: u64,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let args = WithdrawFromSubAccountV1Args::new(role_id, amount);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
+        );
+
+        let main_ix = Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
+
     pub fn new_token_with_program_exec_ix_index(
         swig_account: Pubkey,
         payer: Pubkey,
@@ -2907,6 +3189,51 @@ impl SubAccountSignInstruction {
 
         Ok(vec![preceding_instruction, main_ix])
     }
+
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        sub_account: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        role_id: u32,
+        instructions: Vec<Instruction>,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new_readonly(swig_account, false),
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let (accounts, ixs) =
+            compact_instructions_sub_account(swig_account, sub_account, accounts, instructions);
+        let ix_bytes = ixs.into_bytes();
+        let args = SubAccountSignV1Args::new(role_id, ix_bytes.len() as u16);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
+        );
+
+        let main_ix = Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &ix_bytes, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
 }
 
 pub struct ToggleSubAccountInstruction;
@@ -3155,6 +3482,48 @@ impl ToggleSubAccountInstruction {
 
         Ok(vec![preceding_instruction, main_ix])
     }
+
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        sub_account: Pubkey,
+        role_id: u32,
+        auth_role_id: u32,
+        enabled: bool,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(sub_account, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let args = ToggleSubAccountV1Args::new(role_id, auth_role_id, enabled);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
+        );
+
+        let main_ix = Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
 }
 
 pub struct TransferAssetsV1Instruction;
@@ -3387,6 +3756,47 @@ impl TransferAssetsV1Instruction {
             instruction_sysvar_index,
             Some(target_ix_index),
             None,
+        );
+
+        let main_ix = Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, main_ix])
+    }
+
+    pub fn new_with_program_exec_odometer(
+        swig_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        role_id: u32,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let mut accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let args = TransferAssetsV1Args::new(role_id);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
         );
 
         let main_ix = Instruction {

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -177,10 +177,23 @@ pub fn swig_wallet_address(config_address: &Pubkey) -> Pubkey {
 fn build_program_exec_authority_payload(
     instruction_sysvar_index: u8,
     target_ix_index: Option<u8>,
+    odometer_start_index: Option<u16>,
 ) -> Vec<u8> {
-    match target_ix_index {
-        Some(idx) => vec![instruction_sysvar_index, idx],
-        None => vec![instruction_sysvar_index],
+    match odometer_start_index {
+        Some(idx) => {
+            let target_ix_idx = target_ix_index.unwrap_or(255);
+            let odo_bytes = idx.to_le_bytes();
+            vec![
+                instruction_sysvar_index,
+                target_ix_idx,
+                odo_bytes[0],
+                odo_bytes[1],
+            ]
+        },
+        None => match target_ix_index {
+            Some(idx) => vec![instruction_sysvar_index, idx],
+            None => vec![instruction_sysvar_index],
+        },
     }
 }
 
@@ -517,7 +530,7 @@ impl AddAuthorityInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -575,8 +588,11 @@ impl AddAuthorityInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -678,7 +694,7 @@ impl SignV2Instruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let sign_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -719,8 +735,56 @@ impl SignV2Instruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
+
+        let sign_ix = Instruction {
+            program_id: Pubkey::from(swig::ID),
+            accounts,
+            data: [arg_bytes, &ix_bytes, &authority_payload].concat(),
+        };
+
+        Ok(vec![preceding_instruction, sign_ix])
+    }
+
+    pub fn new_program_exec_with_odometer(
+        swig_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        payer: Pubkey,
+        preceding_instruction: Instruction,
+        inner_instruction: Instruction,
+        role_id: u32,
+        target_ix_index: u8,
+        odometer_start_index: u16,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
+
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            AccountMeta::new(payer, true),
+        ];
+
+        let (mut accounts, ixs) =
+            compact_instructions(swig_account, accounts, vec![inner_instruction]);
+
+        let instruction_sysvar_index = accounts.len() as u8;
+        accounts.push(AccountMeta::new_readonly(INSTRUCTIONS_ID, false));
+
+        let ix_bytes = ixs.into_bytes();
+        let args = swig::actions::sign_v2::SignV2Args::new(role_id, ix_bytes.len() as u16);
+        let arg_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            Some(odometer_start_index),
+        );
 
         let sign_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -1117,7 +1181,7 @@ impl RemoveAuthorityInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -1153,8 +1217,11 @@ impl RemoveAuthorityInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -1520,7 +1587,7 @@ impl UpdateAuthorityInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -1568,8 +1635,11 @@ impl UpdateAuthorityInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -1769,7 +1839,7 @@ impl CreateSessionInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -1807,8 +1877,11 @@ impl CreateSessionInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: Pubkey::from(swig::ID),
@@ -2007,7 +2080,7 @@ impl CreateSubAccountInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -2045,8 +2118,11 @@ impl CreateSubAccountInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -2436,7 +2512,7 @@ impl WithdrawFromSubAccountInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -2483,7 +2559,7 @@ impl WithdrawFromSubAccountInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -2523,8 +2599,11 @@ impl WithdrawFromSubAccountInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -2569,8 +2648,11 @@ impl WithdrawFromSubAccountInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -2770,7 +2852,7 @@ impl SubAccountSignInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -2811,8 +2893,11 @@ impl SubAccountSignInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -3018,7 +3103,7 @@ impl ToggleSubAccountInstruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -3056,8 +3141,11 @@ impl ToggleSubAccountInstruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -3258,7 +3346,7 @@ impl TransferAssetsV1Instruction {
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
         let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, None);
+            build_program_exec_authority_payload(instruction_sysvar_index, None, None);
 
         let main_ix = Instruction {
             program_id: program_id(),
@@ -3295,8 +3383,11 @@ impl TransferAssetsV1Instruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
 
-        let authority_payload =
-            build_program_exec_authority_payload(instruction_sysvar_index, Some(target_ix_index));
+        let authority_payload = build_program_exec_authority_payload(
+            instruction_sysvar_index,
+            Some(target_ix_index),
+            None,
+        );
 
         let main_ix = Instruction {
             program_id: program_id(),

--- a/program/tests/program_authority_test.rs
+++ b/program/tests/program_authority_test.rs
@@ -1357,3 +1357,421 @@ fn test_program_exec_explicit_ix_index_wrong_program_fails() {
         println!("Got expected error: {:?}", err.err);
     }
 }
+
+// ============================================================================
+// Odometer tests
+// ============================================================================
+
+/// Helper to build program exec sign instructions with odometer support.
+///
+/// authority_payload format: [instruction_sysvar_index, target_ix_index,
+/// odometer_start_index(u16 LE)]
+fn build_program_exec_sign_instructions_with_odometer(
+    swig_account: Pubkey,
+    swig_wallet_address: Pubkey,
+    payer: Pubkey,
+    preceding_instruction: Instruction,
+    inner_instruction: Instruction,
+    role_id: u32,
+    target_ix_index: u8,
+    odometer_start_index: u16,
+) -> anyhow::Result<Vec<Instruction>> {
+    swig_interface::SignV2Instruction::new_program_exec_with_odometer(
+        swig_account,
+        swig_wallet_address,
+        payer,
+        preceding_instruction,
+        inner_instruction,
+        role_id,
+        target_ix_index,
+        odometer_start_index,
+    )
+}
+
+/// Shared setup for odometer tests: creates context, deploys test program,
+/// creates swig with Ed25519 root + ProgramExec authority, airdrops funds.
+fn setup_odometer_test() -> (SwigTestContext, Pubkey, Pubkey, Keypair, Keypair) {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let state_account = Keypair::new();
+
+    deploy_test_program(&mut context).expect("Failed to deploy test program");
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+
+    create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    context.svm.airdrop(&swig, 100_000_000).unwrap();
+    context.svm.airdrop(&swig_wallet, 100_000_000).unwrap();
+
+    let program_exec_data =
+        create_program_exec_authority_data(TEST_PROGRAM_ID, &VALID_DISCRIMINATOR);
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::ProgramExec,
+            authority: &program_exec_data,
+        },
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    set_test_program_state(&mut context, &state_account.pubkey(), false).unwrap();
+    context.svm.warp_to_slot(100);
+
+    (context, swig, swig_wallet, swig_authority, state_account)
+}
+
+/// Build a test program instruction with a u32 counter embedded after the
+/// discriminator.
+fn build_test_program_ix_with_counter(
+    swig: Pubkey,
+    swig_wallet: Pubkey,
+    state_account: Pubkey,
+    counter: u32,
+) -> Instruction {
+    let mut data = VALID_DISCRIMINATOR.to_vec();
+    data.extend_from_slice(&counter.to_le_bytes());
+    Instruction {
+        program_id: TEST_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new_readonly(swig, false),
+            AccountMeta::new_readonly(swig_wallet, false),
+            AccountMeta::new_readonly(state_account, false),
+            AccountMeta::new_readonly(program_id(), false),
+        ],
+        data,
+    }
+}
+
+/// Helper to read the ProgramExec authority's signature_odometer from on-chain
+/// swig state.
+fn read_odometer(context: &SwigTestContext, swig: &Pubkey, role_id: u32) -> u32 {
+    let swig_account = context.svm.get_account(swig).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    let role = swig_data.get_role(role_id).unwrap().unwrap();
+    role.authority.signature_odometer().unwrap()
+}
+
+/// Execute a program exec sign with odometer and return the result.
+fn execute_odometer_tx(
+    context: &mut SwigTestContext,
+    swig: Pubkey,
+    swig_wallet: Pubkey,
+    swig_authority: &Keypair,
+    state_account: Pubkey,
+    counter: u32,
+    target_ix_index: u8,
+    odometer_start_index: u16,
+) -> Result<litesvm::types::TransactionMetadata, litesvm::types::FailedTransactionMetadata> {
+    context.svm.expire_blockhash();
+    let test_program_ix =
+        build_test_program_ix_with_counter(swig, swig_wallet, state_account, counter);
+    let inner_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet,
+        &swig_authority.pubkey(),
+        1000,
+    );
+    let instructions = build_program_exec_sign_instructions_with_odometer(
+        swig,
+        swig_wallet,
+        swig_authority.pubkey(),
+        test_program_ix,
+        inner_ix,
+        1, // role_id for ProgramExec authority
+        target_ix_index,
+        odometer_start_index,
+    )
+    .unwrap();
+
+    let message = v0::Message::try_compile(
+        &swig_authority.pubkey(),
+        &instructions,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&swig_authority]).unwrap();
+    context.svm.send_transaction(tx)
+}
+
+/// Test: 4-byte payload with correct counter succeeds and advances odometer.
+#[test_log::test]
+fn test_program_exec_odometer_success() {
+    let (mut context, swig, swig_wallet, swig_authority, state_account) = setup_odometer_test();
+
+    assert_eq!(
+        read_odometer(&context, &swig, 1),
+        0,
+        "Initial odometer should be 0"
+    );
+
+    // target_ix_index=255 means ignore (use current_index - 1)
+    // odometer_start_index=8 (counter is right after the 8-byte discriminator)
+    let res = execute_odometer_tx(
+        &mut context,
+        swig,
+        swig_wallet,
+        &swig_authority,
+        state_account.pubkey(),
+        1, // counter: expected = 0.wrapping_add(1) = 1
+        255,
+        8,
+    );
+
+    if res.is_err() {
+        if let Some(logs) = res.as_ref().err().map(|e| &e.meta.logs) {
+            for log in logs {
+                println!("{}", log);
+            }
+        }
+    }
+
+    assert!(
+        res.is_ok(),
+        "Odometer tx with correct counter should succeed"
+    );
+    assert_eq!(
+        read_odometer(&context, &swig, 1),
+        1,
+        "Odometer should advance to 1"
+    );
+}
+
+/// Test: 4-byte payload with wrong counter fails.
+#[test_log::test]
+fn test_program_exec_odometer_wrong_counter_fails() {
+    let (mut context, swig, swig_wallet, swig_authority, state_account) = setup_odometer_test();
+
+    let res = execute_odometer_tx(
+        &mut context,
+        swig,
+        swig_wallet,
+        &swig_authority,
+        state_account.pubkey(),
+        5, // wrong counter: expected 1, got 5
+        255,
+        8,
+    );
+
+    assert!(res.is_err(), "Odometer tx with wrong counter should fail");
+    assert_eq!(
+        read_odometer(&context, &swig, 1),
+        0,
+        "Odometer should remain 0"
+    );
+}
+
+/// Test: sequential counter increments across multiple transactions.
+#[test_log::test]
+fn test_program_exec_odometer_sequential() {
+    let (mut context, swig, swig_wallet, swig_authority, state_account) = setup_odometer_test();
+
+    for expected_counter in 1u32..=3 {
+        let res = execute_odometer_tx(
+            &mut context,
+            swig,
+            swig_wallet,
+            &swig_authority,
+            state_account.pubkey(),
+            expected_counter,
+            255,
+            8,
+        );
+
+        if res.is_err() {
+            if let Some(logs) = res.as_ref().err().map(|e| &e.meta.logs) {
+                for log in logs {
+                    println!("{}", log);
+                }
+            }
+        }
+
+        assert!(
+            res.is_ok(),
+            "Sequential odometer tx #{} should succeed",
+            expected_counter
+        );
+        assert_eq!(
+            read_odometer(&context, &swig, 1),
+            expected_counter,
+            "Odometer should be {} after tx #{}",
+            expected_counter,
+            expected_counter
+        );
+    }
+}
+
+/// Test: legacy 1-byte payload fails after odometer has been incremented.
+#[test_log::test]
+fn test_program_exec_odometer_required_if_active() {
+    let (mut context, swig, swig_wallet, swig_authority, state_account) = setup_odometer_test();
+
+    // First, advance odometer to 1 using the new 4-byte payload
+    let res = execute_odometer_tx(
+        &mut context,
+        swig,
+        swig_wallet,
+        &swig_authority,
+        state_account.pubkey(),
+        1,
+        255,
+        8,
+    );
+    assert!(res.is_ok(), "First odometer tx should succeed");
+    assert_eq!(read_odometer(&context, &swig, 1), 1);
+
+    // Now try 1-byte payload — should fail because odometer > 0
+    context.svm.expire_blockhash();
+    let test_program_ix = Instruction {
+        program_id: TEST_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new_readonly(swig, false),
+            AccountMeta::new_readonly(swig_wallet, false),
+            AccountMeta::new_readonly(state_account.pubkey(), false),
+            AccountMeta::new_readonly(program_id(), false),
+        ],
+        data: VALID_DISCRIMINATOR.to_vec(),
+    };
+    let inner_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet,
+        &swig_authority.pubkey(),
+        1000,
+    );
+    let instructions = build_program_exec_sign_instructions(
+        swig,
+        swig_wallet,
+        swig_authority.pubkey(),
+        test_program_ix,
+        inner_ix,
+        1,
+    )
+    .unwrap();
+
+    let message = v0::Message::try_compile(
+        &swig_authority.pubkey(),
+        &instructions,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&swig_authority]).unwrap();
+    let res = context.svm.send_transaction(tx);
+
+    assert!(
+        res.is_err(),
+        "1-byte payload should fail when odometer > 0"
+    );
+}
+
+/// Test: 4-byte payload with odometer_start_index=0xFFFF (ignore) works when
+/// odometer == 0.
+#[test_log::test]
+fn test_program_exec_odometer_ignore_when_zero() {
+    let (mut context, swig, swig_wallet, swig_authority, state_account) = setup_odometer_test();
+
+    let res = execute_odometer_tx(
+        &mut context,
+        swig,
+        swig_wallet,
+        &swig_authority,
+        state_account.pubkey(),
+        0, // counter value doesn't matter since odometer is ignored
+        255,
+        0xFFFF, // ignore odometer
+    );
+
+    if res.is_err() {
+        if let Some(logs) = res.as_ref().err().map(|e| &e.meta.logs) {
+            for log in logs {
+                println!("{}", log);
+            }
+        }
+    }
+
+    assert!(
+        res.is_ok(),
+        "4-byte payload with 0xFFFF should succeed when odometer == 0"
+    );
+    assert_eq!(
+        read_odometer(&context, &swig, 1),
+        0,
+        "Odometer should remain 0 when ignored"
+    );
+}
+
+/// Test: 4-byte payload with odometer_start_index=0xFFFF fails when odometer >
+/// 0.
+#[test_log::test]
+fn test_program_exec_odometer_ignore_when_active_fails() {
+    let (mut context, swig, swig_wallet, swig_authority, state_account) = setup_odometer_test();
+
+    // Advance odometer to 1
+    let res = execute_odometer_tx(
+        &mut context,
+        swig,
+        swig_wallet,
+        &swig_authority,
+        state_account.pubkey(),
+        1,
+        255,
+        8,
+    );
+    assert!(res.is_ok(), "First odometer tx should succeed");
+    assert_eq!(read_odometer(&context, &swig, 1), 1);
+
+    // Now try with 0xFFFF — should fail because odometer > 0
+    let res = execute_odometer_tx(
+        &mut context,
+        swig,
+        swig_wallet,
+        &swig_authority,
+        state_account.pubkey(),
+        0,
+        255,
+        0xFFFF,
+    );
+
+    assert!(
+        res.is_err(),
+        "4-byte payload with 0xFFFF should fail when odometer > 0"
+    );
+}
+
+/// Test: 4-byte payload with odometer_start_index < prefix_len fails.
+#[test_log::test]
+fn test_program_exec_odometer_start_before_prefix_fails() {
+    let (mut context, swig, swig_wallet, swig_authority, state_account) = setup_odometer_test();
+
+    // VALID_DISCRIMINATOR is 8 bytes, so prefix_len = 8.
+    // odometer_start_index = 4 which is < 8 — should fail.
+    let res = execute_odometer_tx(
+        &mut context,
+        swig,
+        swig_wallet,
+        &swig_authority,
+        state_account.pubkey(),
+        1,
+        255,
+        4, // overlaps with prefix
+    );
+
+    assert!(
+        res.is_err(),
+        "Odometer start index < prefix_len should fail"
+    );
+}

--- a/program/tests/program_authority_test.rs
+++ b/program/tests/program_authority_test.rs
@@ -1672,10 +1672,7 @@ fn test_program_exec_odometer_required_if_active() {
         VersionedTransaction::try_new(VersionedMessage::V0(message), &[&swig_authority]).unwrap();
     let res = context.svm.send_transaction(tx);
 
-    assert!(
-        res.is_err(),
-        "1-byte payload should fail when odometer > 0"
-    );
+    assert!(res.is_err(), "1-byte payload should fail when odometer > 0");
 }
 
 /// Test: 4-byte payload with odometer_start_index=0xFFFF (ignore) works when

--- a/rust-sdk/src/client_role.rs
+++ b/rust-sdk/src/client_role.rs
@@ -2045,6 +2045,8 @@ where
     pub instruction_prefix: Vec<u8>,
     /// Function that provides the preceding instruction for authentication
     pub preceding_instruction_fn: F,
+    /// Signature counter for replay protection
+    pub odometer: u32,
 }
 
 impl<F> ProgramExecClientRole<F>
@@ -2069,6 +2071,22 @@ where
             program_id,
             instruction_prefix,
             preceding_instruction_fn,
+            odometer: 0,
+        }
+    }
+
+    /// Creates a new ProgramExecClientRole with an initial odometer value.
+    pub fn new_with_odometer(
+        program_id: Pubkey,
+        instruction_prefix: Vec<u8>,
+        preceding_instruction_fn: F,
+        odometer: u32,
+    ) -> Self {
+        Self {
+            program_id,
+            instruction_prefix,
+            preceding_instruction_fn,
+            odometer,
         }
     }
 
@@ -2400,21 +2418,17 @@ where
     }
 
     fn odometer(&self) -> Result<u32, SwigError> {
-        Err(SwigError::InterfaceError(
-            "ProgramExec authority does not use odometer".to_string(),
-        ))
+        Ok(self.odometer)
     }
 
     fn increment_odometer(&mut self) -> Result<(), SwigError> {
-        Err(SwigError::InterfaceError(
-            "ProgramExec authority does not use odometer".to_string(),
-        ))
+        self.odometer = self.odometer.wrapping_add(1);
+        Ok(())
     }
 
-    fn update_odometer(&mut self, _odometer: u32) -> Result<(), SwigError> {
-        Err(SwigError::InterfaceError(
-            "ProgramExec authority does not use odometer".to_string(),
-        ))
+    fn update_odometer(&mut self, odometer: u32) -> Result<(), SwigError> {
+        self.odometer = odometer;
+        Ok(())
     }
 
     fn sign_v2_instruction(

--- a/state/src/authority/programexec/mod.rs
+++ b/state/src/authority/programexec/mod.rs
@@ -20,7 +20,7 @@ use super::{Authority, AuthorityInfo, AuthorityType};
 use crate::{IntoBytes, SwigAuthenticateError, SwigStateError, Transmutable, TransmutableMut};
 
 const MAX_INSTRUCTION_PREFIX_LEN: usize = 40;
-const IX_PREFIX_OFFSET: usize = 32 + 1 + 7; // program_id + instruction_prefix_len + padding
+const IX_PREFIX_OFFSET: usize = 32 + 1 + 3 + 4; // program_id + instruction_prefix_len + padding + signature_odometer
 
 /// Standard Program Execution authority implementation.
 ///
@@ -35,7 +35,9 @@ pub struct ProgramExecAuthority {
     /// Length of the instruction prefix to match (0-40)
     pub instruction_prefix_len: u8,
     /// Padding for alignment
-    _padding: [u8; 7],
+    _padding: [u8; 3],
+    /// Signature counter for replay protection
+    pub signature_odometer: u32,
     pub instruction_prefix: [u8; MAX_INSTRUCTION_PREFIX_LEN],
 }
 
@@ -49,7 +51,8 @@ impl ProgramExecAuthority {
         Self {
             program_id,
             instruction_prefix_len,
-            _padding: [0; 7],
+            _padding: [0; 3],
+            signature_odometer: 0,
             instruction_prefix: [0; MAX_INSTRUCTION_PREFIX_LEN],
         }
     }
@@ -116,6 +119,7 @@ impl Authority for ProgramExecAuthority {
         assert_program_exec_cant_be_swig(create_data_program_id)?;
         authority.program_id.copy_from_slice(create_data_program_id);
         authority.instruction_prefix_len = prefix_len as u8;
+        authority.signature_odometer = 0;
         authority.instruction_prefix[..prefix_len]
             .copy_from_slice(&create_data[IX_PREFIX_OFFSET..IX_PREFIX_OFFSET + prefix_len]);
         Ok(())
@@ -164,7 +168,7 @@ impl AuthorityInfo for ProgramExecAuthority {
     }
 
     fn signature_odometer(&self) -> Option<u32> {
-        None
+        Some(self.signature_odometer)
     }
 
     fn authenticate(
@@ -175,20 +179,70 @@ impl AuthorityInfo for ProgramExecAuthority {
         _slot: u64,
     ) -> Result<(), ProgramError> {
         // authority_payload format:
-        //   1 byte:  [instruction_sysvar_index] -- authenticate against current_index - 1
-        //   2 bytes: [instruction_sysvar_index, target_ix_index] -- authenticate against target_ix_index
-        if authority_payload.is_empty() || authority_payload.len() > 2 {
-            return Err(SwigAuthenticateError::InvalidAuthorityPayload.into());
-        }
+        //   1 byte:  [instruction_sysvar_index] -- legacy, no odometer
+        //   2 bytes: [instruction_sysvar_index, target_ix_index] -- legacy, no odometer
+        //   4 bytes: [instruction_sysvar_index, target_ix_index, odometer_start_index(u16 LE)]
+        //            target_ix_index == 255 means ignore (use current_index - 1)
+        //            odometer_start_index == 0xFFFF means ignore odometer check
+        let (instruction_sysvar_index, target_ix_index, odometer_start_index) =
+            match authority_payload.len() {
+                1 => {
+                    if self.signature_odometer > 0 {
+                        return Err(
+                            SwigAuthenticateError::PermissionDeniedProgramExecSignatureReused
+                                .into(),
+                        );
+                    }
+                    (authority_payload[0] as usize, None, None)
+                },
+                2 => {
+                    if self.signature_odometer > 0 {
+                        return Err(
+                            SwigAuthenticateError::PermissionDeniedProgramExecSignatureReused
+                                .into(),
+                        );
+                    }
+                    (
+                        authority_payload[0] as usize,
+                        Some(authority_payload[1]),
+                        None,
+                    )
+                },
+                4 => {
+                    let sysvar_idx = authority_payload[0] as usize;
+                    let target_ix = if authority_payload[1] == 255 {
+                        None
+                    } else {
+                        Some(authority_payload[1])
+                    };
+                    let odo_start =
+                        u16::from_le_bytes([authority_payload[2], authority_payload[3]]);
+                    if odo_start == 0xFFFF {
+                        if self.signature_odometer > 0 {
+                            return Err(
+                                SwigAuthenticateError::PermissionDeniedProgramExecSignatureReused
+                                    .into(),
+                            );
+                        }
+                        (sysvar_idx, target_ix, None)
+                    } else {
+                        if (odo_start as usize) < self.instruction_prefix_len as usize {
+                            return Err(
+                                SwigAuthenticateError::PermissionDeniedProgramExecInvalidInstructionData
+                                    .into(),
+                            );
+                        }
+                        (sysvar_idx, target_ix, Some(odo_start))
+                    }
+                },
+                _ => return Err(SwigAuthenticateError::InvalidAuthorityPayload.into()),
+            };
 
-        let instruction_sysvar_index = authority_payload[0] as usize;
-        let target_ix_index = if authority_payload.len() == 2 {
-            Some(authority_payload[1])
-        } else {
-            None
-        };
         let config_account_index = 0; // Config is always the first account (swig account)
         let wallet_account_index = 1; // Wallet is the second account (swig wallet address)
+
+        let odometer_config =
+            odometer_start_index.map(|start| (start, self.signature_odometer.wrapping_add(1)));
 
         program_exec_authenticate(
             account_infos,
@@ -199,7 +253,12 @@ impl AuthorityInfo for ProgramExecAuthority {
             &self.instruction_prefix,
             self.instruction_prefix_len as usize,
             target_ix_index,
-        )
+            odometer_config,
+        )?;
+
+        odometer_config.map(|(_, counter)| self.signature_odometer = counter);
+
+        Ok(())
     }
 }
 
@@ -225,6 +284,8 @@ fn assert_program_exec_cant_be_swig(program_id: &[u8]) -> Result<(), ProgramErro
 /// - Has instruction data matching the expected prefix
 /// - Passed the config and wallet accounts as its first two accounts
 /// - Executed successfully (implied by the transaction being valid)
+/// - Optionally validates an odometer counter read from the target instruction
+///   data
 ///
 /// # Arguments
 /// * `account_infos` - List of accounts involved in the transaction
@@ -236,6 +297,10 @@ fn assert_program_exec_cant_be_swig(program_id: &[u8]) -> Result<(), ProgramErro
 /// * `prefix_len` - Length of the prefix to match
 /// * `target_ix_index` - Optional explicit transaction instruction index to
 ///   authenticate against. When `None`, defaults to `current_index - 1`.
+/// * `odometer_config` - Optional `(start_index, expected_counter)`. When
+///   `Some`, reads a u32 from the target instruction data at `start_index` and
+///   validates it equals `expected_counter`. Returns the read counter on
+///   success.
 pub fn program_exec_authenticate(
     account_infos: &[AccountInfo],
     instruction_sysvar_index: usize,
@@ -245,6 +310,7 @@ pub fn program_exec_authenticate(
     expected_instruction_prefix: &[u8; MAX_INSTRUCTION_PREFIX_LEN],
     prefix_len: usize,
     target_ix_index: Option<u8>,
+    odometer_config: Option<(u16, u32)>,
 ) -> Result<(), ProgramError> {
     // Get the sysvar instructions account
     let sysvar_instructions = account_infos
@@ -338,8 +404,22 @@ pub fn program_exec_authenticate(
         return Err(SwigAuthenticateError::PermissionDeniedProgramExecInvalidWalletAccount.into());
     }
 
-    // If we get here, all checks passed - the instruction executed successfully
-    // (implied by the transaction being valid) with the correct program, data, and
-    // accounts
+    // Validate odometer if configured
+    if let Some((odo_start, expected_counter)) = odometer_config {
+        let odo_start = odo_start as usize;
+        let instruction_data = preceding_ix.get_instruction_data();
+        if instruction_data.len() < odo_start + 4 {
+            return Err(
+                SwigAuthenticateError::PermissionDeniedProgramExecInvalidInstructionData.into(),
+            );
+        }
+        let counter = u32::from_le_bytes(unsafe {
+            *(instruction_data.as_ptr().add(odo_start) as *const [u8; 4])
+        });
+        if counter != expected_counter {
+            return Err(SwigAuthenticateError::PermissionDeniedProgramExecSignatureReused.into());
+        }
+    }
+
     Ok(())
 }

--- a/state/src/authority/programexec/session.rs
+++ b/state/src/authority/programexec/session.rs
@@ -22,7 +22,9 @@ pub struct CreateProgramExecSessionAuthority {
     /// Length of the instruction prefix to match (0-32)
     pub instruction_prefix_len: u8,
     /// Padding for alignment
-    _padding: [u8; 7],
+    _padding: [u8; 3],
+    /// Signature counter for replay protection
+    pub signature_odometer: u32,
     /// The instruction data prefix that must match
     pub instruction_prefix: [u8; MAX_INSTRUCTION_PREFIX_LEN],
     /// The session key for temporary authentication
@@ -51,7 +53,8 @@ impl CreateProgramExecSessionAuthority {
             program_id,
             instruction_prefix,
             instruction_prefix_len,
-            _padding: [0; 7],
+            _padding: [0; 3],
+            signature_odometer: 0,
             session_key,
             max_session_length,
         }
@@ -83,7 +86,9 @@ pub struct ProgramExecSessionAuthority {
     /// Length of the instruction prefix to match (0-32)
     pub instruction_prefix_len: u8,
     /// Padding for alignment
-    _padding: [u8; 7],
+    _padding: [u8; 3],
+    /// Signature counter for replay protection
+    pub signature_odometer: u32,
     /// The instruction data prefix that must match
     pub instruction_prefix: [u8; MAX_INSTRUCTION_PREFIX_LEN],
 
@@ -114,7 +119,8 @@ impl ProgramExecSessionAuthority {
         Self {
             program_id,
             instruction_prefix_len,
-            _padding: [0; 7],
+            _padding: [0; 3],
+            signature_odometer: 0,
             instruction_prefix,
             session_key,
             max_session_length,
@@ -158,6 +164,7 @@ impl Authority for ProgramExecSessionAuthority {
         authority.program_id = create.program_id;
         authority.instruction_prefix = create.instruction_prefix;
         authority.instruction_prefix_len = create.instruction_prefix_len;
+        authority.signature_odometer = 0;
         authority.session_key = create.session_key;
         authority.max_session_length = create.max_session_length;
         authority.current_session_expiration = 0;
@@ -184,7 +191,7 @@ impl AuthorityInfo for ProgramExecSessionAuthority {
     }
 
     fn signature_odometer(&self) -> Option<u32> {
-        None
+        Some(self.signature_odometer)
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -254,20 +261,70 @@ impl AuthorityInfo for ProgramExecSessionAuthority {
         _slot: u64,
     ) -> Result<(), ProgramError> {
         // authority_payload format:
-        //   1 byte:  [instruction_sysvar_index] -- authenticate against current_index - 1
-        //   2 bytes: [instruction_sysvar_index, target_ix_index] -- authenticate against target_ix_index
-        if authority_payload.is_empty() || authority_payload.len() > 2 {
-            return Err(SwigAuthenticateError::InvalidAuthorityPayload.into());
-        }
+        //   1 byte:  [instruction_sysvar_index] -- legacy, no odometer
+        //   2 bytes: [instruction_sysvar_index, target_ix_index] -- legacy, no odometer
+        //   4 bytes: [instruction_sysvar_index, target_ix_index, odometer_start_index(u16 LE)]
+        //            target_ix_index == 255 means ignore (use current_index - 1)
+        //            odometer_start_index == 0xFFFF means ignore odometer check
+        let (instruction_sysvar_index, target_ix_index, odometer_start_index) =
+            match authority_payload.len() {
+                1 => {
+                    if self.signature_odometer > 0 {
+                        return Err(
+                            SwigAuthenticateError::PermissionDeniedProgramExecSignatureReused
+                                .into(),
+                        );
+                    }
+                    (authority_payload[0] as usize, None, None)
+                },
+                2 => {
+                    if self.signature_odometer > 0 {
+                        return Err(
+                            SwigAuthenticateError::PermissionDeniedProgramExecSignatureReused
+                                .into(),
+                        );
+                    }
+                    (
+                        authority_payload[0] as usize,
+                        Some(authority_payload[1]),
+                        None,
+                    )
+                },
+                4 => {
+                    let sysvar_idx = authority_payload[0] as usize;
+                    let target_ix = if authority_payload[1] == 0xFF {
+                        None
+                    } else {
+                        Some(authority_payload[1])
+                    };
+                    let odo_start =
+                        u16::from_le_bytes([authority_payload[2], authority_payload[3]]);
+                    if odo_start == 0xFFFF {
+                        if self.signature_odometer > 0 {
+                            return Err(
+                                SwigAuthenticateError::PermissionDeniedProgramExecSignatureReused
+                                    .into(),
+                            );
+                        }
+                        (sysvar_idx, target_ix, None)
+                    } else {
+                        if (odo_start as usize) < self.instruction_prefix_len as usize {
+                            return Err(
+                                SwigAuthenticateError::PermissionDeniedProgramExecInvalidInstructionData
+                                    .into(),
+                            );
+                        }
+                        (sysvar_idx, target_ix, Some(odo_start))
+                    }
+                },
+                _ => return Err(SwigAuthenticateError::InvalidAuthorityPayload.into()),
+            };
 
-        let instruction_sysvar_index = authority_payload[0] as usize;
-        let target_ix_index = if authority_payload.len() == 2 {
-            Some(authority_payload[1])
-        } else {
-            None
-        };
         let config_account_index = 0;
         let wallet_account_index = 1;
+
+        let odometer_config =
+            odometer_start_index.map(|start| (start, self.signature_odometer.wrapping_add(1)));
 
         program_exec_authenticate(
             account_infos,
@@ -278,6 +335,11 @@ impl AuthorityInfo for ProgramExecSessionAuthority {
             &self.instruction_prefix,
             self.instruction_prefix_len as usize,
             target_ix_index,
-        )
+            odometer_config,
+        )?;
+
+        odometer_config.map(|(_, counter)| self.signature_odometer = counter);
+
+        Ok(())
     }
 }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -191,6 +191,8 @@ pub enum SwigAuthenticateError {
     PermissionDeniedProgramExecInvalidWalletAccount,
     /// Program execution cannot be the Swig program
     PermissionDeniedProgramExecCannotBeSwig,
+    /// Program execution signature has been reused (odometer mismatch)
+    PermissionDeniedProgramExecSignatureReused,
 }
 
 impl From<SwigStateError> for ProgramError {


### PR DESCRIPTION
- Add signature odometer (replay protection counter) to ProgramExec and ProgramExecSession authorities
- Repurpose 4 bytes of existing _padding: [u8; 7] → _padding: [u8; 3] + signature_odometer: u32 for binary-compatible struct layout (80/120 bytes unchanged)
- Support a new 4-byte authority payload format [sysvar_ix_index, target_ix_index, odometer_start_index(u16 LE)] that reads the counter from the target instruction's data at the specified byte offset
- Maintain full backwards compatibility: legacy 1-byte and 2-byte payloads continue to work when signature_odometer == 0; once the odometer is incremented, the new 4-byte format is required going forward