### PR TITLE
SWI-479: Fix SignV2 destination-limit transfer scanning

### DIFF
--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -492,8 +492,7 @@ pub fn sign_v2(
                                     )? {
                                         dest_action.run(amount, slot)?;
                                         destination_limit_applied = true;
-                                        return Ok(false); // Stop processing
-                                                          // after first match
+                                        return Ok(true);
                                     }
 
                                     // Then check non-recurring destination limits
@@ -504,11 +503,11 @@ pub fn sign_v2(
                                     )? {
                                         dest_action.run(amount)?;
                                         destination_limit_applied = true;
-                                        return Ok(false); // Stop processing
-                                                          // after first match
+                                        return Ok(true);
                                     }
 
-                                    Ok(true) // Continue processing
+                                    Err(SwigAuthenticateError::PermissionDeniedMissingPermission
+                                        .into())
                                 },
                             )?;
 
@@ -574,52 +573,54 @@ pub fn sign_v2(
                     }
 
                     if total_token_spent > 0 {
-                        // Check token destination limits for outgoing transfers using zero-copy
-                        // approach
                         let source_account_key = unsafe { all_accounts.get_unchecked(index) }.key();
-                        let mut destination_limit_applied = false;
+                        if has_token_destination_limits(actions, mint)? {
+                            let mut destination_limit_applied = false;
 
-                        process_token_destinations(
-                            sign_v2.instruction_payload,
-                            source_account_key,
-                            all_accounts,
-                            ctx.accounts.swig_wallet_address.key(),
-                            |destination| -> Result<bool, ProgramError> {
-                                // Create the combined key [mint + destination] for matching
-                                let mut combined_key = [0u8; 64];
-                                combined_key[..32].copy_from_slice(mint);
-                                combined_key[32..].copy_from_slice(destination.as_ref());
+                            process_token_destinations(
+                                sign_v2.instruction_payload,
+                                source_account_key,
+                                all_accounts,
+                                ctx.accounts.swig_wallet_address.key(),
+                                |destination, amount| -> Result<bool, ProgramError> {
+                                    // Create the combined key [mint + destination] for matching
+                                    let mut combined_key = [0u8; 64];
+                                    combined_key[..32].copy_from_slice(mint);
+                                    combined_key[32..].copy_from_slice(destination.as_ref());
 
-                                // First check recurring destination limits
-                                if let Some(action) = RoleMut::get_action_mut::<
-                                    TokenRecurringDestinationLimit,
-                                >(
-                                    actions, &combined_key
-                                )? {
-                                    action.run(total_token_spent, slot)?;
-                                    destination_limit_applied = true;
-                                    return Ok(false); // Stop processing after
-                                                      // first match
-                                }
+                                    // First check recurring destination limits
+                                    if let Some(action) = RoleMut::get_action_mut::<
+                                        TokenRecurringDestinationLimit,
+                                    >(
+                                        actions, &combined_key
+                                    )? {
+                                        action.run(amount, slot)?;
+                                        destination_limit_applied = true;
+                                        return Ok(true);
+                                    }
 
-                                // Then check non-recurring destination limits
-                                if let Some(action) = RoleMut::get_action_mut::<
-                                    TokenDestinationLimit,
-                                >(
-                                    actions, &combined_key
-                                )? {
-                                    action.run(total_token_spent)?;
-                                    destination_limit_applied = true;
-                                    return Ok(false); // Stop processing after
-                                                      // first match
-                                }
+                                    // Then check non-recurring destination limits
+                                    if let Some(action) = RoleMut::get_action_mut::<
+                                        TokenDestinationLimit,
+                                    >(
+                                        actions, &combined_key
+                                    )? {
+                                        action.run(amount)?;
+                                        destination_limit_applied = true;
+                                        return Ok(true);
+                                    }
 
-                                Ok(true) // Continue processing
-                            },
-                        )?;
+                                    Err(SwigAuthenticateError::PermissionDeniedMissingPermission
+                                        .into())
+                                },
+                            )?;
 
-                        // If a destination limit was applied, continue to next account
-                        if destination_limit_applied {
+                            if !destination_limit_applied {
+                                return Err(
+                                    SwigAuthenticateError::PermissionDeniedMissingPermission.into(),
+                                );
+                            }
+
                             continue 'account_loop;
                         }
 
@@ -779,6 +780,38 @@ fn has_sol_destination_limits(actions_data: &[u8]) -> Result<bool, ProgramError>
     Ok(false)
 }
 
+/// Checks if the role has token destination limits configured for a mint.
+fn has_token_destination_limits(
+    actions_data: &[u8],
+    token_mint: &[u8],
+) -> Result<bool, ProgramError> {
+    let mut cursor = 0;
+    while cursor < actions_data.len() {
+        if cursor + Action::LEN > actions_data.len() {
+            break;
+        }
+
+        let action =
+            unsafe { Action::load_unchecked(&actions_data[cursor..cursor + Action::LEN])? };
+        let permission = action.permission()?;
+        let action_start = cursor + Action::LEN;
+        let boundary = action.boundary() as usize;
+
+        if (permission == Permission::TokenDestinationLimit
+            || permission == Permission::TokenRecurringDestinationLimit)
+            && boundary >= action_start + 32
+            && actions_data.len() >= action_start + 32
+            && token_mint == &actions_data[action_start..action_start + 32]
+        {
+            return Ok(true);
+        }
+
+        cursor = boundary;
+    }
+
+    Ok(false)
+}
+
 /// Processes SOL transfer destinations and amounts from instruction payload
 /// using a callback. This zero-copy approach avoids allocations by calling the
 /// provided function for each transfer.
@@ -800,8 +833,8 @@ fn process_sol_transfers<F>(
     mut callback: F,
 ) -> Result<(), ProgramError>
 where
-    F: FnMut(&Pubkey, u64) -> Result<bool, ProgramError>, /* Returns true to continue, false to
-                                                           * stop */
+    // Returns true to continue, false to stop.
+    F: FnMut(&Pubkey, u64) -> Result<bool, ProgramError>,
 {
     // Parse the instruction payload using the instruction iterator
     let restricted_keys: &[&Pubkey] = &[]; // No restricted keys for this use case
@@ -878,7 +911,8 @@ fn process_token_destinations<F>(
     mut callback: F,
 ) -> Result<(), ProgramError>
 where
-    F: FnMut(&Pubkey) -> Result<bool, ProgramError>, // Returns true to continue, false to stop
+    F: FnMut(&Pubkey, u64) -> Result<bool, ProgramError>, /* Returns true to continue, false to
+                                                           * stop */
 {
     // Parse the instruction payload using the instruction iterator
     let restricted_keys: &[&Pubkey] = &[]; // No restricted keys for this use case
@@ -893,7 +927,7 @@ where
             || *instruction.program_id == crate::SPL_TOKEN_2022_ID
         {
             // Check if this is a Transfer instruction (discriminator = 3)
-            if !instruction.data.is_empty() && instruction.data[0] == 3 {
+            if instruction.data.len() >= 9 && instruction.data[0] == 3 {
                 // SPL Token Transfer instruction layout:
                 // - accounts[0]: source token account
                 // - accounts[1]: destination token account
@@ -905,8 +939,19 @@ where
                     if *source_pubkey == source_account.as_ref() {
                         let destination_pubkey = instruction.accounts[1].pubkey;
 
-                        // Call the callback with the destination
-                        if !callback(destination_pubkey)? {
+                        let amount = u64::from_le_bytes([
+                            instruction.data[1],
+                            instruction.data[2],
+                            instruction.data[3],
+                            instruction.data[4],
+                            instruction.data[5],
+                            instruction.data[6],
+                            instruction.data[7],
+                            instruction.data[8],
+                        ]);
+
+                        // Call the callback with the destination and transfer amount.
+                        if !callback(destination_pubkey, amount)? {
                             return Ok(()); // Early exit if callback returns
                                            // false
                         }

--- a/program/tests/sol_destination_limit_v2.rs
+++ b/program/tests/sol_destination_limit_v2.rs
@@ -21,7 +21,7 @@ use swig_state::{
     },
     authority::AuthorityType,
     swig::{swig_account_seeds, swig_wallet_address_seeds, SwigWithRoles},
-    SwigAuthenticateError,
+    IntoBytes, SwigAuthenticateError,
 };
 
 /// Test basic SOL destination limit functionality with SignV2
@@ -143,6 +143,151 @@ fn test_sol_destination_limit_basic_v2() {
     assert_eq!(
         dest_limit.amount,
         destination_limit_amount - transfer_amount
+    );
+}
+
+/// Destination limits must validate every transfer in a single SignV2 payload.
+#[test_log::test]
+fn test_sol_destination_limit_rejects_second_unmatched_transfer_v2() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let allowed_recipient = Keypair::new();
+    let blocked_recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&allowed_recipient.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&blocked_recipient.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::SolDestinationLimit(SolDestinationLimit {
+                destination: allowed_recipient.pubkey().to_bytes(),
+                amount: 1_000_000_000,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, 2_000_000_000)
+        .unwrap();
+
+    let allowed_transfer_amount = 100_000_000u64;
+    let blocked_transfer_amount = 500_000_000u64;
+    let allowed_transfer_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet_address,
+        &allowed_recipient.pubkey(),
+        allowed_transfer_amount,
+    );
+    let blocked_transfer_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet_address,
+        &blocked_recipient.pubkey(),
+        blocked_transfer_amount,
+    );
+
+    let initial_accounts = vec![
+        AccountMeta::new(swig, false),
+        AccountMeta::new(swig_wallet_address, false),
+        AccountMeta::new_readonly(second_authority.pubkey(), true),
+    ];
+    let (final_accounts, compact_ixs) = compact_instructions(
+        swig,
+        initial_accounts,
+        vec![allowed_transfer_ix, blocked_transfer_ix],
+    );
+    let instruction_payload = compact_ixs.into_bytes();
+    let sign_args = SignV2Args::new(1, instruction_payload.len() as u16);
+    let mut sign_ix_data = Vec::new();
+    sign_ix_data.extend_from_slice(sign_args.into_bytes().unwrap());
+    sign_ix_data.extend_from_slice(&instruction_payload);
+    sign_ix_data.push(2);
+
+    let sign_ix = Instruction {
+        program_id: swig::ID.into(),
+        accounts: final_accounts,
+        data: sign_ix_data,
+    };
+
+    let allowed_initial_balance = context
+        .svm
+        .get_balance(&allowed_recipient.pubkey())
+        .unwrap();
+    let blocked_initial_balance = context
+        .svm
+        .get_balance(&blocked_recipient.pubkey())
+        .unwrap();
+    let swig_initial_balance = context.svm.get_balance(&swig_wallet_address).unwrap();
+
+    let message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&second_authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(
+                SwigAuthenticateError::PermissionDeniedMissingPermission as u32
+            ),
+        )
+    );
+    assert_eq!(
+        context
+            .svm
+            .get_balance(&allowed_recipient.pubkey())
+            .unwrap(),
+        allowed_initial_balance
+    );
+    assert_eq!(
+        context
+            .svm
+            .get_balance(&blocked_recipient.pubkey())
+            .unwrap(),
+        blocked_initial_balance
+    );
+    assert_eq!(
+        context.svm.get_balance(&swig_wallet_address).unwrap(),
+        swig_initial_balance
     );
 }
 

--- a/program/tests/token_destination_limit_v2.rs
+++ b/program/tests/token_destination_limit_v2.rs
@@ -25,6 +25,7 @@ use swig_state::{
     },
     authority::AuthorityType,
     swig::{swig_account_seeds, swig_wallet_address_seeds, SwigWithRoles},
+    IntoBytes, SwigAuthenticateError,
 };
 
 /// Test basic token destination limit functionality with SignV2
@@ -195,6 +196,213 @@ fn test_token_destination_limit_basic_v2() {
         dest_limit.amount,
         destination_limit_amount - transfer_amount
     );
+}
+
+/// Destination limits must validate every token transfer in one SignV2 payload.
+#[test_log::test]
+fn test_token_destination_limit_rejects_second_unmatched_transfer_v2() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let allowed_recipient = Keypair::new();
+    let blocked_recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&allowed_recipient.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&blocked_recipient.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let allowed_recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &allowed_recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+    let blocked_recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &blocked_recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+
+    mint_to(
+        &mut context.svm,
+        &mint_pubkey,
+        &context.default_payer,
+        &swig_ata,
+        1000,
+    )
+    .unwrap();
+
+    create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::TokenDestinationLimit(TokenDestinationLimit {
+                token_mint: mint_pubkey.to_bytes(),
+                destination: allowed_recipient_ata.to_bytes(),
+                amount: 1000,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, 2_000_000_000)
+        .unwrap();
+
+    let allowed_transfer_amount = 100u64;
+    let blocked_transfer_amount = 200u64;
+    let allowed_transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &allowed_recipient_ata,
+        &swig_wallet_address,
+        &[],
+        allowed_transfer_amount,
+    )
+    .unwrap();
+    let blocked_transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &blocked_recipient_ata,
+        &swig_wallet_address,
+        &[],
+        blocked_transfer_amount,
+    )
+    .unwrap();
+
+    let initial_accounts = vec![
+        AccountMeta::new(swig, false),
+        AccountMeta::new(swig_wallet_address, false),
+        AccountMeta::new_readonly(second_authority.pubkey(), true),
+    ];
+    let (final_accounts, compact_ixs) = compact_instructions(
+        swig,
+        initial_accounts,
+        vec![allowed_transfer_ix, blocked_transfer_ix],
+    );
+    let instruction_payload = compact_ixs.into_bytes();
+    let sign_args = SignV2Args::new(1, instruction_payload.len() as u16);
+    let mut sign_ix_data = Vec::new();
+    sign_ix_data.extend_from_slice(sign_args.into_bytes().unwrap());
+    sign_ix_data.extend_from_slice(&instruction_payload);
+    sign_ix_data.push(2);
+
+    let sign_ix = Instruction {
+        program_id: swig::ID.into(),
+        accounts: final_accounts,
+        data: sign_ix_data,
+    };
+
+    let allowed_initial_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&allowed_recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+    let blocked_initial_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&blocked_recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+
+    let message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&second_authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(
+                SwigAuthenticateError::PermissionDeniedMissingPermission as u32
+            ),
+        )
+    );
+
+    let allowed_final_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&allowed_recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+    let blocked_final_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&blocked_recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+
+    assert_eq!(allowed_final_balance, allowed_initial_balance);
+    assert_eq!(blocked_final_balance, blocked_initial_balance);
 }
 
 /// Test token destination limit exceeded with SignV2


