### PR TITLE
SWI-480: Bind SignV2 secp signatures to role id

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -806,8 +806,7 @@ impl SignV2Instruction {
             );
         }
 
-        let mut signature_bytes = Vec::new();
-        signature_bytes.extend_from_slice(&ix_bytes);
+        let signature_bytes = [arg_bytes, &ix_bytes].concat();
 
         let nonced_payload = prepare_secp256k1_payload(
             current_slot,
@@ -902,12 +901,14 @@ impl SignV2Instruction {
             );
         }
 
+        let signature_bytes = [arg_bytes, &ix_bytes].concat();
+
         // Compute message hash (keccak for secp256r1 compatibility)
         let slot_bytes = current_slot.to_le_bytes();
         let counter_bytes = counter.to_le_bytes();
         let message_hash = keccak::hash(
             &[
-                &ix_bytes,
+                &signature_bytes,
                 &account_payload_bytes,
                 &slot_bytes[..],
                 &counter_bytes[..],

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -124,6 +124,7 @@ impl IntoBytes for SignV2Args {
 pub struct SignV2<'a> {
     pub args: &'a SignV2Args,
     authority_payload: &'a [u8],
+    authentication_payload: &'a [u8],
     instruction_payload: &'a [u8],
 }
 
@@ -139,15 +140,20 @@ impl<'a> SignV2<'a> {
         if data.len() < SignV2Args::LEN {
             return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
         }
-        let (inst, rest) = unsafe { data.split_at_unchecked(SignV2Args::LEN) };
+        let (inst, rest) = data.split_at(SignV2Args::LEN);
         let args = unsafe { SignV2Args::load_unchecked(inst)? };
+        let instruction_payload_len = args.instruction_payload_len as usize;
+        if rest.len() < instruction_payload_len {
+            return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
+        }
 
-        let (instruction_payload, authority_payload) =
-            unsafe { rest.split_at_unchecked(args.instruction_payload_len as usize) };
+        let (instruction_payload, authority_payload) = rest.split_at(instruction_payload_len);
+        let authentication_payload = &data[..SignV2Args::LEN + instruction_payload_len];
 
         Ok(Self {
             args,
             authority_payload,
+            authentication_payload,
             instruction_payload,
         })
     }
@@ -210,14 +216,14 @@ pub fn sign_v2(
         role.authority.authenticate_session(
             all_accounts,
             sign_v2.authority_payload,
-            sign_v2.instruction_payload,
+            sign_v2.authentication_payload,
             slot,
         )?;
     } else {
         role.authority.authenticate(
             all_accounts,
             sign_v2.authority_payload,
-            sign_v2.instruction_payload,
+            sign_v2.authentication_payload,
             slot,
         )?;
     }

--- a/program/tests/sign_secp256k1_v2.rs
+++ b/program/tests/sign_secp256k1_v2.rs
@@ -17,14 +17,16 @@ use solana_sdk::{
     signer::Signer,
     transaction::{TransactionError, VersionedTransaction},
 };
+use swig::actions::sign_v2::SignV2Args;
 use swig_interface::{AuthorityConfig, ClientAction, CreateSessionInstruction};
 use swig_state::{
-    action::all::All,
+    action::{all::All, sol_limit::SolLimit},
     authority::{
         secp256k1::{Secp256k1Authority, Secp256k1SessionAuthority},
         AuthorityType,
     },
     swig::{swig_account_seeds, swig_wallet_address_seeds, SwigWithRoles},
+    IntoBytes, SwigAuthenticateError, Transmutable,
 };
 
 /// Helper function to get the current signature counter for a secp256k1
@@ -161,6 +163,117 @@ fn test_secp256k1_basic_signing_v2() {
     // Verify transfer was successful
     let recipient_account = context.svm.get_account(&recipient.pubkey()).unwrap();
     assert_eq!(recipient_account.lamports, 1_000_000 + transfer_amount);
+}
+
+#[test_log::test]
+fn test_secp256k1_rejects_same_key_role_id_substitution_v2() {
+    let mut context = setup_test_context().unwrap();
+
+    let root_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig_key.as_ref()), &program_id());
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, 10_000_000_000)
+        .unwrap();
+
+    let shared_wallet = LocalSigner::random();
+    let public_key = shared_wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+    let authority_bytes = &public_key.as_ref()[1..];
+    let signed_role_id = 1;
+    let substituted_role_id = 2;
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256k1,
+            authority: authority_bytes,
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256k1,
+            authority: authority_bytes,
+        },
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    let recipient = Keypair::new();
+    context.svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
+    let transfer_amount = 5_000_000;
+    let transfer_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet_address,
+        &recipient.pubkey(),
+        transfer_amount,
+    );
+
+    let signing_fn = |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        let hash = B256::from(hash);
+        shared_wallet.sign_hash_sync(&hash).unwrap().as_bytes()
+    };
+
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let mut sign_ix = swig_interface::SignV2Instruction::new_secp256k1_with_signers(
+        swig_key,
+        swig_wallet_address,
+        signing_fn,
+        current_slot,
+        1,
+        transfer_ix,
+        signed_role_id,
+        &[context.default_payer.pubkey()],
+    )
+    .unwrap();
+
+    let signed_args =
+        unsafe { SignV2Args::load_unchecked(&sign_ix.data[..SignV2Args::LEN]) }.unwrap();
+    let substituted_args =
+        SignV2Args::new(substituted_role_id, signed_args.instruction_payload_len);
+    sign_ix.data[..SignV2Args::LEN].copy_from_slice(substituted_args.into_bytes().unwrap());
+
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&context.default_payer])
+            .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_err(),
+        "role_id substitution should invalidate the signature"
+    );
+    match result.unwrap_err().err {
+        TransactionError::InstructionError(_, InstructionError::Custom(code)) => {
+            assert_eq!(code, SwigAuthenticateError::PermissionDenied as u32);
+        },
+        err => panic!("Expected secp256k1 authentication error, got {:?}", err),
+    }
+
+    let recipient_account = context.svm.get_account(&recipient.pubkey()).unwrap();
+    assert_eq!(recipient_account.lamports, 1_000_000);
 }
 
 #[test_log::test]

