### PR TITLE
SWI-481 enforce one-shot sub-account creation

### DIFF
--- a/program/src/actions/create_sub_account_v1.rs
+++ b/program/src/actions/create_sub_account_v1.rs
@@ -15,10 +15,7 @@ use pinocchio::{
 use pinocchio_system::instructions::Transfer;
 use swig_assertions::*;
 use swig_state::{
-    action::{
-        all::All, manage_authority::ManageAuthority, sub_account::SubAccount, ActionLoader,
-        Actionable,
-    },
+    action::{sub_account::SubAccount, ActionLoader},
     authority::AuthorityType,
     role::RoleMut,
     swig::{
@@ -183,22 +180,6 @@ pub fn create_sub_account_v1(
             slot,
         )?;
     }
-    // Check if the role has the required permissions (All or SubAccount)
-    let has_all_permission = {
-        let all_action = RoleMut::get_action_mut::<All>(role.actions, &[])?;
-        all_action.is_some()
-    };
-
-    let has_sub_account_permission = {
-        let sub_account_action = RoleMut::get_action_mut::<SubAccount>(role.actions, &[])?;
-        sub_account_action.is_some()
-    };
-
-    // Even if role has `All` action, it must have a `SubAccount` action before it
-    // can create a `SubAccount`
-    if !has_sub_account_permission {
-        return Err(SwigError::AuthorityCannotCreateSubAccount.into());
-    }
     // Derive the sub-account address using the authority index as seed (keeping PDA
     // for deterministic addressing)
     let role_id_bytes = create_sub_account.args.role_id.to_le_bytes();
@@ -210,6 +191,17 @@ pub fn create_sub_account_v1(
         ctx.accounts.sub_account.key(),
         SwigError::InvalidSeedSwigAccount,
     )?;
+
+    if RoleMut::get_action_mut::<SubAccount>(role.actions, ctx.accounts.sub_account.key().as_ref())?
+        .is_some()
+    {
+        return Err(SwigError::SubAccountAlreadyExists.into());
+    }
+
+    let Some(sub_account_action_mut) = RoleMut::get_action_mut::<SubAccount>(role.actions, &[])?
+    else {
+        return Err(SwigError::AuthorityCannotCreateSubAccount.into());
+    };
 
     // Transfer lamports to the sub_account to make it system-owned and rent-exempt
     // This follows the same pattern as swig_wallet_address creation in create_v1.rs
@@ -238,16 +230,13 @@ pub fn create_sub_account_v1(
     }
 
     // Update the SubAccount action to store all sub-account metadata
-    if let Some(sub_account_action_mut) = RoleMut::get_action_mut::<SubAccount>(role.actions, &[])?
-    {
-        sub_account_action_mut
-            .sub_account
-            .copy_from_slice(ctx.accounts.sub_account.key().as_ref());
-        sub_account_action_mut.bump = create_sub_account.args.sub_account_bump;
-        sub_account_action_mut.enabled = true; // Default to enabled
-        sub_account_action_mut.role_id = create_sub_account.args.role_id;
-        sub_account_action_mut.swig_id = swig.id;
-    }
+    sub_account_action_mut
+        .sub_account
+        .copy_from_slice(ctx.accounts.sub_account.key().as_ref());
+    sub_account_action_mut.bump = create_sub_account.args.sub_account_bump;
+    sub_account_action_mut.enabled = true; // Default to enabled
+    sub_account_action_mut.role_id = create_sub_account.args.role_id;
+    sub_account_action_mut.swig_id = swig.id;
 
     Ok(())
 }

--- a/program/tests/sub_account_test.rs
+++ b/program/tests/sub_account_test.rs
@@ -192,6 +192,84 @@ fn test_create_sub_account() {
     );
 }
 
+#[test_log::test]
+fn test_create_sub_account_cannot_recreate_bound_sub_account() {
+    let mut context = setup_test_context().unwrap();
+    let recipient = Keypair::new();
+    context.svm.warp_to_slot(1);
+
+    let root_authority = Keypair::new();
+    let sub_account_authority = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&sub_account_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+    context.svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: sub_account_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::SubAccount(SubAccount::new_for_creation()),
+            ClientAction::SubAccount(SubAccount::new_for_creation()),
+        ],
+    )
+    .unwrap();
+
+    let role_id = 1;
+    let root_role_id = 0;
+    let sub_account =
+        create_sub_account(&mut context, &swig_key, &sub_account_authority, role_id, id).unwrap();
+
+    context.svm.airdrop(&sub_account, 5_000_000_000).unwrap();
+
+    toggle_sub_account(
+        &mut context,
+        &swig_key,
+        &sub_account,
+        &root_authority,
+        role_id,
+        root_role_id,
+        false,
+    )
+    .unwrap();
+
+    let recreate_result =
+        create_sub_account(&mut context, &swig_key, &sub_account_authority, role_id, id);
+    assert!(
+        recreate_result.is_err(),
+        "create_sub_account should be one-shot once a sub-account is bound"
+    );
+
+    let transfer_ix =
+        solana_system_interface::instruction::transfer(&sub_account, &recipient.pubkey(), 1_000);
+    let sign_result = sub_account_sign(
+        &mut context,
+        &swig_key,
+        &sub_account,
+        &sub_account_authority,
+        role_id,
+        vec![transfer_ix],
+    );
+    assert!(
+        sign_result.is_err(),
+        "create_sub_account replay should not re-enable a disabled sub-account"
+    );
+}
+
 // Test the withdrawal from a sub-account back to the main swig account
 #[test_log::test]
 fn test_withdraw_sol_from_sub_account() {


### PR DESCRIPTION
## Summary
- Make `create_sub_account_v1` one-shot for a deterministic sub-account PDA by rejecting creation when the role already has a `SubAccount` action bound to that PDA.
- Keep `toggle_sub_account_v1` as the legitimate re-enable path; this PR only removes `create_sub_account_v1` as an accidental state-toggle/replay path.
- Add a regression test with duplicate SubAccount creation slots to prove a second create cannot consume another zeroed slot and re-enable a disabled sub-account.

## Ticket note
For SWI-481 / SEC-4: A disabled sub-account can still be intentionally re-enabled via `toggle_sub_account_v1`. That is the expected admin/self-toggle path today. The bug is narrower: `create_sub_account_v1` should not be usable after the deterministic sub-account PDA is already bound. The fix therefore rejects re-creation once the role already has a SubAccount action for the PDA, while preserving the toggle-based re-enable behavior.

## Validation
- `cargo test -p swig --test sub_account_test -- --nocapture`
- `cargo +stable clippy --workspace --all-targets`
- `cargo build-sbf --arch v1`

All commands completed with exit code 0. Existing repository warnings remain.