### PR DESCRIPTION
## Summary

Fixes SWI-479 by making SignV2 destination-limit checks scan every outgoing transfer in the payload instead of stopping after the first matching destination.

- Continue scanning SOL transfers after a destination-limit match and reject any later unmatched destination.
- Apply token destination limits per parsed token transfer amount, not the source account's aggregate token delta.
- Reject token transfers to unmatched destinations when destination limits exist for that mint.
- Add SOL and SPL token regressions for a single SignV2 payload with one allowed transfer followed by one blocked transfer.

## Testing

- `rustup run nightly rustfmt --check --edition 2021 program/src/actions/sign_v2.rs program/tests/sol_destination_limit_v2.rs program/tests/token_destination_limit_v2.rs`
- `cargo test -p swig --test sol_destination_limit_v2`
- `cargo test -p swig --test token_destination_limit_v2`
- `cargo test -p swig --test sol_destination_limit_v2 test_sol_destination_limit_rejects_second_unmatched_transfer_v2`
- `cargo test -p swig --test token_destination_limit_v2 test_token_destination_limit_rejects_second_unmatched_transfer_v2`
- `cargo build-sbf --arch v1`
- `cargo +stable clippy --workspace --all-targets`

Note: `cargo clippy --workspace --all-targets` on the repo's pinned `1.91.0-aarch64-apple-darwin` toolchain is unavailable because `cargo-clippy` is not applicable to that toolchain, so I ran the same clippy command with `+stable`.