--- a/program/tests/sign_secp256r1_v2.rs
+++ b/program/tests/sign_secp256r1_v2.rs
@@ -16,9 +16,10 @@ use solana_sdk::{
     transaction::{TransactionError, VersionedTransaction},
 };
 use solana_secp256r1_program::sign_message;
+use swig::actions::sign_v2::SignV2Args;
 use swig_interface::{AuthorityConfig, ClientAction};
 use swig_state::{
-    action::all::All,
+    action::{all::All, sol_limit::SolLimit},
     authority::{
         secp256r1::{
             Secp256r1Authority, Secp256r1SessionAuthority, COMPRESSED_PUBKEY_SERIALIZED_SIZE,
@@ -27,6 +28,7 @@ use swig_state::{
         AuthorityType,
     },
     swig::{swig_account_seeds, swig_wallet_address_seeds, SwigWithRoles},
+    IntoBytes, SwigAuthenticateError, Transmutable,
 };
 
 /// Helper to generate a real secp256r1 key pair for testing
@@ -291,6 +293,115 @@ fn test_secp256r1_basic_signing_v2() {
     );
 
     println!("✓ Secp256r1 signing test passed with real cryptography");
+}
+
+#[test_log::test]
+fn test_secp256r1_rejects_same_key_role_id_substitution_v2() {
+    let mut context = setup_test_context().unwrap();
+
+    let root_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig_key.as_ref()), &program_id());
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, 10_000_000_000)
+        .unwrap();
+
+    let (signing_key, public_key) = create_test_secp256r1_keypair();
+    let signed_role_id = 1;
+    let substituted_role_id = 2;
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256r1,
+            authority: &public_key,
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256r1,
+            authority: &public_key,
+        },
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    let recipient = Keypair::new();
+    context.svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
+    let transfer_amount = 5_000_000;
+    let transfer_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet_address,
+        &recipient.pubkey(),
+        transfer_amount,
+    );
+
+    let authority_fn = |message_hash: &[u8]| -> [u8; 64] {
+        sign_message(message_hash, &signing_key.private_key_to_der().unwrap()).unwrap()
+    };
+
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let mut instructions = swig_interface::SignV2Instruction::new_secp256r1(
+        swig_key,
+        swig_wallet_address,
+        authority_fn,
+        current_slot,
+        1,
+        transfer_ix,
+        signed_role_id,
+        &public_key,
+    )
+    .unwrap();
+
+    let sign_ix = instructions.last_mut().unwrap();
+    let signed_args =
+        unsafe { SignV2Args::load_unchecked(&sign_ix.data[..SignV2Args::LEN]) }.unwrap();
+    let substituted_args =
+        SignV2Args::new(substituted_role_id, signed_args.instruction_payload_len);
+    sign_ix.data[..SignV2Args::LEN].copy_from_slice(substituted_args.into_bytes().unwrap());
+
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &instructions,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&context.default_payer])
+            .unwrap();
+
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_err(),
+        "role_id substitution should invalidate the secp256r1 message hash"
+    );
+    match result.unwrap_err().err {
+        TransactionError::InstructionError(_, InstructionError::Custom(code)) => {
+            assert_eq!(
+                code,
+                SwigAuthenticateError::PermissionDeniedSecp256r1InvalidMessageHash as u32
+            );
+        },
+        err => panic!(
+            "Expected invalid secp256r1 message hash error, got {:?}",
+            err
+        ),
+    }
+
+    let recipient_account = context.svm.get_account(&recipient.pubkey()).unwrap();
+    assert_eq!(recipient_account.lamports, 1_000_000);
 }
 
 #[test_log::test]


### PR DESCRIPTION
## Summary
- Bind SignV2 secp256k1/r1 authentication to the serialized SignV2 args plus instruction payload, so `role_id` is covered by the signature/hash.
- Update the k1/r1 SignV2 interface builders to sign the same args-prefixed payload the program verifies.
- Add same-key, cross-role substitution regressions for secp256k1 and secp256r1.

## Severity note
This is probably narrower than a practical High severity impersonation issue because the substituted roles must already share the same signer key. The fix still matters because the signature should authorize a specific role intent, not just a key plus instruction payload.

## Tests
- `cargo build-sbf --arch v1`
- `cargo test -p swig --test sign_secp256k1_v2 test_secp256k1_rejects_same_key_role_id_substitution_v2 -- --nocapture`
- `cargo test -p swig --test sign_secp256r1_v2 test_secp256r1_rejects_same_key_role_id_substitution_v2 -- --nocapture`
- `cargo test -p swig --test sign_secp256k1_v2 test_secp256k1_basic_signing_v2 -- --nocapture`
- `cargo test -p swig --test sign_secp256r1_v2 test_secp256r1_basic_signing_v2 -- --nocapture`
- `rustup run nightly rustfmt --edition 2021 interface/src/lib.rs program/src/actions/sign_v2.rs program/tests/sign_secp256k1_v2.rs program/tests/sign_secp256r1_v2.rs`
- `cargo +stable clippy --workspace --all-targets`

Linear: SWI-480