### PR TITLE
SWI-450: Reject duplicate authority in Add authority

### DIFF
--- a/program/src/actions/add_authority_v1.rs
+++ b/program/src/actions/add_authority_v1.rs
@@ -179,32 +179,6 @@ pub fn add_authority_v1(
             unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
         let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
 
-        {
-            let mut role_cursor = 0;
-            for _i in 0..swig.roles as usize {
-                let position = unsafe {
-                    Position::load_unchecked(
-                        swig_roles.get_unchecked(role_cursor..role_cursor + Position::LEN),
-                    )?
-                };
-                let authority_length = position.authority_length() as usize;
-                let (authority, actions) = unsafe {
-                    swig_roles
-                        .get_unchecked(
-                            role_cursor + Position::LEN
-                                ..role_cursor + Position::LEN + authority_length,
-                        )
-                        .split_at(authority_length)
-                };
-                if authority == add_authority_v1.authority_data
-                    && position.authority_type()? == new_authority_type
-                {
-                    return Err(SwigError::DuplicateAuthority.into());
-                }
-                role_cursor = position.boundary() as usize;
-            }
-        }
-
         let acting_role = Swig::get_mut_role(add_authority_v1.args.acting_role_id, swig_roles)?;
         if acting_role.is_none() {
             return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
@@ -236,6 +210,30 @@ pub fn add_authority_v1(
         if all.is_none() && manage_authority.is_none() {
             return Err(SwigAuthenticateError::PermissionDeniedToManageAuthority.into());
         }
+
+        {
+            let mut role_cursor = 0;
+            for _i in 0..swig.roles as usize {
+                let position = unsafe {
+                    Position::load_unchecked(
+                        swig_roles.get_unchecked(role_cursor..role_cursor + Position::LEN),
+                    )?
+                };
+                let authority_length = position.authority_length() as usize;
+                let authority = unsafe {
+                    swig_roles.get_unchecked(
+                        role_cursor + Position::LEN..role_cursor + Position::LEN + authority_length,
+                    )
+                };
+                if authority == add_authority_v1.authority_data
+                    && position.authority_type()? == new_authority_type
+                {
+                    return Err(SwigError::DuplicateAuthority.into());
+                }
+                role_cursor = position.boundary() as usize;
+            }
+        }
+
         let new_authority_length = authority_type_to_length(&new_authority_type)?;
         let role_size = Position::LEN + new_authority_length + add_authority_v1.actions.len();
 

--- a/program/src/actions/add_authority_v1.rs
+++ b/program/src/actions/add_authority_v1.rs
@@ -178,6 +178,20 @@ pub fn add_authority_v1(
         let (swig_header, swig_roles) =
             unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
         let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+
+        {
+            let mut role_cursor = 0;
+            for _i in 0..swig.roles as usize {
+                let position = unsafe { Position::load_unchecked(swig_roles.get_unchecked(role_cursor..role_cursor + Position::LEN))? };
+                let authority_length = position.authority_length() as usize;
+                let (authority, actions) = unsafe { swig_roles.get_unchecked(role_cursor + Position::LEN..role_cursor + Position::LEN + authority_length).split_at(authority_length) };
+                if authority == add_authority_v1.authority_data && position.authority_type()? == new_authority_type {
+                    return Err(SwigError::DuplicateAuthority.into());
+                }
+                role_cursor = position.boundary() as usize;
+            }
+        }
+
         let acting_role = Swig::get_mut_role(add_authority_v1.args.acting_role_id, swig_roles)?;
         if acting_role.is_none() {
             return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());

--- a/program/src/actions/add_authority_v1.rs
+++ b/program/src/actions/add_authority_v1.rs
@@ -182,10 +182,23 @@ pub fn add_authority_v1(
         {
             let mut role_cursor = 0;
             for _i in 0..swig.roles as usize {
-                let position = unsafe { Position::load_unchecked(swig_roles.get_unchecked(role_cursor..role_cursor + Position::LEN))? };
+                let position = unsafe {
+                    Position::load_unchecked(
+                        swig_roles.get_unchecked(role_cursor..role_cursor + Position::LEN),
+                    )?
+                };
                 let authority_length = position.authority_length() as usize;
-                let (authority, actions) = unsafe { swig_roles.get_unchecked(role_cursor + Position::LEN..role_cursor + Position::LEN + authority_length).split_at(authority_length) };
-                if authority == add_authority_v1.authority_data && position.authority_type()? == new_authority_type {
+                let (authority, actions) = unsafe {
+                    swig_roles
+                        .get_unchecked(
+                            role_cursor + Position::LEN
+                                ..role_cursor + Position::LEN + authority_length,
+                        )
+                        .split_at(authority_length)
+                };
+                if authority == add_authority_v1.authority_data
+                    && position.authority_type()? == new_authority_type
+                {
                     return Err(SwigError::DuplicateAuthority.into());
                 }
                 role_cursor = position.boundary() as usize;

--- a/program/tests/add_authority_test.rs
+++ b/program/tests/add_authority_test.rs
@@ -257,7 +257,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should succeed - current equals limit and last_reset is 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -277,7 +280,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - current doesn't equal limit
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -300,7 +306,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - last_reset is not 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -327,7 +336,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should succeed - current equals limit and last_reset is 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -348,7 +360,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - current doesn't equal limit
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -372,7 +387,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - last_reset is not 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -399,7 +417,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should succeed - current equals limit and last_reset is 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -419,7 +440,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - current doesn't equal limit
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -442,7 +466,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - last_reset is not 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -508,10 +535,7 @@ fn test_cannot_add_duplicate_authority() {
         vec![ClientAction::ManageAuthority(ManageAuthority {})],
     );
 
-    assert!(
-        result.is_err(),
-        "Re-adding the same authority should fail"
-    );
+    assert!(result.is_err(), "Re-adding the same authority should fail");
     if let Err(err) = result {
         let error_string = format!("{:?}", err);
         assert!(

--- a/program/tests/add_authority_test.rs
+++ b/program/tests/add_authority_test.rs
@@ -248,23 +248,23 @@ fn test_recurring_action_layout_validation() {
 
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
-    let second_authority = Keypair::new();
-    context
-        .svm
-        .airdrop(&second_authority.pubkey(), 10_000_000_000)
-        .unwrap();
+
+    // Each add_authority call uses a fresh keypair to keep each case independent
+    // from the program's duplicate-authority check.
 
     // Test SOL recurring limit validation
     use swig_state::action::sol_recurring_limit::SolRecurringLimit;
 
     // Should succeed - current equals limit and last_reset is 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::SolRecurringLimit(SolRecurringLimit {
             recurring_amount: 500,
@@ -276,13 +276,15 @@ fn test_recurring_action_layout_validation() {
     assert!(result.is_ok(), "Valid SOL recurring limit should succeed");
 
     // Should fail - current doesn't equal limit
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::SolRecurringLimit(SolRecurringLimit {
             recurring_amount: 500,
@@ -297,13 +299,15 @@ fn test_recurring_action_layout_validation() {
     );
 
     // Should fail - last_reset is not 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::SolRecurringLimit(SolRecurringLimit {
             recurring_amount: 500,
@@ -322,13 +326,15 @@ fn test_recurring_action_layout_validation() {
     let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
 
     // Should succeed - current equals limit and last_reset is 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::TokenRecurringLimit(TokenRecurringLimit {
             token_mint: mint_pubkey.to_bytes().try_into().unwrap(),
@@ -341,13 +347,15 @@ fn test_recurring_action_layout_validation() {
     assert!(result.is_ok(), "Valid token recurring limit should succeed");
 
     // Should fail - current doesn't equal limit
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::TokenRecurringLimit(TokenRecurringLimit {
             token_mint: mint_pubkey.to_bytes().try_into().unwrap(),
@@ -363,13 +371,15 @@ fn test_recurring_action_layout_validation() {
     );
 
     // Should fail - last_reset is not 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::TokenRecurringLimit(TokenRecurringLimit {
             token_mint: mint_pubkey.to_bytes().try_into().unwrap(),
@@ -388,13 +398,15 @@ fn test_recurring_action_layout_validation() {
     use swig_state::action::stake_recurring_limit::StakeRecurringLimit;
 
     // Should succeed - current equals limit and last_reset is 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::StakeRecurringLimit(StakeRecurringLimit {
             recurring_amount: 500,
@@ -406,13 +418,15 @@ fn test_recurring_action_layout_validation() {
     assert!(result.is_ok(), "Valid stake recurring limit should succeed");
 
     // Should fail - current doesn't equal limit
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::StakeRecurringLimit(StakeRecurringLimit {
             recurring_amount: 500,
@@ -427,13 +441,15 @@ fn test_recurring_action_layout_validation() {
     );
 
     // Should fail - last_reset is not 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::StakeRecurringLimit(StakeRecurringLimit {
             recurring_amount: 500,
@@ -445,5 +461,176 @@ fn test_recurring_action_layout_validation() {
     assert!(
         result.is_err(),
         "Stake recurring limit with non-zero last_reset should fail"
+    );
+}
+
+#[test_log::test]
+fn test_cannot_add_duplicate_authority() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    context.svm.warp_to_slot(10);
+
+    let result = add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    );
+
+    assert!(
+        result.is_err(),
+        "Re-adding the same authority should fail"
+    );
+    if let Err(err) = result {
+        let error_string = format!("{:?}", err);
+        assert!(
+            error_string.contains("DuplicateAuthority") || error_string.contains("Custom"),
+            "Expected duplicate authority error, got: {:?}",
+            err
+        );
+    }
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(
+        swig.state.roles, 2,
+        "Duplicate attempt should not add a role"
+    );
+    assert_eq!(
+        swig.state.role_counter, 2,
+        "Duplicate attempt should not burn a role id"
+    );
+}
+
+#[test_log::test]
+fn test_cannot_add_duplicate_of_last_role_among_multiple() {
+    use swig_state::action::{all::All, sol_limit::SolLimit};
+
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    // Three distinct authorities, each with a different action set.
+    let authority1 = Keypair::new();
+    let authority2 = Keypair::new();
+    let authority3 = Keypair::new();
+    for kp in [&authority1, &authority2, &authority3] {
+        context.svm.airdrop(&kp.pubkey(), 10_000_000_000).unwrap();
+    }
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: authority1.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+    context.svm.warp_to_slot(10);
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: authority2.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1_000_000 })],
+    )
+    .unwrap();
+    context.svm.warp_to_slot(12);
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: authority3.pubkey().as_ref(),
+        },
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+    context.svm.warp_to_slot(14);
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig.state.roles, 4, "Setup should have root + 3 roles");
+
+    // Re-add authority3 (the last role) — must fail.
+    let result = add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: authority3.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    );
+
+    assert!(
+        result.is_err(),
+        "Re-adding the last existing authority should fail"
+    );
+    if let Err(err) = result {
+        let error_string = format!("{:?}", err);
+        assert!(
+            error_string.contains("DuplicateAuthority") || error_string.contains("Custom"),
+            "Expected duplicate authority error, got: {:?}",
+            err
+        );
+    }
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(
+        swig.state.roles, 4,
+        "Duplicate attempt should not add a role"
+    );
+    assert_eq!(
+        swig.state.role_counter, 4,
+        "Duplicate attempt should not burn a role id"
     );
 }

--- a/program/tests/add_authority_v2_test.rs
+++ b/program/tests/add_authority_v2_test.rs
@@ -254,23 +254,23 @@ fn test_recurring_action_layout_validation() {
 
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
-    let second_authority = Keypair::new();
-    context
-        .svm
-        .airdrop(&second_authority.pubkey(), 10_000_000_000)
-        .unwrap();
+
+    // Each add_authority call uses a fresh keypair to keep each case independent
+    // from the program's duplicate-authority check.
 
     // Test SOL recurring limit validation
     use swig_state::action::sol_recurring_limit::SolRecurringLimit;
 
     // Should succeed - current equals limit and last_reset is 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::SolRecurringLimit(SolRecurringLimit {
             recurring_amount: 500,
@@ -282,13 +282,15 @@ fn test_recurring_action_layout_validation() {
     assert!(result.is_ok(), "Valid SOL recurring limit should succeed");
 
     // Should fail - current doesn't equal limit
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::SolRecurringLimit(SolRecurringLimit {
             recurring_amount: 500,
@@ -303,13 +305,15 @@ fn test_recurring_action_layout_validation() {
     );
 
     // Should fail - last_reset is not 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::SolRecurringLimit(SolRecurringLimit {
             recurring_amount: 500,
@@ -328,13 +332,15 @@ fn test_recurring_action_layout_validation() {
     let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
 
     // Should succeed - current equals limit and last_reset is 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::TokenRecurringLimit(TokenRecurringLimit {
             token_mint: mint_pubkey.to_bytes().try_into().unwrap(),
@@ -347,13 +353,15 @@ fn test_recurring_action_layout_validation() {
     assert!(result.is_ok(), "Valid token recurring limit should succeed");
 
     // Should fail - current doesn't equal limit
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::TokenRecurringLimit(TokenRecurringLimit {
             token_mint: mint_pubkey.to_bytes().try_into().unwrap(),
@@ -369,13 +377,15 @@ fn test_recurring_action_layout_validation() {
     );
 
     // Should fail - last_reset is not 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::TokenRecurringLimit(TokenRecurringLimit {
             token_mint: mint_pubkey.to_bytes().try_into().unwrap(),
@@ -394,13 +404,15 @@ fn test_recurring_action_layout_validation() {
     use swig_state::action::stake_recurring_limit::StakeRecurringLimit;
 
     // Should succeed - current equals limit and last_reset is 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::StakeRecurringLimit(StakeRecurringLimit {
             recurring_amount: 500,
@@ -412,13 +424,15 @@ fn test_recurring_action_layout_validation() {
     assert!(result.is_ok(), "Valid stake recurring limit should succeed");
 
     // Should fail - current doesn't equal limit
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::StakeRecurringLimit(StakeRecurringLimit {
             recurring_amount: 500,
@@ -433,13 +447,15 @@ fn test_recurring_action_layout_validation() {
     );
 
     // Should fail - last_reset is not 0
+    let authority = Keypair::new();
+    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
         &swig_authority,
         AuthorityConfig {
             authority_type: AuthorityType::Ed25519,
-            authority: second_authority.pubkey().as_ref(),
+            authority: authority.pubkey().as_ref(),
         },
         vec![ClientAction::StakeRecurringLimit(StakeRecurringLimit {
             recurring_amount: 500,

--- a/program/tests/add_authority_v2_test.rs
+++ b/program/tests/add_authority_v2_test.rs
@@ -263,7 +263,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should succeed - current equals limit and last_reset is 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -283,7 +286,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - current doesn't equal limit
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -306,7 +312,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - last_reset is not 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -333,7 +342,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should succeed - current equals limit and last_reset is 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -354,7 +366,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - current doesn't equal limit
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -378,7 +393,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - last_reset is not 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -405,7 +423,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should succeed - current equals limit and last_reset is 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -425,7 +446,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - current doesn't equal limit
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,
@@ -448,7 +472,10 @@ fn test_recurring_action_layout_validation() {
 
     // Should fail - last_reset is not 0
     let authority = Keypair::new();
-    context.svm.airdrop(&authority.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&authority.pubkey(), 10_000_000_000)
+        .unwrap();
     let result = add_authority_with_ed25519_root(
         &mut context,
         &swig_key,

--- a/program/tests/program_scope_test_v2.rs
+++ b/program/tests/program_scope_test_v2.rs
@@ -41,6 +41,7 @@ fn test_token_transfer_with_program_scope_v2() {
 
     // Setup payers and recipients
     let swig_authority = Keypair::new();
+    let program_scope_authority = Keypair::new();
     let regular_sender = Keypair::new();
     let recipient = Keypair::new();
 
@@ -48,6 +49,10 @@ fn test_token_transfer_with_program_scope_v2() {
     context
         .svm
         .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&program_scope_authority.pubkey(), 10_000_000_000)
         .unwrap();
     context
         .svm
@@ -98,7 +103,7 @@ fn test_token_transfer_with_program_scope_v2() {
         &swig_authority,
         AuthorityConfig {
             authority_type: swig_state::authority::AuthorityType::Ed25519,
-            authority: swig_authority.pubkey().as_ref(),
+            authority: program_scope_authority.pubkey().as_ref(),
         },
         vec![
             ClientAction::Program(Program {
@@ -201,14 +206,14 @@ fn test_token_transfer_with_program_scope_v2() {
     let sign_ix = SignV2Instruction::new_ed25519(
         swig,
         swig_wallet_address,
-        swig_authority.pubkey(),
+        program_scope_authority.pubkey(),
         swig_transfer_ix,
         1, // authority role id
     )
     .unwrap();
 
     let swig_transfer_message = v0::Message::try_compile(
-        &swig_authority.pubkey(),
+        &program_scope_authority.pubkey(),
         &[sign_ix],
         &[],
         context.svm.latest_blockhash(),
@@ -219,7 +224,7 @@ fn test_token_transfer_with_program_scope_v2() {
 
     let swig_transfer_tx = VersionedTransaction::try_new(
         VersionedMessage::V0(swig_transfer_message),
-        &[swig_authority],
+        &[program_scope_authority],
     )
     .unwrap();
 
@@ -412,8 +417,16 @@ fn read_program_scope_state_v2(
             const PROGRAM_SCOPE_LEN: usize = 144; // Fixed: was incorrectly 128
 
             if action_data.len() == PROGRAM_SCOPE_LEN {
+                // ProgramScope contains u128 fields, so the host requires 16-byte
+                // alignment when reborrowing from a byte slice. role.actions points
+                // into a Vec<u8> that may only be 8-aligned, so copy into an aligned
+                // local buffer first.
+                #[repr(C, align(16))]
+                struct AlignedProgramScopeBytes([u8; PROGRAM_SCOPE_LEN]);
+                let mut aligned = AlignedProgramScopeBytes([0u8; PROGRAM_SCOPE_LEN]);
+                aligned.0.copy_from_slice(action_data);
                 let program_scope = unsafe {
-                    swig_state::action::program_scope::ProgramScope::load_unchecked(action_data)
+                    swig_state::action::program_scope::ProgramScope::load_unchecked(&aligned.0)
                 }
                 .ok()?;
 
@@ -471,12 +484,17 @@ fn test_recurring_limit_program_scope_v2() {
 
     // Setup payers and recipients
     let swig_authority = Keypair::new();
+    let program_scope_authority = Keypair::new();
     let recipient = Keypair::new();
 
     // Airdrop to participants
     context
         .svm
         .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&program_scope_authority.pubkey(), 10_000_000_000)
         .unwrap();
     context
         .svm
@@ -549,7 +567,7 @@ fn test_recurring_limit_program_scope_v2() {
         &swig_authority,
         AuthorityConfig {
             authority_type: swig_state::authority::AuthorityType::Ed25519,
-            authority: swig_authority.pubkey().as_ref(),
+            authority: program_scope_authority.pubkey().as_ref(),
         },
         vec![
             ClientAction::Program(Program {
@@ -585,8 +603,12 @@ fn test_recurring_limit_program_scope_v2() {
     let transfer_batch = 100;
 
     // Check initial program scope state
-    let initial_amount =
-        read_program_scope_state_v2(&mut context, &swig, &swig_authority, &swig_wallet_ata);
+    let initial_amount = read_program_scope_state_v2(
+        &mut context,
+        &swig,
+        &program_scope_authority,
+        &swig_wallet_ata,
+    );
     println!("Initial program scope current_amount: {:?}", initial_amount);
 
     // Transfer in batches of 100 tokens up to limit (should succeed)
@@ -595,7 +617,7 @@ fn test_recurring_limit_program_scope_v2() {
             &mut context,
             swig,
             swig_wallet_address,
-            &swig_authority,
+            &program_scope_authority,
             swig_wallet_ata,
             recipient_ata,
             transfer_batch,
@@ -605,8 +627,12 @@ fn test_recurring_limit_program_scope_v2() {
         println!("Total transferred: {}/{}", transferred, transfer_limit);
 
         // Check program scope state after each transfer
-        let current_amount =
-            read_program_scope_state_v2(&mut context, &swig, &swig_authority, &swig_wallet_ata);
+        let current_amount = read_program_scope_state_v2(
+            &mut context,
+            &swig,
+            &program_scope_authority,
+            &swig_wallet_ata,
+        );
         println!(
             "After transfer, program scope current_amount: {:?}",
             current_amount
@@ -627,7 +653,7 @@ fn test_recurring_limit_program_scope_v2() {
         &mut context,
         swig,
         swig_wallet_address,
-        &swig_authority,
+        &program_scope_authority,
         swig_wallet_ata,
         recipient_ata,
         transfer_batch,
@@ -635,8 +661,12 @@ fn test_recurring_limit_program_scope_v2() {
     );
 
     // Check program scope state after failed transfer
-    let current_amount =
-        read_program_scope_state_v2(&mut context, &swig, &swig_authority, &swig_wallet_ata);
+    let current_amount = read_program_scope_state_v2(
+        &mut context,
+        &swig,
+        &program_scope_authority,
+        &swig_wallet_ata,
+    );
     println!(
         "After failed transfer, program scope current_amount: {:?}",
         current_amount
@@ -669,8 +699,12 @@ fn test_recurring_limit_program_scope_v2() {
     );
 
     // Check program scope state after slot advancement
-    let current_amount =
-        read_program_scope_state_v2(&mut context, &swig, &swig_authority, &swig_wallet_ata);
+    let current_amount = read_program_scope_state_v2(
+        &mut context,
+        &swig,
+        &program_scope_authority,
+        &swig_wallet_ata,
+    );
     println!(
         "After slot advancement, program scope current_amount: {:?}",
         current_amount
@@ -686,7 +720,7 @@ fn test_recurring_limit_program_scope_v2() {
             &mut context,
             swig,
             swig_wallet_address,
-            &swig_authority,
+            &program_scope_authority,
             swig_wallet_ata,
             recipient_ata,
             transfer_batch,
@@ -699,8 +733,12 @@ fn test_recurring_limit_program_scope_v2() {
         );
 
         // Check program scope state after each transfer in second batch
-        let current_amount =
-            read_program_scope_state_v2(&mut context, &swig, &swig_authority, &swig_wallet_ata);
+        let current_amount = read_program_scope_state_v2(
+            &mut context,
+            &swig,
+            &program_scope_authority,
+            &swig_wallet_ata,
+        );
         println!(
             "After transfer (post-reset), program scope current_amount: {:?}",
             current_amount
@@ -728,7 +766,7 @@ fn test_recurring_limit_program_scope_v2() {
         &mut context,
         swig,
         swig_wallet_address,
-        &swig_authority,
+        &program_scope_authority,
         swig_wallet_ata,
         recipient_ata,
         transfer_batch,
@@ -746,7 +784,7 @@ fn test_recurring_limit_program_scope_v2() {
         &mut context,
         swig,
         swig_wallet_address,
-        &swig_authority,
+        &program_scope_authority,
         swig_wallet_ata,
         recipient_ata,
         transfer_batch,
@@ -765,7 +803,7 @@ fn test_recurring_limit_program_scope_v2() {
         &mut context,
         swig,
         swig_wallet_address,
-        &swig_authority,
+        &program_scope_authority,
         swig_wallet_ata,
         recipient_ata,
         transfer_batch,
@@ -1031,12 +1069,17 @@ fn test_program_scope_token_limit_cpi_enforcement_v2() {
 fn test_program_scope_balance_underflow_check_v2() {
     let mut context = setup_test_context().unwrap();
     let swig_authority = Keypair::new();
+    let program_scope_authority = Keypair::new();
     let external_funding_account = Keypair::new(); // External account that funds the swig wallet
 
     // Airdrops
     context
         .svm
         .airdrop(&swig_authority.pubkey(), 10 * LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&program_scope_authority.pubkey(), 10 * LAMPORTS_PER_SOL)
         .unwrap();
     context
         .svm
@@ -1101,7 +1144,7 @@ fn test_program_scope_balance_underflow_check_v2() {
         &swig_authority,
         AuthorityConfig {
             authority_type: swig_state::authority::AuthorityType::Ed25519,
-            authority: swig_authority.pubkey().as_ref(),
+            authority: program_scope_authority.pubkey().as_ref(),
         },
         vec![
             ClientAction::Program(swig_state::action::program::Program {
@@ -1141,7 +1184,7 @@ fn test_program_scope_balance_underflow_check_v2() {
     let initial_accounts = vec![
         AccountMeta::new(swig, false),
         AccountMeta::new(swig_wallet_address, false),
-        AccountMeta::new_readonly(swig_authority.pubkey(), true),
+        AccountMeta::new_readonly(program_scope_authority.pubkey(), true),
         AccountMeta::new(external_funding_ata, false),
         AccountMeta::new(swig_wallet_ata, false),
         AccountMeta::new_readonly(external_funding_account.pubkey(), true),
@@ -1176,7 +1219,7 @@ fn test_program_scope_balance_underflow_check_v2() {
         VersionedMessage::V0(message),
         &[
             &context.default_payer,
-            &swig_authority,
+            &program_scope_authority,
             &external_funding_account,
         ],
     )
@@ -1692,9 +1735,14 @@ fn test_program_scope_multiple_targets_v2() {
     let mut context = setup_test_context().unwrap();
 
     let swig_authority = Keypair::new();
+    let program_scope_authority = Keypair::new();
     context
         .svm
         .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&program_scope_authority.pubkey(), 10_000_000_000)
         .unwrap();
 
     // Setup two different token mints
@@ -1801,7 +1849,7 @@ fn test_program_scope_multiple_targets_v2() {
         &swig_authority,
         AuthorityConfig {
             authority_type: swig_state::authority::AuthorityType::Ed25519,
-            authority: swig_authority.pubkey().as_ref(),
+            authority: program_scope_authority.pubkey().as_ref(),
         },
         vec![
             ClientAction::Program(Program {
@@ -1836,14 +1884,14 @@ fn test_program_scope_multiple_targets_v2() {
     let sign_ix1 = SignV2Instruction::new_ed25519(
         swig,
         swig_wallet_address,
-        swig_authority.pubkey(),
+        program_scope_authority.pubkey(),
         transfer1_ix,
         1,
     )
     .unwrap();
 
     let message = v0::Message::try_compile(
-        &swig_authority.pubkey(),
+        &program_scope_authority.pubkey(),
         &[sign_ix1],
         &[],
         context.svm.latest_blockhash(),
@@ -1851,7 +1899,8 @@ fn test_program_scope_multiple_targets_v2() {
     .unwrap();
 
     let tx =
-        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&swig_authority]).unwrap();
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&program_scope_authority])
+            .unwrap();
 
     let result = context.svm.send_transaction(tx);
     assert!(
@@ -1882,14 +1931,14 @@ fn test_program_scope_multiple_targets_v2() {
     let sign_ix2 = SignV2Instruction::new_ed25519(
         swig,
         swig_wallet_address,
-        swig_authority.pubkey(),
+        program_scope_authority.pubkey(),
         transfer2_ix,
         1,
     )
     .unwrap();
 
     let message = v0::Message::try_compile(
-        &swig_authority.pubkey(),
+        &program_scope_authority.pubkey(),
         &[sign_ix2],
         &[],
         context.svm.latest_blockhash(),
@@ -1897,7 +1946,8 @@ fn test_program_scope_multiple_targets_v2() {
     .unwrap();
 
     let tx =
-        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&swig_authority]).unwrap();
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&program_scope_authority])
+            .unwrap();
 
     let result = context.svm.send_transaction(tx);
     assert!(
@@ -1939,14 +1989,14 @@ fn test_program_scope_multiple_targets_v2() {
     let sign_ix_over = SignV2Instruction::new_ed25519(
         swig,
         swig_wallet_address,
-        swig_authority.pubkey(),
+        program_scope_authority.pubkey(),
         over_limit_ix,
         1,
     )
     .unwrap();
 
     let message = v0::Message::try_compile(
-        &swig_authority.pubkey(),
+        &program_scope_authority.pubkey(),
         &[sign_ix_over],
         &[],
         context.svm.latest_blockhash(),
@@ -1954,7 +2004,8 @@ fn test_program_scope_multiple_targets_v2() {
     .unwrap();
 
     let tx =
-        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&swig_authority]).unwrap();
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&program_scope_authority])
+            .unwrap();
 
     let result = context.svm.send_transaction(tx);
     assert!(
@@ -1973,9 +2024,14 @@ fn test_program_scope_invalid_balance_field_indices_v2() {
     let mut context = setup_test_context().unwrap();
 
     let swig_authority = Keypair::new();
+    let program_scope_authority = Keypair::new();
     context
         .svm
         .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&program_scope_authority.pubkey(), 10_000_000_000)
         .unwrap();
 
     let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
@@ -2040,7 +2096,7 @@ fn test_program_scope_invalid_balance_field_indices_v2() {
         &swig_authority,
         AuthorityConfig {
             authority_type: swig_state::authority::AuthorityType::Ed25519,
-            authority: swig_authority.pubkey().as_ref(),
+            authority: program_scope_authority.pubkey().as_ref(),
         },
         vec![
             ClientAction::Program(Program {
@@ -2074,14 +2130,14 @@ fn test_program_scope_invalid_balance_field_indices_v2() {
     let sign_ix = SignV2Instruction::new_ed25519(
         swig,
         swig_wallet_address,
-        swig_authority.pubkey(),
+        program_scope_authority.pubkey(),
         transfer_ix,
         1,
     )
     .unwrap();
 
     let message = v0::Message::try_compile(
-        &swig_authority.pubkey(),
+        &program_scope_authority.pubkey(),
         &[sign_ix],
         &[],
         context.svm.latest_blockhash(),
@@ -2089,7 +2145,8 @@ fn test_program_scope_invalid_balance_field_indices_v2() {
     .unwrap();
 
     let tx =
-        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&swig_authority]).unwrap();
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&program_scope_authority])
+            .unwrap();
 
     let result = context.svm.send_transaction(tx);
 

--- a/rust-sdk/src/tests/ix_builder/authority_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/authority_tests.rs
@@ -201,7 +201,7 @@ fn test_remove_authority_with_ed25519_root() {
     let add_auth_ix = builder
         .add_authority_instruction(
             AuthorityType::Ed25519,
-            &authority_pubkey.to_bytes(),
+            &new_authority.pubkey().to_bytes(),
             permissions,
             None,
         )

--- a/rust-sdk/src/tests/wallet/sub_accounts_test.rs
+++ b/rust-sdk/src/tests/wallet/sub_accounts_test.rs
@@ -422,9 +422,8 @@ fn test_sub_account_error_cases() {
         SwigError::TransactionFailedWithLogs { .. }
     ));
 
-    // Test Case 4: Create valid sub-account with main authority
-    // First, ensure main authority has sub-account permission
-    // Add sub-account permission to main authority
+    // Test Case 4: Create valid sub-account with a dedicated sub-account authority
+    // First, switch back to main authority (role 0) to perform the add
     swig_wallet
         .switch_authority(
             0,
@@ -433,10 +432,15 @@ fn test_sub_account_error_cases() {
         )
         .unwrap();
 
+    let sub_account_authority = Keypair::new();
+    swig_wallet
+        .litesvm()
+        .airdrop(&sub_account_authority.pubkey(), 100_000_000)
+        .unwrap();
     swig_wallet
         .add_authority(
             AuthorityType::Ed25519,
-            &main_authority.pubkey().to_bytes(),
+            &sub_account_authority.pubkey().to_bytes(),
             vec![Permission::SubAccount {
                 sub_account: [0; 32],
             }],
@@ -446,8 +450,8 @@ fn test_sub_account_error_cases() {
     swig_wallet
         .switch_authority(
             2,
-            Box::new(Ed25519ClientRole::new(main_authority.pubkey())),
-            Some(&main_authority),
+            Box::new(Ed25519ClientRole::new(sub_account_authority.pubkey())),
+            Some(&sub_account_authority),
         )
         .unwrap();
 


### PR DESCRIPTION
- Iterate existing roles once before realloc and return "DuplicateAuthority" if any role already stores the same authority bytes and authority type.
- Added test cases for the same