### PR TITLE
Fix InstructionHolder scratch ownership

### DIFF
--- a/instructions/src/lib.rs
+++ b/instructions/src/lib.rs
@@ -52,6 +52,7 @@ pub struct InstructionHolder<'a> {
     pub indexes: &'a [usize],
     pub accounts: &'a [AccountMeta<'a>],
     pub data: &'a [u8],
+    pub uses_swig_signer: bool,
 }
 
 impl<'a> InstructionHolder<'a> {
@@ -287,16 +288,21 @@ where
         let mut infos = Vec::with_capacity(num_accounts);
         const INDEX_UNINIT: MaybeUninit<usize> = MaybeUninit::uninit();
         let mut indexes = [INDEX_UNINIT; MAX_ACCOUNTS];
+        let mut uses_swig_signer = false;
         for i in 0..num_accounts {
             let (pubkey_index, cursor) = self.read_u8()?;
             self.cursor = cursor;
             let account = self.accounts.get_account(pubkey_index as usize)?;
             indexes[i].write(pubkey_index as usize);
             let pubkey = account.pubkey();
+            let is_signer = (pubkey == self.signer || account.signer())
+                && !self.restricted_keys.is_restricted(pubkey);
+            if is_signer && pubkey == self.signer {
+                uses_swig_signer = true;
+            }
             accounts[i].write(AccountMeta {
                 pubkey,
-                is_signer: (pubkey == self.signer || account.signer())
-                    && !self.restricted_keys.is_restricted(pubkey),
+                is_signer,
                 is_writable: account.writable(),
             });
             infos.push(account.into_account());
@@ -314,6 +320,7 @@ where
             accounts: unsafe { core::slice::from_raw_parts(accounts.as_ptr() as _, num_accounts) },
             indexes: unsafe { core::slice::from_raw_parts(indexes.as_ptr() as _, num_accounts) },
             data,
+            uses_swig_signer,
         })
     }
 

--- a/instructions/src/lib.rs
+++ b/instructions/src/lib.rs
@@ -38,7 +38,52 @@ impl From<InstructionError> for ProgramError {
     }
 }
 
-/// Holds parsed instruction data and associated accounts.
+#[inline(always)]
+fn uninit_array<T>() -> [MaybeUninit<T>; MAX_ACCOUNTS] {
+    unsafe { MaybeUninit::<[MaybeUninit<T>; MAX_ACCOUNTS]>::uninit().assume_init() }
+}
+
+/// Reusable fixed storage for one parsed compact instruction.
+pub struct InstructionScratch<'a> {
+    account_metas: [MaybeUninit<AccountMeta<'a>>; MAX_ACCOUNTS],
+    indexes: [MaybeUninit<usize>; MAX_ACCOUNTS],
+    cpi_accounts: [MaybeUninit<Account<'a>>; MAX_ACCOUNTS],
+}
+
+impl<'a> InstructionScratch<'a> {
+    #[inline(always)]
+    pub fn new() -> Self {
+        Self {
+            account_metas: uninit_array(),
+            indexes: uninit_array(),
+            cpi_accounts: uninit_array(),
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn account_metas(&self, len: usize) -> &[AccountMeta<'a>] {
+        core::slice::from_raw_parts(self.account_metas.as_ptr() as *const AccountMeta<'a>, len)
+    }
+
+    #[inline(always)]
+    unsafe fn indexes(&self, len: usize) -> &[usize] {
+        core::slice::from_raw_parts(self.indexes.as_ptr() as *const usize, len)
+    }
+
+    #[inline(always)]
+    unsafe fn cpi_accounts(&self, len: usize) -> &[Account<'a>] {
+        core::slice::from_raw_parts(self.cpi_accounts.as_ptr() as *const Account<'a>, len)
+    }
+}
+
+impl<'a> Default for InstructionScratch<'a> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Holds a borrowed view over parsed instruction data and associated accounts.
 ///
 /// # Fields
 /// * `program_id` - The program that will execute this instruction
@@ -46,23 +91,27 @@ impl From<InstructionError> for ProgramError {
 /// * `indexes` - Original indexes of accounts in the instruction
 /// * `accounts` - Account metadata for the instruction
 /// * `data` - Raw instruction data
-pub struct InstructionHolder<'a> {
+pub struct InstructionHolder<'scratch, 'a> {
     pub program_id: &'a Pubkey,
-    pub cpi_accounts: Vec<Account<'a>>,
-    pub indexes: &'a [usize],
-    pub accounts: &'a [AccountMeta<'a>],
+    pub cpi_accounts: &'scratch [Account<'a>],
+    pub indexes: &'scratch [usize],
+    pub accounts: &'scratch [AccountMeta<'a>],
     pub data: &'a [u8],
     pub uses_swig_signer: bool,
 }
 
-impl<'a> InstructionHolder<'a> {
+impl<'scratch, 'a> InstructionHolder<'scratch, 'a>
+where
+    'a: 'scratch,
+{
     pub fn execute(
-        &'a self,
+        &self,
         all_accounts: &'a [AccountInfo],
         swig_key: &'a Pubkey,
         swig_signer: &[Signer],
     ) -> ProgramResult {
         if self.program_id == &pinocchio_system::ID
+            && self.accounts.len() >= 2
             && self.data.len() >= 12
             && unsafe { self.data.get_unchecked(0..4) == [2, 0, 0, 0] }
             && unsafe { self.accounts.get_unchecked(0).pubkey == swig_key }
@@ -74,13 +123,7 @@ impl<'a> InstructionHolder<'a> {
             if from_account.owner() == &pinocchio_system::ID {
                 // For system-owned PDAs (new swig_wallet_address accounts),
                 // use proper CPI with signer seeds
-                unsafe {
-                    invoke_signed_unchecked(
-                        &self.borrow(),
-                        self.cpi_accounts.as_slice(),
-                        swig_signer,
-                    )
-                }
+                unsafe { invoke_signed_unchecked(&self.borrow(), self.cpi_accounts, swig_signer) }
             } else {
                 // For program-owned accounts (old swig accounts),
                 // use direct lamport manipulation for backwards compatibility
@@ -100,9 +143,7 @@ impl<'a> InstructionHolder<'a> {
                 }
             }
         } else {
-            unsafe {
-                invoke_signed_unchecked(&self.borrow(), self.cpi_accounts.as_slice(), swig_signer)
-            }
+            unsafe { invoke_signed_unchecked(&self.borrow(), self.cpi_accounts, swig_signer) }
         }
         Ok(())
     }
@@ -146,8 +187,11 @@ pub trait RestrictedKeys {
     fn is_restricted(&self, pubkey: &Pubkey) -> bool;
 }
 
-impl<'a> InstructionHolder<'a> {
-    pub fn borrow(&'a self) -> Instruction<'a, 'a, 'a, 'a> {
+impl<'scratch, 'a> InstructionHolder<'scratch, 'a>
+where
+    'a: 'scratch,
+{
+    pub fn borrow(&self) -> Instruction<'a, 'scratch, 'a, 'a> {
         Instruction {
             program_id: self.program_id,
             accounts: self.accounts,
@@ -239,28 +283,31 @@ impl<'a> InstructionIterator<'a, &'a [AccountInfo], &'a [&'a Pubkey], &'a Accoun
     }
 }
 
-impl<'a, AL, RK, P> Iterator for InstructionIterator<'a, AL, RK, P>
-where
-    AL: AccountLookup<'a, P>,
-    RK: RestrictedKeys,
-    P: AccountProxy<'a>,
-{
-    type Item = Result<InstructionHolder<'a>, InstructionError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.remaining == 0 {
-            return None;
-        }
-        self.remaining -= 1;
-        Some(self.parse_next_instruction())
-    }
-}
-
 impl<'a, AL, RK, P> InstructionIterator<'a, AL, RK, P>
 where
     AL: AccountLookup<'a, P>,
     RK: RestrictedKeys,
     P: AccountProxy<'a>,
 {
+    /// Parses the next compact instruction into fixed scratch storage and calls
+    /// `handler` while the parsed slices are still valid.
+    #[inline(always)]
+    pub fn process_next<'scratch, E, F>(
+        &mut self,
+        scratch: &'scratch mut InstructionScratch<'a>,
+        handler: F,
+    ) -> Result<Option<Result<(), E>>, InstructionError>
+    where
+        'a: 'scratch,
+        F: FnOnce(InstructionHolder<'scratch, 'a>) -> Result<(), E>,
+    {
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+        self.remaining -= 1;
+        self.parse_next_instruction(scratch, handler).map(Some)
+    }
+
     /// Parses the next instruction from the compact format.
     ///
     /// This method handles the parsing of:
@@ -269,9 +316,16 @@ where
     /// 3. Instruction data
     ///
     /// # Returns
-    /// * `Result<InstructionHolder<'a>, InstructionError>` - Parsed instruction
-    ///   or error
-    fn parse_next_instruction(&mut self) -> Result<InstructionHolder<'a>, InstructionError> {
+    /// * `Result<(), E>` - Callback success or parser/callback error
+    fn parse_next_instruction<'scratch, E, F>(
+        &mut self,
+        scratch: &'scratch mut InstructionScratch<'a>,
+        handler: F,
+    ) -> Result<Result<(), E>, InstructionError>
+    where
+        'a: 'scratch,
+        F: FnOnce(InstructionHolder<'scratch, 'a>) -> Result<(), E>,
+    {
         // Parse program_id
         let (program_id_index, cursor) = self.read_u8()?;
         self.cursor = cursor;
@@ -283,29 +337,28 @@ where
         let (num_accounts, cursor) = self.read_u8()?;
         self.cursor = cursor;
         let num_accounts = num_accounts as usize;
-        const AM_UNINIT: MaybeUninit<AccountMeta> = MaybeUninit::uninit();
-        let mut accounts = [AM_UNINIT; MAX_ACCOUNTS];
-        let mut infos = Vec::with_capacity(num_accounts);
-        const INDEX_UNINIT: MaybeUninit<usize> = MaybeUninit::uninit();
-        let mut indexes = [INDEX_UNINIT; MAX_ACCOUNTS];
+        if num_accounts > MAX_ACCOUNTS {
+            return Err(InstructionError::MissingAccountInfo);
+        }
+
         let mut uses_swig_signer = false;
         for i in 0..num_accounts {
             let (pubkey_index, cursor) = self.read_u8()?;
             self.cursor = cursor;
             let account = self.accounts.get_account(pubkey_index as usize)?;
-            indexes[i].write(pubkey_index as usize);
+            scratch.indexes[i].write(pubkey_index as usize);
             let pubkey = account.pubkey();
             let is_signer = (pubkey == self.signer || account.signer())
                 && !self.restricted_keys.is_restricted(pubkey);
             if is_signer && pubkey == self.signer {
                 uses_swig_signer = true;
             }
-            accounts[i].write(AccountMeta {
+            scratch.account_metas[i].write(AccountMeta {
                 pubkey,
                 is_signer,
                 is_writable: account.writable(),
             });
-            infos.push(account.into_account());
+            scratch.cpi_accounts[i].write(account.into_account());
         }
 
         // Parse data
@@ -314,14 +367,16 @@ where
         let (data, cursor) = self.read_slice(data_len as usize)?;
         self.cursor = cursor;
 
-        Ok(InstructionHolder {
+        let instruction = InstructionHolder {
             program_id,
-            cpi_accounts: infos,
-            accounts: unsafe { core::slice::from_raw_parts(accounts.as_ptr() as _, num_accounts) },
-            indexes: unsafe { core::slice::from_raw_parts(indexes.as_ptr() as _, num_accounts) },
+            cpi_accounts: unsafe { scratch.cpi_accounts(num_accounts) },
+            accounts: unsafe { scratch.account_metas(num_accounts) },
+            indexes: unsafe { scratch.indexes(num_accounts) },
             data,
             uses_swig_signer,
-        })
+        };
+
+        Ok(handler(instruction))
     }
 
     /// Reads a u8 value from the current cursor position.
@@ -371,5 +426,41 @@ where
 
         let slice = unsafe { self.data.get_unchecked(self.cursor..end) };
         Ok((slice, end))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instruction_holder_borrows_scratch_account_metadata() {
+        let program_id: Pubkey = [1; 32];
+        let account_key: Pubkey = [2; 32];
+        let data = [3, 4, 5];
+        let account_metas = [AccountMeta {
+            pubkey: &account_key,
+            is_writable: true,
+            is_signer: false,
+        }];
+        let indexes = [7usize];
+        let holder = InstructionHolder {
+            program_id: &program_id,
+            cpi_accounts: &[],
+            indexes: &indexes,
+            accounts: &account_metas,
+            data: &data,
+            uses_swig_signer: false,
+        };
+
+        let instruction = holder.borrow();
+
+        assert_eq!(instruction.program_id, &program_id);
+        assert_eq!(instruction.data, data.as_slice());
+        assert_eq!(instruction.accounts.len(), 1);
+        assert_eq!(instruction.accounts[0].pubkey, &account_key);
+        assert!(instruction.accounts[0].is_writable);
+        assert!(!instruction.accounts[0].is_signer);
+        assert_eq!(holder.indexes, &[7]);
     }
 }

--- a/program/src/actions/add_authority_v1.rs
+++ b/program/src/actions/add_authority_v1.rs
@@ -118,17 +118,28 @@ impl<'a> AddAuthorityV1<'a> {
 
         let (inst, rest) = data.split_at(AddAuthorityV1Args::LEN);
         let args = unsafe { AddAuthorityV1Args::load_unchecked(inst)? };
-        let (authority_data, rest) = rest.split_at(args.new_authority_data_len as usize);
-        let (actions_payload, authority_payload) = rest.split_at(args.actions_data_len as usize);
+        let authority_data_len = args.new_authority_data_len as usize;
+        let actions_data_len = args.actions_data_len as usize;
+        let data_payload_len = AddAuthorityV1Args::LEN
+            .checked_add(authority_data_len)
+            .and_then(|len| len.checked_add(actions_data_len))
+            .ok_or(SwigError::InvalidSwigAddAuthorityInstructionDataTooShort)?;
+        if authority_data_len > rest.len() || data_payload_len > data.len() {
+            return Err(SwigError::InvalidSwigAddAuthorityInstructionDataTooShort.into());
+        }
+
+        let (authority_data, rest) = rest.split_at(authority_data_len);
+        if actions_data_len > rest.len() {
+            return Err(SwigError::InvalidSwigAddAuthorityInstructionDataTooShort.into());
+        }
+        let (actions_payload, authority_payload) = rest.split_at(actions_data_len);
 
         Ok(Self {
             args,
             authority_data,
             authority_payload,
             actions: actions_payload,
-            data_payload: &data[..AddAuthorityV1Args::LEN
-                + args.new_authority_data_len as usize
-                + args.actions_data_len as usize],
+            data_payload: &data[..data_payload_len],
         })
     }
 }
@@ -245,4 +256,35 @@ pub fn add_authority_v1(
         add_authority_v1.actions,
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_instruction_bytes_rejects_short_authority_payload() {
+        let args = AddAuthorityV1Args::new(0, AuthorityType::Ed25519, 32, 8, 1);
+        let mut data = args.into_bytes().unwrap().to_vec();
+        data.extend_from_slice(&[1, 2]);
+
+        assert!(matches!(
+            AddAuthorityV1::from_instruction_bytes(&data),
+            Err(ProgramError::Custom(code))
+                if code == SwigError::InvalidSwigAddAuthorityInstructionDataTooShort as u32
+        ));
+    }
+
+    #[test]
+    fn from_instruction_bytes_rejects_short_actions_payload() {
+        let args = AddAuthorityV1Args::new(0, AuthorityType::Ed25519, 2, 8, 1);
+        let mut data = args.into_bytes().unwrap().to_vec();
+        data.extend_from_slice(&[1, 2, 3]);
+
+        assert!(matches!(
+            AddAuthorityV1::from_instruction_bytes(&data),
+            Err(ProgramError::Custom(code))
+                if code == SwigError::InvalidSwigAddAuthorityInstructionDataTooShort as u32
+        ));
+    }
 }

--- a/program/src/actions/create_v1.rs
+++ b/program/src/actions/create_v1.rs
@@ -112,8 +112,11 @@ impl<'a> CreateV1<'a> {
         }
         let (args, rest) = unsafe { bytes.split_at_unchecked(CreateV1Args::LEN) };
         let args = unsafe { CreateV1Args::load_unchecked(args)? };
-        let (authority_data, actions) =
-            unsafe { rest.split_at_unchecked(args.authority_data_len as usize) };
+        let authority_data_len = args.authority_data_len as usize;
+        if authority_data_len > rest.len() {
+            return Err(SwigError::InvalidSwigCreateInstructionDataTooShort.into());
+        }
+        let (authority_data, actions) = unsafe { rest.split_at_unchecked(authority_data_len) };
         Ok(Self {
             args,
             authority_data,
@@ -251,4 +254,22 @@ pub fn create_v1(ctx: Context<CreateV1Accounts>, create: &[u8]) -> ProgramResult
 
     swig_builder.add_role(authority_type, create_v1.authority_data, create_v1.actions)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_instruction_bytes_rejects_short_authority_payload() {
+        let args = CreateV1Args::new([0; 32], 1, AuthorityType::Ed25519, 32, 1);
+        let mut data = args.into_bytes().unwrap().to_vec();
+        data.extend_from_slice(&[1, 2]);
+
+        assert!(matches!(
+            CreateV1::from_instruction_bytes(&data),
+            Err(ProgramError::Custom(code))
+                if code == SwigError::InvalidSwigCreateInstructionDataTooShort as u32
+        ));
+    }
 }

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -14,7 +14,7 @@ use pinocchio::{
 };
 use pinocchio_pubkey::from_str;
 use swig_assertions::*;
-use swig_compact_instructions::InstructionIterator;
+use swig_compact_instructions::{InstructionIterator, InstructionScratch};
 use swig_state::{
     action::{
         all::All,
@@ -239,12 +239,13 @@ pub fn sign_v2(
     // Intentionally no restricted keys: SignV2 forwards existing outer signer
     // bits in compact CPI metas in addition to the Swig wallet PDA signer.
     let rkeys: &[&Pubkey] = &[];
-    let ix_iter = InstructionIterator::new(
+    let mut ix_iter = InstructionIterator::new(
         all_accounts,
         sign_v2.instruction_payload,
         ctx.accounts.swig_wallet_address.key(),
         rkeys,
     )?;
+    let mut instruction_scratch = InstructionScratch::new();
     let b = [swig.wallet_bump];
     let seeds = swig_wallet_address_signer(ctx.accounts.swig.key().as_ref(), &b);
     let signer = seeds.as_slice();
@@ -254,13 +255,18 @@ pub fn sign_v2(
         || RoleMut::get_action_mut::<AllButManageAuthority>(role.actions, &[])?.is_some();
 
     if has_unrestricted_sign_permission {
-        for ix in ix_iter {
-            let instruction = ix.map_err(|_| SwigError::InstructionExecutionError)?;
-            instruction.execute(
-                all_accounts,
-                ctx.accounts.swig_wallet_address.key(),
-                &[signer.into()],
-            )?;
+        while let Some(result) = ix_iter
+            .process_next(&mut instruction_scratch, |instruction| -> ProgramResult {
+                instruction.execute(
+                    all_accounts,
+                    ctx.accounts.swig_wallet_address.key(),
+                    &[signer.into()],
+                )?;
+                Ok(())
+            })
+            .map_err(|_| SwigError::InstructionExecutionError)?
+        {
+            result?;
         }
 
         return Ok(());
@@ -346,8 +352,8 @@ pub fn sign_v2(
         }
     }
 
-    for ix in ix_iter {
-        if let Ok(instruction) = ix {
+    while let Some(result) = ix_iter
+        .process_next(&mut instruction_scratch, |instruction| -> ProgramResult {
             if !has_program_all_permission && instruction.uses_swig_signer {
                 let program_id_bytes = instruction.program_id.as_ref();
                 let has_permission = (has_program_curated_permission
@@ -455,9 +461,12 @@ pub fn sign_v2(
                     _ => {},
                 }
             }
-        } else {
-            return Err(SwigError::InstructionExecutionError.into());
-        }
+
+            Ok(())
+        })
+        .map_err(|_| SwigError::InstructionExecutionError)?
+    {
+        result?;
     }
 
     let actions = role.actions;
@@ -827,50 +836,54 @@ where
     let restricted_keys: &[&Pubkey] = &[];
     let mut instruction_iter =
         InstructionIterator::new(all_accounts, instruction_payload, signer, restricted_keys)?;
+    let mut instruction_scratch = InstructionScratch::new();
 
-    while let Some(instruction) = instruction_iter.next() {
-        let instruction = instruction?;
+    while let Some(result) =
+        instruction_iter.process_next(&mut instruction_scratch, |instruction| -> ProgramResult {
+            if *instruction.program_id != crate::SYSTEM_PROGRAM_ID {
+                return Ok(());
+            }
 
-        if *instruction.program_id != crate::SYSTEM_PROGRAM_ID {
-            continue;
-        }
+            if instruction.data.len() < SYSTEM_TRANSFER_DATA_LEN {
+                return Ok(());
+            }
 
-        if instruction.data.len() < SYSTEM_TRANSFER_DATA_LEN {
-            continue;
-        }
+            let discriminator = u32::from_le_bytes([
+                instruction.data[0],
+                instruction.data[1],
+                instruction.data[2],
+                instruction.data[3],
+            ]);
 
-        let discriminator = u32::from_le_bytes([
-            instruction.data[0],
-            instruction.data[1],
-            instruction.data[2],
-            instruction.data[3],
-        ]);
+            if discriminator != SYSTEM_TRANSFER_DISCRIMINATOR {
+                return Ok(());
+            }
 
-        if discriminator != SYSTEM_TRANSFER_DISCRIMINATOR {
-            continue;
-        }
+            if instruction.accounts.len() < 2 {
+                return Ok(());
+            }
 
-        if instruction.accounts.len() < 2 {
-            continue;
-        }
+            if instruction.accounts[0].pubkey != source_account_bytes {
+                return Ok(());
+            }
 
-        if instruction.accounts[0].pubkey != source_account_bytes {
-            continue;
-        }
+            let destination_pubkey = instruction.accounts[1].pubkey;
+            let amount = u64::from_le_bytes([
+                instruction.data[4],
+                instruction.data[5],
+                instruction.data[6],
+                instruction.data[7],
+                instruction.data[8],
+                instruction.data[9],
+                instruction.data[10],
+                instruction.data[11],
+            ]);
 
-        let destination_pubkey = instruction.accounts[1].pubkey;
-        let amount = u64::from_le_bytes([
-            instruction.data[4],
-            instruction.data[5],
-            instruction.data[6],
-            instruction.data[7],
-            instruction.data[8],
-            instruction.data[9],
-            instruction.data[10],
-            instruction.data[11],
-        ]);
-
-        callback(destination_pubkey, amount)?;
+            callback(destination_pubkey, amount)?;
+            Ok(())
+        })?
+    {
+        result?;
     }
 
     Ok(())
@@ -903,45 +916,50 @@ where
     let restricted_keys: &[&Pubkey] = &[];
     let mut instruction_iter =
         InstructionIterator::new(all_accounts, instruction_payload, signer, restricted_keys)?;
+    let mut instruction_scratch = InstructionScratch::new();
 
-    while let Some(instruction) = instruction_iter.next() {
-        let instruction = instruction?;
+    while let Some(result) =
+        instruction_iter.process_next(&mut instruction_scratch, |instruction| -> ProgramResult {
+            let is_token_program = *instruction.program_id == crate::SPL_TOKEN_ID
+                || *instruction.program_id == crate::SPL_TOKEN_2022_ID;
 
-        let is_token_program = *instruction.program_id == crate::SPL_TOKEN_ID
-            || *instruction.program_id == crate::SPL_TOKEN_2022_ID;
+            if !is_token_program || instruction.data.is_empty() {
+                return Ok(());
+            }
 
-        if !is_token_program || instruction.data.is_empty() {
-            continue;
-        }
+            let (min_data_len, destination_index) = match instruction.data[0] {
+                TOKEN_TRANSFER_DISCRIMINATOR => (TOKEN_TRANSFER_DATA_LEN, 1),
+                TOKEN_TRANSFER_CHECKED_DISCRIMINATOR => (TOKEN_TRANSFER_CHECKED_DATA_LEN, 2),
+                _ => return Ok(()),
+            };
 
-        let (min_data_len, destination_index) = match instruction.data[0] {
-            TOKEN_TRANSFER_DISCRIMINATOR => (TOKEN_TRANSFER_DATA_LEN, 1),
-            TOKEN_TRANSFER_CHECKED_DISCRIMINATOR => (TOKEN_TRANSFER_CHECKED_DATA_LEN, 2),
-            _ => continue,
-        };
+            if instruction.data.len() < min_data_len
+                || instruction.accounts.len() <= destination_index
+            {
+                return Ok(());
+            }
 
-        if instruction.data.len() < min_data_len || instruction.accounts.len() <= destination_index
-        {
-            continue;
-        }
+            if instruction.accounts[0].pubkey != source_account_bytes {
+                return Ok(());
+            }
 
-        if instruction.accounts[0].pubkey != source_account_bytes {
-            continue;
-        }
+            let destination_pubkey = instruction.accounts[destination_index].pubkey;
+            let amount = u64::from_le_bytes([
+                instruction.data[1],
+                instruction.data[2],
+                instruction.data[3],
+                instruction.data[4],
+                instruction.data[5],
+                instruction.data[6],
+                instruction.data[7],
+                instruction.data[8],
+            ]);
 
-        let destination_pubkey = instruction.accounts[destination_index].pubkey;
-        let amount = u64::from_le_bytes([
-            instruction.data[1],
-            instruction.data[2],
-            instruction.data[3],
-            instruction.data[4],
-            instruction.data[5],
-            instruction.data[6],
-            instruction.data[7],
-            instruction.data[8],
-        ]);
-
-        callback(destination_pubkey, amount)?;
+            callback(destination_pubkey, amount)?;
+            Ok(())
+        })?
+    {
+        result?;
     }
 
     Ok(())

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -72,12 +72,19 @@ const STAKE_BALANCE_RANGE: core::ops::Range<usize> = 184..192;
 
 /// Account state constants
 const TOKEN_ACCOUNT_INITIALIZED_STATE: u8 = 1;
-const SYSTEM_TRANSFER_DISCRIMINATOR: u32 = 2;
-const TOKEN_TRANSFER_DISCRIMINATOR: u8 = 3;
-const TOKEN_TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
 
 /// Empty exclude ranges for hash_except when no exclusions are needed
 const NO_EXCLUDE_RANGES: &[core::ops::Range<usize>] = &[];
+
+/// Maximum number of accounts that can have pre-CPI snapshot hashes.
+const MAX_ACCOUNT_SNAPSHOTS: usize = 100;
+
+const SYSTEM_TRANSFER_DISCRIMINATOR: u32 = 2;
+const SYSTEM_TRANSFER_DATA_LEN: usize = 12;
+const TOKEN_TRANSFER_DISCRIMINATOR: u8 = 3;
+const TOKEN_TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
+const TOKEN_TRANSFER_DATA_LEN: usize = 9;
+const TOKEN_TRANSFER_CHECKED_DATA_LEN: usize = 10;
 
 /// Arguments for signing a transaction with a Swig wallet.
 ///
@@ -144,9 +151,14 @@ impl<'a> SignV2<'a> {
         }
         let (inst, rest) = unsafe { data.split_at_unchecked(SignV2Args::LEN) };
         let args = unsafe { SignV2Args::load_unchecked(inst)? };
+        let instruction_payload_len = args.instruction_payload_len as usize;
+
+        if instruction_payload_len > rest.len() {
+            return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
+        }
 
         let (instruction_payload, authority_payload) =
-            unsafe { rest.split_at_unchecked(args.instruction_payload_len as usize) };
+            unsafe { rest.split_at_unchecked(instruction_payload_len) };
 
         Ok(Self {
             args,
@@ -202,11 +214,11 @@ pub fn sign_v2(
     }
     let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
     let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
-    let role = Swig::get_mut_role(sign_v2.args.role_id, swig_roles)?;
-    if role.is_none() {
+    // The generic account classifier already identified account 0 as Swig config.
+    // Keep this hot-path discriminator check as a local unsafe-read precondition.
+    let Some(role) = Swig::get_mut_role(sign_v2.args.role_id, swig_roles)? else {
         return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
-    }
-    let role = role.unwrap();
+    };
     let clock = Clock::get()?;
     let slot = clock.slot;
     if role.authority.session_based() {
@@ -224,6 +236,8 @@ pub fn sign_v2(
             slot,
         )?;
     }
+    // Intentionally no restricted keys: SignV2 forwards existing outer signer
+    // bits in compact CPI metas in addition to the Swig wallet PDA signer.
     let rkeys: &[&Pubkey] = &[];
     let ix_iter = InstructionIterator::new(
         all_accounts,
@@ -235,14 +249,34 @@ pub fn sign_v2(
     let seeds = swig_wallet_address_signer(ctx.accounts.swig.key().as_ref(), &b);
     let signer = seeds.as_slice();
 
-    // Check if we have All or AllButManageAuthority permission to skip CPI
-    // validation
-    let has_all_permission = RoleMut::get_action_mut::<All>(role.actions, &[])?.is_some()
+    let has_unrestricted_sign_permission = RoleMut::get_action_mut::<All>(role.actions, &[])?
+        .is_some()
         || RoleMut::get_action_mut::<AllButManageAuthority>(role.actions, &[])?.is_some();
 
-    // Capture account snapshots before instruction execution
+    if has_unrestricted_sign_permission {
+        for ix in ix_iter {
+            let instruction = ix.map_err(|_| SwigError::InstructionExecutionError)?;
+            instruction.execute(
+                all_accounts,
+                ctx.accounts.swig_wallet_address.key(),
+                &[signer.into()],
+            )?;
+        }
+
+        return Ok(());
+    }
+
+    let has_program_all_permission =
+        RoleMut::get_action_mut::<ProgramAll>(role.actions, &[])?.is_some();
+    let has_program_curated_permission = !has_program_all_permission
+        && RoleMut::get_action_mut::<ProgramCurated>(role.actions, &[])?.is_some();
+
+    // Snapshot hashes are the pre-CPI integrity baseline for writable accounts.
+    // SignV2 permits specific balance fields to change, then verifies the rest
+    // of each protected account is unchanged after CPI execution.
     const UNINIT_HASH: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
-    let mut account_snapshots: [MaybeUninit<[u8; 32]>; 100] = [UNINIT_HASH; 100];
+    let mut account_snapshots: [MaybeUninit<[u8; 32]>; MAX_ACCOUNT_SNAPSHOTS] =
+        [UNINIT_HASH; MAX_ACCOUNT_SNAPSHOTS];
 
     let mut total_sol_spent: u64 = 0;
 
@@ -303,40 +337,28 @@ pub fn sign_v2(
             _ => None,
         };
 
-        if hash != None && index < 100 {
-            account_snapshots[index].write(hash.unwrap());
+        if let Some(hash) = hash {
+            if index >= MAX_ACCOUNT_SNAPSHOTS {
+                return Err(SwigError::InvalidAccountsLength.into());
+            }
+
+            account_snapshots[index].write(hash);
         }
     }
 
     for ix in ix_iter {
         if let Ok(instruction) = ix {
-            // Check CPI signing permissions if not All permission
-            if !has_all_permission {
-                // Check if swig_wallet_address account is being used as a signer for this
-                // instruction
-                let swig_wallet_address_is_signer =
-                    instruction.accounts.iter().any(|account_meta| {
-                        account_meta.pubkey == ctx.accounts.swig_wallet_address.key()
-                            && account_meta.is_signer
-                    });
+            if !has_program_all_permission && instruction.uses_swig_signer {
+                let program_id_bytes = instruction.program_id.as_ref();
+                let has_permission = (has_program_curated_permission
+                    && ProgramCurated::is_curated_program(
+                        &program_id_bytes.try_into().unwrap_or([0; 32]),
+                    ))
+                    || RoleMut::get_action_mut::<Program>(role.actions, program_id_bytes)?
+                        .is_some();
 
-                if swig_wallet_address_is_signer {
-                    // This is a CPI call where swig_wallet_address is signing - check Program
-                    // permissions
-                    let program_id_bytes = instruction.program_id.as_ref();
-
-                    // Check if we have any program permission that allows this program
-                    let has_permission =
-                        // Check for ProgramAll permission (allows any program)
-                        RoleMut::get_action_mut::<ProgramAll>(role.actions, &[])?.is_some() ||
-                        // Check for ProgramCurated permission (allows curated programs)
-                        (RoleMut::get_action_mut::<ProgramCurated>(role.actions, &[])?.is_some() && ProgramCurated::is_curated_program(&program_id_bytes.try_into().unwrap_or([0; 32]))) ||
-                        // Check for specific Program permission
-                        RoleMut::get_action_mut::<Program>(role.actions, program_id_bytes)?.is_some();
-
-                    if !has_permission {
-                        return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
-                    }
+                if !has_permission {
+                    return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
                 }
             }
 
@@ -357,26 +379,30 @@ pub fn sign_v2(
             // After execution, scan writable accounts once and update spent in-place
             for (account_index, classifier) in account_classifiers.iter_mut().enumerate() {
                 let account = unsafe { all_accounts.get_unchecked(account_index) };
+
                 if !account.is_writable() {
                     continue;
                 }
+
                 match classifier {
                     AccountClassification::SwigTokenAccount { balance, spent } => {
                         let data = unsafe { account.borrow_data_unchecked() };
-                        if data.len() >= 72 {
-                            let current = u64::from_le_bytes(unsafe {
-                                data.get_unchecked(TOKEN_BALANCE_RANGE)
-                                    .try_into()
-                                    .unwrap_or([0; 8])
-                            });
-                            if current < *balance {
-                                let delta = (*balance).saturating_sub(current);
-                                *spent = spent.saturating_add(delta);
-                                *balance = current;
-                            } else if current > *balance {
-                                *balance = current;
-                            }
+
+                        if data.len() < TOKEN_BALANCE_RANGE.end {
+                            continue;
                         }
+
+                        let current = u64::from_le_bytes(unsafe {
+                            data.get_unchecked(TOKEN_BALANCE_RANGE)
+                                .try_into()
+                                .unwrap_or([0; 8])
+                        });
+
+                        if current < *balance {
+                            *spent = spent.saturating_add(*balance - current);
+                        }
+
+                        *balance = current;
                     },
                     AccountClassification::SwigStakeAccount {
                         state: _,
@@ -384,42 +410,47 @@ pub fn sign_v2(
                         spent,
                     } => {
                         let data = unsafe { account.borrow_data_unchecked() };
-                        if data.len() >= 192 {
-                            let current = u64::from_le_bytes(unsafe {
-                                data.get_unchecked(STAKE_BALANCE_RANGE)
-                                    .try_into()
-                                    .unwrap_or([0; 8])
-                            });
-                            if current < *balance {
-                                let delta = (*balance).saturating_sub(current);
-                                *spent = spent.saturating_add(delta);
-                                *balance = current;
-                            } else if current > *balance {
-                                *balance = current;
-                            }
+
+                        if data.len() < STAKE_BALANCE_RANGE.end {
+                            continue;
                         }
+
+                        let current = u64::from_le_bytes(unsafe {
+                            data.get_unchecked(STAKE_BALANCE_RANGE)
+                                .try_into()
+                                .unwrap_or([0; 8])
+                        });
+
+                        if current < *balance {
+                            *spent = spent.saturating_add(*balance - current);
+                        }
+
+                        *balance = current;
                     },
                     AccountClassification::ProgramScope {
                         role_index: _,
                         balance,
                         spent,
                     } => {
-                        let account_key = unsafe { account.key() };
-                        if let Some(program_scope) = RoleMut::get_action_mut::<ProgramScope>(
+                        let account_key = account.key();
+                        let Some(program_scope) = RoleMut::get_action_mut::<ProgramScope>(
                             role.actions,
                             account_key.as_ref(),
-                        )? {
-                            let data = unsafe { account.borrow_data_unchecked() };
-                            if let Ok(current) = program_scope.read_account_balance(data) {
-                                if current < *balance {
-                                    let delta = (*balance).saturating_sub(current);
-                                    *spent = spent.saturating_add(delta);
-                                    *balance = current;
-                                } else if current > *balance {
-                                    *balance = current;
-                                }
-                            }
+                        )?
+                        else {
+                            continue;
+                        };
+
+                        let data = unsafe { account.borrow_data_unchecked() };
+                        let Ok(current) = program_scope.read_account_balance(data) else {
+                            continue;
+                        };
+
+                        if current < *balance {
+                            *spent = spent.saturating_add(*balance - current);
                         }
+
+                        *balance = current;
                     },
                     _ => {},
                 }
@@ -430,340 +461,277 @@ pub fn sign_v2(
     }
 
     let actions = role.actions;
-    if has_all_permission {
-        return Ok(());
-    } else {
-        'account_loop: for (index, account) in account_classifiers.iter_mut().enumerate() {
-            match account {
-                AccountClassification::ThisSwigV2 { lamports } => {
-                    let account_info = unsafe { all_accounts.get_unchecked(index) };
+    for (index, account) in account_classifiers.iter_mut().enumerate() {
+        match account {
+            AccountClassification::ThisSwigV2 { .. } => {
+                // SOL spend enforcement for the Swig config account:
+                // 1. Verify writable Swig account data/owner did not change unexpectedly.
+                // 2. Verify the Swig wallet PDA remains rent-exempt after CPIs.
+                // 3. If SOL was spent, charge a general SOL limit when present.
+                // 4. If any SOL destination limits exist, every actual debit must be
+                //    parsed and charged to a matching destination limit.
+                // 5. If SOL was spent but neither a general nor destination limit applies,
+                //    reject the instruction.
+                let account_info = unsafe { all_accounts.get_unchecked(index) };
 
-                    if account_info.is_writable() {
-                        let data = unsafe { &account_info.borrow_data_unchecked() };
-                        let current_hash =
-                            hash_except(&data, account_info.owner(), NO_EXCLUDE_RANGES);
-                        let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
-                        if *snapshot_hash != current_hash {
-                            return Err(SwigError::AccountDataModifiedUnexpectedly.into());
-                        }
-                    }
-
-                    let current_lamports = account_info.lamports();
-                    let mut matched = false;
-
-                    // Make sure that the swig wallet address has sufficient balance
-                    let swig_wallet_balance = ctx.accounts.swig_wallet_address.lamports();
-                    let swig_wallet_rent_exempt_minimum = pinocchio::sysvars::rent::Rent::get()?
-                        .minimum_balance(ctx.accounts.swig_wallet_address.data_len());
-                    if swig_wallet_balance < swig_wallet_rent_exempt_minimum {
-                        return Err(
-                            SwigAuthenticateError::PermissionDeniedInsufficientBalance.into()
-                        );
-                    }
-
-                    if total_sol_spent > 0 {
-                        // First check general SOL limits
-                        let mut general_limit_applied = false;
-
-                        if let Some(action) = RoleMut::get_action_mut::<SolLimit>(actions, &[])? {
-                            action.run(total_sol_spent)?;
-                            general_limit_applied = true;
-                        } else if let Some(action) =
-                            RoleMut::get_action_mut::<SolRecurringLimit>(actions, &[])?
-                        {
-                            action.run(total_sol_spent, slot)?;
-                            general_limit_applied = true;
-                        }
-
-                        // Only check destination limits if they exist
-                        if has_sol_destination_limits(actions)? {
-                            let mut destination_limit_applied = false;
-                            let mut parsed_sol_spent = 0u64;
-                            // Process SOL transfers using zero-copy callback approach
-                            process_sol_transfers(
-                                sign_v2.instruction_payload,
-                                ctx.accounts.swig_wallet_address.key(),
-                                all_accounts,
-                                ctx.accounts.swig_wallet_address.key(),
-                                |destination_pubkey, amount| -> Result<bool, ProgramError> {
-                                    let missing_permission =
-                                        SwigAuthenticateError::PermissionDeniedMissingPermission;
-                                    let next_parsed_sol_spent = parsed_sol_spent
-                                        .checked_add(amount)
-                                        .ok_or(missing_permission)?;
-                                    parsed_sol_spent = next_parsed_sol_spent;
-                                    let dest_pubkey = destination_pubkey.as_ref();
-
-                                    // First check recurring destination limits (higher precedence)
-                                    if let Some(dest_action) = RoleMut::get_action_mut::<
-                                        SolRecurringDestinationLimit,
-                                    >(
-                                        actions, dest_pubkey
-                                    )? {
-                                        dest_action.run(amount, slot)?;
-                                        destination_limit_applied = true;
-                                        return Ok(true);
-                                    }
-
-                                    // Then check non-recurring destination limits
-                                    if let Some(dest_action) = RoleMut::get_action_mut::<
-                                        SolDestinationLimit,
-                                    >(
-                                        actions, dest_pubkey
-                                    )? {
-                                        dest_action.run(amount)?;
-                                        destination_limit_applied = true;
-                                        return Ok(true);
-                                    }
-
-                                    Err(SwigAuthenticateError::PermissionDeniedMissingPermission
-                                        .into())
-                                },
-                            )?;
-
-                            // If destination limits exist, every actual debit must be parsed
-                            // and charged to a matching destination limit.
-                            let parsed_all_sol_spend = parsed_sol_spent == total_sol_spent;
-                            if !destination_limit_applied || !parsed_all_sol_spend {
-                                return Err(
-                                    SwigAuthenticateError::PermissionDeniedMissingPermission.into(),
-                                );
-                            }
-                        }
-
-                        // If we have general limits OR destination limits exist, continue
-                        if general_limit_applied || has_sol_destination_limits(actions)? {
-                            continue;
-                        }
-
-                        return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
-                    }
-                },
-                AccountClassification::SwigTokenAccount { balance, .. } => {
-                    let account_info = unsafe { all_accounts.get_unchecked(index) };
-
-                    // Only validate snapshots for writable accounts
-                    if account_info.is_writable() {
-                        let data = unsafe { &account_info.borrow_data_unchecked() };
-                        let exclude_ranges = [TOKEN_BALANCE_EXCLUDE_RANGE];
-                        let current_hash =
-                            hash_except(&data, account_info.owner(), &exclude_ranges);
-                        let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
-                        if *snapshot_hash != current_hash {
-                            return Err(SwigError::AccountDataModifiedUnexpectedly.into());
-                        }
-                    }
-
+                if account_info.is_writable() {
                     let data = unsafe { &account_info.borrow_data_unchecked() };
-                    let mint = unsafe { data.get_unchecked(TOKEN_MINT_RANGE) };
-                    let state = unsafe { *data.get_unchecked(TOKEN_STATE_INDEX) };
-
-                    let authority = unsafe { data.get_unchecked(TOKEN_AUTHORITY_RANGE) };
-                    let current_token_balance = u64::from_le_bytes(unsafe {
-                        data.get_unchecked(TOKEN_BALANCE_RANGE)
-                            .try_into()
-                            .map_err(|_| ProgramError::InvalidAccountData)?
-                    });
-
-                    if authority != ctx.accounts.swig_wallet_address.key() {
-                        return Err(
-                            SwigAuthenticateError::PermissionDeniedTokenAccountAuthorityNotSwig
-                                .into(),
-                        );
+                    let current_hash = hash_except(&data, account_info.owner(), NO_EXCLUDE_RANGES);
+                    let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
+                    if *snapshot_hash != current_hash {
+                        return Err(SwigError::AccountDataModifiedUnexpectedly.into());
                     }
-                    if state != TOKEN_ACCOUNT_INITIALIZED_STATE {
-                        return Err(
-                            SwigAuthenticateError::PermissionDeniedTokenAccountNotInitialized
-                                .into(),
-                        );
-                    }
+                }
 
-                    // Find the cumulative amount spent for this token account
-                    let mut total_token_spent: u64 = 0;
-                    if let AccountClassification::SwigTokenAccount { balance: _, spent } = account {
-                        total_token_spent = *spent;
-                    }
+                let swig_wallet_balance = ctx.accounts.swig_wallet_address.lamports();
+                let swig_wallet_rent_exempt_minimum = pinocchio::sysvars::rent::Rent::get()?
+                    .minimum_balance(ctx.accounts.swig_wallet_address.data_len());
+                if swig_wallet_balance < swig_wallet_rent_exempt_minimum {
+                    return Err(SwigAuthenticateError::PermissionDeniedInsufficientBalance.into());
+                }
 
-                    if total_token_spent > 0 {
-                        let source_account_key = unsafe { all_accounts.get_unchecked(index) }.key();
-                        if has_token_destination_limits(actions, mint)? {
-                            let mut destination_limit_applied = false;
-                            let mut parsed_token_spent = 0u64;
+                if total_sol_spent == 0 {
+                    continue;
+                }
 
-                            process_token_destinations(
-                                sign_v2.instruction_payload,
-                                source_account_key,
-                                all_accounts,
-                                ctx.accounts.swig_wallet_address.key(),
-                                |destination, amount| -> Result<bool, ProgramError> {
-                                    let missing_permission =
-                                        SwigAuthenticateError::PermissionDeniedMissingPermission;
-                                    let next_parsed_token_spent = parsed_token_spent
-                                        .checked_add(amount)
-                                        .ok_or(missing_permission)?;
-                                    parsed_token_spent = next_parsed_token_spent;
-                                    // Create the combined key [mint + destination] for matching
-                                    let mut combined_key = [0u8; 64];
-                                    combined_key[..32].copy_from_slice(mint);
-                                    combined_key[32..].copy_from_slice(destination.as_ref());
+                let general_sol_limit_applied =
+                    if let Some(action) = RoleMut::get_action_mut::<SolLimit>(actions, &[])? {
+                        action.run(total_sol_spent)?;
+                        true
+                    } else if let Some(action) =
+                        RoleMut::get_action_mut::<SolRecurringLimit>(actions, &[])?
+                    {
+                        action.run(total_sol_spent, slot)?;
+                        true
+                    } else {
+                        false
+                    };
 
-                                    // First check recurring destination limits
-                                    if let Some(action) = RoleMut::get_action_mut::<
-                                        TokenRecurringDestinationLimit,
-                                    >(
-                                        actions, &combined_key
-                                    )? {
-                                        action.run(amount, slot)?;
-                                        destination_limit_applied = true;
-                                        return Ok(true);
-                                    }
+                let has_destination_sol_limits = has_sol_destination_limits(actions)?;
+                let destination_sol_limit_applied = if has_destination_sol_limits {
+                    let mut matched_any_destination_limit = false;
+                    let mut parsed_sol_spent = 0u64;
 
-                                    // Then check non-recurring destination limits
-                                    if let Some(action) = RoleMut::get_action_mut::<
-                                        TokenDestinationLimit,
-                                    >(
-                                        actions, &combined_key
-                                    )? {
-                                        action.run(amount)?;
-                                        destination_limit_applied = true;
-                                        return Ok(true);
-                                    }
+                    process_sol_transfers(
+                        sign_v2.instruction_payload,
+                        ctx.accounts.swig_wallet_address.key(),
+                        all_accounts,
+                        ctx.accounts.swig_wallet_address.key(),
+                        |destination_pubkey, amount| -> Result<(), ProgramError> {
+                            parsed_sol_spent = parsed_sol_spent
+                                .checked_add(amount)
+                                .ok_or(SwigAuthenticateError::PermissionDeniedMissingPermission)?;
 
-                                    Err(SwigAuthenticateError::PermissionDeniedMissingPermission
-                                        .into())
-                                },
-                            )?;
+                            let dest_pubkey = destination_pubkey.as_ref();
 
-                            let parsed_all_token_spend = parsed_token_spent == total_token_spent;
-                            if !destination_limit_applied || !parsed_all_token_spend {
-                                return Err(
-                                    SwigAuthenticateError::PermissionDeniedMissingPermission.into(),
-                                );
+                            if let Some(action) = RoleMut::get_action_mut::<
+                                SolRecurringDestinationLimit,
+                            >(
+                                actions, dest_pubkey
+                            )? {
+                                action.run(amount, slot)?;
+                                matched_any_destination_limit = true;
+                                return Ok(());
                             }
 
-                            continue 'account_loop;
-                        }
+                            if let Some(action) = RoleMut::get_action_mut::<SolDestinationLimit>(
+                                actions,
+                                dest_pubkey,
+                            )? {
+                                action.run(amount)?;
+                                matched_any_destination_limit = true;
+                                return Ok(());
+                            }
 
-                        // Check regular token limits for outgoing transfers
-                        if let Some(action) = RoleMut::get_action_mut::<TokenLimit>(actions, mint)?
-                        {
-                            action.run(total_token_spent)?;
-                            continue;
-                        } else if let Some(action) =
-                            RoleMut::get_action_mut::<TokenRecurringLimit>(actions, mint)?
-                        {
-                            action.run(total_token_spent, slot)?;
-                            continue;
-                        }
-                        return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
-                    }
-                },
-                AccountClassification::SwigStakeAccount {
-                    state: _,
-                    balance,
-                    spent,
-                } => {
-                    let account_info = unsafe { all_accounts.get_unchecked(index) };
+                            Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into())
+                        },
+                    )?;
 
-                    // Only validate snapshots for writable accounts
-                    if account_info.is_writable() {
-                        let data = unsafe { &account_info.borrow_data_unchecked() };
-                        let exclude_ranges = [STAKE_BALANCE_EXCLUDE_RANGE];
-                        let current_hash =
-                            hash_except(&data, account_info.owner(), &exclude_ranges);
-                        let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
-                        if *snapshot_hash != current_hash {
-                            return Err(SwigError::AccountDataModifiedUnexpectedly.into());
-                        }
-                    }
-
-                    // Validate stake spending permissions if any stake was spent
-                    if *spent > 0 {
-                        if let Some(action) = RoleMut::get_action_mut::<StakeLimit>(actions, &[])? {
-                            action.run(*spent)?;
-                            continue;
-                        } else if let Some(action) =
-                            RoleMut::get_action_mut::<StakeRecurringLimit>(actions, &[])?
-                        {
-                            action.run(*spent, slot)?;
-                            continue;
-                        }
+                    if !matched_any_destination_limit || parsed_sol_spent != total_sol_spent {
                         return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
                     }
 
+                    true
+                } else {
+                    false
+                };
+
+                if !general_sol_limit_applied && !destination_sol_limit_applied {
+                    return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+                }
+
+                continue;
+            },
+            AccountClassification::SwigTokenAccount { spent, .. } => {
+                let account_info = unsafe { all_accounts.get_unchecked(index) };
+
+                if account_info.is_writable() {
+                    let data = unsafe { &account_info.borrow_data_unchecked() };
+                    let exclude_ranges = [TOKEN_BALANCE_EXCLUDE_RANGE];
+                    let current_hash = hash_except(&data, account_info.owner(), &exclude_ranges);
+                    let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
+                    if *snapshot_hash != current_hash {
+                        return Err(SwigError::AccountDataModifiedUnexpectedly.into());
+                    }
+                }
+
+                let data = unsafe { &account_info.borrow_data_unchecked() };
+                let mint = unsafe { data.get_unchecked(TOKEN_MINT_RANGE) };
+                let state = unsafe { *data.get_unchecked(TOKEN_STATE_INDEX) };
+                let authority = unsafe { data.get_unchecked(TOKEN_AUTHORITY_RANGE) };
+
+                if authority != ctx.accounts.swig_wallet_address.key() {
+                    return Err(
+                        SwigAuthenticateError::PermissionDeniedTokenAccountAuthorityNotSwig.into(),
+                    );
+                }
+                if state != TOKEN_ACCOUNT_INITIALIZED_STATE {
+                    return Err(
+                        SwigAuthenticateError::PermissionDeniedTokenAccountNotInitialized.into(),
+                    );
+                }
+
+                let total_token_spent = *spent;
+                if total_token_spent == 0 {
                     continue;
-                },
-                AccountClassification::ProgramScope {
-                    role_index,
-                    balance,
-                    ..
-                } => {
-                    let account_info = unsafe { all_accounts.get_unchecked(index) };
+                }
 
-                    // Get the role with the ProgramScope action using the account key
-                    // (target_account)
-                    let account_key = unsafe { all_accounts.get_unchecked(index).key() };
-                    let program_scope =
-                        RoleMut::get_action_mut::<ProgramScope>(actions, account_key.as_ref())?;
+                let general_token_limit_applied =
+                    if let Some(action) = RoleMut::get_action_mut::<TokenLimit>(actions, mint)? {
+                        action.run(total_token_spent)?;
+                        true
+                    } else if let Some(action) =
+                        RoleMut::get_action_mut::<TokenRecurringLimit>(actions, mint)?
+                    {
+                        action.run(total_token_spent, slot)?;
+                        true
+                    } else {
+                        false
+                    };
 
-                    match program_scope {
-                        Some(program_scope) => {
-                            // The target_account verification is now implicit in the match_data
-                            // check that happens in get_action_mut, so
-                            // we don't need to check again
+                let has_destination_token_limits = has_token_destination_limits(actions, mint)?;
+                let destination_token_limit_applied = if has_destination_token_limits {
+                    let source_account_key = account_info.key();
+                    let mut matched_any_destination_limit = false;
+                    let mut parsed_token_spent = 0u64;
 
-                            // Get the current balance by using the program_scope's
-                            // read_account_balance method
-                            let data = unsafe { account_info.borrow_data_unchecked() };
+                    process_token_destinations(
+                        sign_v2.instruction_payload,
+                        source_account_key,
+                        all_accounts,
+                        ctx.accounts.swig_wallet_address.key(),
+                        |destination, amount| -> Result<(), ProgramError> {
+                            parsed_token_spent = parsed_token_spent
+                                .checked_add(amount)
+                                .ok_or(SwigAuthenticateError::PermissionDeniedMissingPermission)?;
 
-                            // Check if balance field range is valid
-                            if program_scope.balance_field_end - program_scope.balance_field_start
-                                > 0
-                                && program_scope.balance_field_end as usize <= data.len()
-                            {
-                                // Only validate snapshots for writable accounts
-                                if account_info.is_writable() {
-                                    // Hash the data excluding the balance field but including owner
-                                    let exclude_ranges =
-                                        [program_scope.balance_field_start as usize
-                                            ..program_scope.balance_field_end as usize];
-                                    let current_hash =
-                                        hash_except(&data, account_info.owner(), &exclude_ranges);
-                                    let snapshot_hash =
-                                        unsafe { account_snapshots[index].assume_init_ref() };
-                                    if *snapshot_hash != current_hash {
-                                        return Err(
-                                            SwigError::AccountDataModifiedUnexpectedly.into()
-                                        );
-                                    }
-                                }
+                            let mut combined_key = [0u8; 64];
+                            combined_key[..32].copy_from_slice(mint);
+                            combined_key[32..].copy_from_slice(destination.as_ref());
 
-                                let mut total_program_scope_spent: u128 = 0;
-                                if let AccountClassification::ProgramScope {
-                                    role_index: _,
-                                    balance: _,
-                                    spent,
-                                } = account
-                                {
-                                    total_program_scope_spent = *spent;
-                                }
-
-                                program_scope.run(total_program_scope_spent, Some(slot))?;
-                            } else {
-                                return Err(SwigError::InvalidProgramScopeBalanceFields.into());
+                            if let Some(action) = RoleMut::get_action_mut::<
+                                TokenRecurringDestinationLimit,
+                            >(
+                                actions, &combined_key
+                            )? {
+                                action.run(amount, slot)?;
+                                matched_any_destination_limit = true;
+                                return Ok(());
                             }
+
+                            if let Some(action) = RoleMut::get_action_mut::<TokenDestinationLimit>(
+                                actions,
+                                &combined_key,
+                            )? {
+                                action.run(amount)?;
+                                matched_any_destination_limit = true;
+                                return Ok(());
+                            }
+
+                            Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into())
                         },
-                        None => {
-                            return Err(
-                                SwigAuthenticateError::PermissionDeniedMissingPermission.into()
-                            );
-                        },
+                    )?;
+
+                    if !matched_any_destination_limit || parsed_token_spent != total_token_spent {
+                        return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
                     }
 
+                    true
+                } else {
+                    false
+                };
+
+                if !general_token_limit_applied && !destination_token_limit_applied {
+                    return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+                }
+
+                continue;
+            },
+            AccountClassification::SwigStakeAccount { spent, .. } => {
+                let account_info = unsafe { all_accounts.get_unchecked(index) };
+
+                if account_info.is_writable() {
+                    let data = unsafe { &account_info.borrow_data_unchecked() };
+                    let exclude_ranges = [STAKE_BALANCE_EXCLUDE_RANGE];
+                    let current_hash = hash_except(&data, account_info.owner(), &exclude_ranges);
+                    let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
+                    if *snapshot_hash != current_hash {
+                        return Err(SwigError::AccountDataModifiedUnexpectedly.into());
+                    }
+                }
+
+                let total_stake_spent = *spent;
+                if total_stake_spent == 0 {
                     continue;
-                },
-                _ => {},
-            }
+                }
+
+                if let Some(action) = RoleMut::get_action_mut::<StakeLimit>(actions, &[])? {
+                    action.run(total_stake_spent)?;
+                    continue;
+                }
+
+                if let Some(action) = RoleMut::get_action_mut::<StakeRecurringLimit>(actions, &[])?
+                {
+                    action.run(total_stake_spent, slot)?;
+                    continue;
+                }
+
+                return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+            },
+            AccountClassification::ProgramScope { spent, .. } => {
+                let account_info = unsafe { all_accounts.get_unchecked(index) };
+                let Some(program_scope) =
+                    RoleMut::get_action_mut::<ProgramScope>(actions, account_info.key().as_ref())?
+                else {
+                    return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+                };
+
+                let data = unsafe { account_info.borrow_data_unchecked() };
+                let balance_field_start = program_scope.balance_field_start as usize;
+                let balance_field_end = program_scope.balance_field_end as usize;
+
+                if balance_field_start >= balance_field_end || balance_field_end > data.len() {
+                    return Err(SwigError::InvalidProgramScopeBalanceFields.into());
+                }
+
+                if account_info.is_writable() {
+                    let exclude_ranges = [balance_field_start..balance_field_end];
+                    let current_hash = hash_except(&data, account_info.owner(), &exclude_ranges);
+                    let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
+                    if *snapshot_hash != current_hash {
+                        return Err(SwigError::AccountDataModifiedUnexpectedly.into());
+                    }
+                }
+
+                let total_program_scope_spent = *spent;
+                if total_program_scope_spent == 0 {
+                    continue;
+                }
+
+                program_scope.run(total_program_scope_spent, Some(slot))?;
+                continue;
+            },
+            _ => {},
         }
     }
 
@@ -853,58 +821,56 @@ fn process_sol_transfers<F>(
     mut callback: F,
 ) -> Result<(), ProgramError>
 where
-    // Returns true to continue, false to stop.
-    F: FnMut(&Pubkey, u64) -> Result<bool, ProgramError>,
+    F: FnMut(&Pubkey, u64) -> Result<(), ProgramError>,
 {
-    // Parse the instruction payload using the instruction iterator
-    let restricted_keys: &[&Pubkey] = &[]; // No restricted keys for this use case
+    let source_account_bytes = source_account.as_ref();
+    let restricted_keys: &[&Pubkey] = &[];
     let mut instruction_iter =
         InstructionIterator::new(all_accounts, instruction_payload, signer, restricted_keys)?;
 
     while let Some(instruction) = instruction_iter.next() {
         let instruction = instruction?;
 
-        // Check if this is a System Program instruction
-        if *instruction.program_id == crate::SYSTEM_PROGRAM_ID {
-            // Check if this is a Transfer instruction.
-            if instruction.data.len() >= 12
-                && u32::from_le_bytes([
-                    instruction.data[0],
-                    instruction.data[1],
-                    instruction.data[2],
-                    instruction.data[3],
-                ]) == SYSTEM_TRANSFER_DISCRIMINATOR
-            {
-                // System Program Transfer instruction layout:
-                // - accounts[0]: source account (funding account)
-                // - accounts[1]: destination account (recipient)
-                // - data[4..12]: amount (u64 little-endian)
-                if instruction.accounts.len() >= 2 {
-                    let source_pubkey = &instruction.accounts[0].pubkey;
-
-                    // Check if this transfer is from our source account
-                    if *source_pubkey == source_account.as_ref() {
-                        let destination_pubkey = instruction.accounts[1].pubkey;
-                        let amount = u64::from_le_bytes([
-                            instruction.data[4],
-                            instruction.data[5],
-                            instruction.data[6],
-                            instruction.data[7],
-                            instruction.data[8],
-                            instruction.data[9],
-                            instruction.data[10],
-                            instruction.data[11],
-                        ]);
-
-                        // Call the callback with the transfer data
-                        if !callback(destination_pubkey, amount)? {
-                            return Ok(()); // Early exit if callback returns
-                                           // false
-                        }
-                    }
-                }
-            }
+        if *instruction.program_id != crate::SYSTEM_PROGRAM_ID {
+            continue;
         }
+
+        if instruction.data.len() < SYSTEM_TRANSFER_DATA_LEN {
+            continue;
+        }
+
+        let discriminator = u32::from_le_bytes([
+            instruction.data[0],
+            instruction.data[1],
+            instruction.data[2],
+            instruction.data[3],
+        ]);
+
+        if discriminator != SYSTEM_TRANSFER_DISCRIMINATOR {
+            continue;
+        }
+
+        if instruction.accounts.len() < 2 {
+            continue;
+        }
+
+        if instruction.accounts[0].pubkey != source_account_bytes {
+            continue;
+        }
+
+        let destination_pubkey = instruction.accounts[1].pubkey;
+        let amount = u64::from_le_bytes([
+            instruction.data[4],
+            instruction.data[5],
+            instruction.data[6],
+            instruction.data[7],
+            instruction.data[8],
+            instruction.data[9],
+            instruction.data[10],
+            instruction.data[11],
+        ]);
+
+        callback(destination_pubkey, amount)?;
     }
 
     Ok(())
@@ -931,61 +897,51 @@ fn process_token_destinations<F>(
     mut callback: F,
 ) -> Result<(), ProgramError>
 where
-    F: FnMut(&Pubkey, u64) -> Result<bool, ProgramError>, /* Returns true to continue, false to
-                                                           * stop */
+    F: FnMut(&Pubkey, u64) -> Result<(), ProgramError>,
 {
-    // Parse the instruction payload using the instruction iterator
-    let restricted_keys: &[&Pubkey] = &[]; // No restricted keys for this use case
+    let source_account_bytes = source_account.as_ref();
+    let restricted_keys: &[&Pubkey] = &[];
     let mut instruction_iter =
         InstructionIterator::new(all_accounts, instruction_payload, signer, restricted_keys)?;
 
     while let Some(instruction) = instruction_iter.next() {
         let instruction = instruction?;
 
-        // Check if this is a token program instruction
-        if *instruction.program_id == crate::SPL_TOKEN_ID
-            || *instruction.program_id == crate::SPL_TOKEN_2022_ID
-        {
-            let destination_index = if instruction.data.len() >= 9
-                && instruction.accounts.len() >= 2
-                && instruction.data[0] == TOKEN_TRANSFER_DISCRIMINATOR
-            {
-                Some(1)
-            } else if instruction.data.len() >= 10
-                && instruction.accounts.len() >= 3
-                && instruction.data[0] == TOKEN_TRANSFER_CHECKED_DISCRIMINATOR
-            {
-                Some(2)
-            } else {
-                None
-            };
+        let is_token_program = *instruction.program_id == crate::SPL_TOKEN_ID
+            || *instruction.program_id == crate::SPL_TOKEN_2022_ID;
 
-            if let Some(destination_index) = destination_index {
-                let source_pubkey = &instruction.accounts[0].pubkey;
-
-                // Check if this transfer is from our source account
-                if *source_pubkey == source_account.as_ref() {
-                    let destination_pubkey = instruction.accounts[destination_index].pubkey;
-
-                    let amount = u64::from_le_bytes([
-                        instruction.data[1],
-                        instruction.data[2],
-                        instruction.data[3],
-                        instruction.data[4],
-                        instruction.data[5],
-                        instruction.data[6],
-                        instruction.data[7],
-                        instruction.data[8],
-                    ]);
-
-                    // Call the callback with the destination and transfer amount.
-                    if !callback(destination_pubkey, amount)? {
-                        return Ok(()); // Early exit if callback returns
-                                       // false
-                    }
-                }
-            }
+        if !is_token_program || instruction.data.is_empty() {
+            continue;
         }
+
+        let (min_data_len, destination_index) = match instruction.data[0] {
+            TOKEN_TRANSFER_DISCRIMINATOR => (TOKEN_TRANSFER_DATA_LEN, 1),
+            TOKEN_TRANSFER_CHECKED_DISCRIMINATOR => (TOKEN_TRANSFER_CHECKED_DATA_LEN, 2),
+            _ => continue,
+        };
+
+        if instruction.data.len() < min_data_len || instruction.accounts.len() <= destination_index
+        {
+            continue;
+        }
+
+        if instruction.accounts[0].pubkey != source_account_bytes {
+            continue;
+        }
+
+        let destination_pubkey = instruction.accounts[destination_index].pubkey;
+        let amount = u64::from_le_bytes([
+            instruction.data[1],
+            instruction.data[2],
+            instruction.data[3],
+            instruction.data[4],
+            instruction.data[5],
+            instruction.data[6],
+            instruction.data[7],
+            instruction.data[8],
+        ]);
+
+        callback(destination_pubkey, amount)?;
     }
 
     Ok(())

--- a/program/src/actions/sub_account_sign_v1.rs
+++ b/program/src/actions/sub_account_sign_v1.rs
@@ -97,8 +97,12 @@ impl<'a> SubAccountSignV1<'a> {
         }
         let (inst, rest) = unsafe { data.split_at_unchecked(SubAccountSignV1Args::LEN) };
         let args = unsafe { SubAccountSignV1Args::load_unchecked(inst)? };
+        let instruction_payload_len = args.instruction_payload_len as usize;
+        if instruction_payload_len > rest.len() {
+            return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
+        }
         let (instruction_payload, authority_payload) =
-            unsafe { rest.split_at_unchecked(args.instruction_payload_len as usize) };
+            unsafe { rest.split_at_unchecked(instruction_payload_len) };
         Ok(Self {
             args,
             authority_payload,
@@ -232,4 +236,23 @@ pub fn sub_account_sign_v1(
         return Err(SwigAuthenticateError::PermissionDeniedInsufficientBalance.into());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swig_state::IntoBytes;
+
+    #[test]
+    fn from_instruction_bytes_rejects_short_instruction_payload() {
+        let args = SubAccountSignV1Args::new(0, 4);
+        let mut data = args.into_bytes().unwrap().to_vec();
+        data.extend_from_slice(&[1, 2]);
+
+        assert!(matches!(
+            SubAccountSignV1::from_instruction_bytes(&data),
+            Err(ProgramError::Custom(code))
+                if code == SwigError::InvalidSwigSignInstructionDataTooShort as u32
+        ));
+    }
 }

--- a/program/src/actions/sub_account_sign_v1.rs
+++ b/program/src/actions/sub_account_sign_v1.rs
@@ -11,7 +11,7 @@ use pinocchio::{
     ProgramResult,
 };
 use swig_assertions::*;
-use swig_compact_instructions::InstructionIterator;
+use swig_compact_instructions::{InstructionIterator, InstructionScratch};
 use swig_state::{
     action::{all::All, sub_account::SubAccount, ActionLoader, Actionable},
     role::RoleMut,
@@ -201,18 +201,19 @@ pub fn sub_account_sign_v1(
     let sub_account_role_id = sub_account.role_id;
     let sub_account_swig_id = sub_account.swig_id;
     let rkeys: &[&Pubkey] = &[];
-    let ix_iter = InstructionIterator::new(
+    let mut ix_iter = InstructionIterator::new(
         all_accounts,
         sign_v1.instruction_payload,
         ctx.accounts.sub_account.key(),
         rkeys,
     )?;
+    let mut instruction_scratch = InstructionScratch::new();
     let role_id_bytes = sub_account_role_id.to_le_bytes();
     let bump_byte = [sub_account_bump];
     let seeds = sub_account_signer(&sub_account_swig_id, &role_id_bytes, &bump_byte);
     let signer = seeds.as_slice();
-    for ix in ix_iter {
-        if let Ok(instruction) = ix {
+    while let Some(result) = ix_iter
+        .process_next(&mut instruction_scratch, |instruction| -> ProgramResult {
             instruction.execute(
                 all_accounts,
                 ctx.accounts.sub_account.key(),
@@ -221,9 +222,11 @@ pub fn sub_account_sign_v1(
 
             // Check after each instruction that we haven't dropped below
             // reserved lamports
-        } else {
-            return Err(SwigError::InstructionExecutionError.into());
-        }
+            Ok(())
+        })
+        .map_err(|_| SwigError::InstructionExecutionError)?
+    {
+        result?;
     }
 
     // Check that the sub-account maintains sufficient lamports for rent exemption

--- a/program/src/actions/update_authority_v1.rs
+++ b/program/src/actions/update_authority_v1.rs
@@ -15,7 +15,7 @@ use swig_state::{
     action::{all::All, manage_authority::ManageAuthority, Action, ActionLoader},
     authority::{authority_type_to_length, AuthorityType},
     role::Position,
-    swig::{Swig, SwigBuilder},
+    swig::{validate_unique_role_actions, Swig},
     Discriminator, IntoBytes, SwigAuthenticateError, SwigStateError, Transmutable, TransmutableMut,
 };
 
@@ -70,6 +70,8 @@ fn calculate_num_actions(actions_data: &[u8]) -> Result<u8, ProgramError> {
     if count == 0 {
         return Err(SwigStateError::InvalidAuthorityMustHaveAtLeastOneAction.into());
     }
+
+    validate_unique_role_actions(actions_data)?;
 
     Ok(count)
 }
@@ -186,13 +188,21 @@ impl<'a> UpdateAuthorityV1<'a> {
 
         let (inst, rest) = data.split_at(UpdateAuthorityV1Args::LEN);
         let args = unsafe { UpdateAuthorityV1Args::load_unchecked(inst)? };
-        let (actions_payload, authority_payload) = rest.split_at(args.actions_data_len as usize);
+        let actions_data_len = args.actions_data_len as usize;
+        let data_payload_len = UpdateAuthorityV1Args::LEN
+            .checked_add(actions_data_len)
+            .ok_or(SwigError::InvalidSwigUpdateAuthorityInstructionDataTooShort)?;
+        if actions_data_len > rest.len() {
+            return Err(SwigError::InvalidSwigUpdateAuthorityInstructionDataTooShort.into());
+        }
+
+        let (actions_payload, authority_payload) = rest.split_at(actions_data_len);
 
         Ok(Self {
             args,
             operation_data: actions_payload,
             authority_payload,
-            data_payload: &data[..UpdateAuthorityV1Args::LEN + args.actions_data_len as usize],
+            data_payload: &data[..data_payload_len],
         })
     }
 
@@ -782,4 +792,22 @@ pub fn update_authority_v1(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_instruction_bytes_rejects_short_actions_payload() {
+        let args = UpdateAuthorityV1Args::new(0, 1, 8, 0);
+        let mut data = args.into_bytes().unwrap().to_vec();
+        data.extend_from_slice(&[1, 2]);
+
+        assert!(matches!(
+            UpdateAuthorityV1::from_instruction_bytes(&data),
+            Err(ProgramError::Custom(code))
+                if code == SwigError::InvalidSwigUpdateAuthorityInstructionDataTooShort as u32
+        ));
+    }
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -87,6 +87,8 @@ security_txt! {
 pub fn process_instruction(mut ctx: InstructionContext) -> ProgramResult {
     validate_entry_account_count(ctx.remaining())?;
 
+    // These are capacity buffers. `execute` initializes only the consumed
+    // `0..index` prefix before passing slices to the action handlers.
     let mut accounts =
         unsafe { Box::<[MaybeUninit<AccountInfo>; MAX_ACCOUNTS]>::new_uninit().assume_init() };
     let mut classifiers = unsafe {
@@ -108,12 +110,12 @@ fn validate_entry_account_count(account_count: u64) -> ProgramResult {
 }
 
 #[inline(always)]
-fn validate_account_slot(
-    index: usize,
+fn validate_account_capacity(
+    end: usize,
     accounts_len: usize,
     account_classification_len: usize,
 ) -> ProgramResult {
-    if index >= accounts_len || index >= account_classification_len {
+    if end > accounts_len || end > account_classification_len {
         return Err(SwigError::InvalidAccountsLength.into());
     }
 
@@ -131,6 +133,16 @@ fn validated_duplicate_account_index(
     }
 
     Ok(account_index)
+}
+
+#[inline(always)]
+unsafe fn is_swig_config_account(account: &AccountInfo) -> bool {
+    if account.owner() != &crate::ID {
+        return false;
+    }
+
+    let data = account.borrow_data_unchecked();
+    data.len() >= Swig::LEN && *data.get_unchecked(0) == Discriminator::SwigConfigAccount as u8
 }
 
 /// Determines if a Swig account is v2 format by checking the last 7 bytes.
@@ -214,48 +226,43 @@ unsafe fn execute(
     accounts: &mut [MaybeUninit<AccountInfo>],
     account_classification: &mut [MaybeUninit<AccountClassification>],
 ) -> Result<(), ProgramError> {
-    let mut index: usize = 0;
+    let acc = ctx
+        .next_account()
+        .map_err(|_| SwigError::InvalidAccountsLength)?;
 
-    // First account must be processed to get SwigWithRoles
-    if let Ok(acc) = ctx.next_account() {
-        validate_account_slot(index, accounts.len(), account_classification.len())?;
-        match acc {
-            MaybeAccount::Account(account) => {
-                let classification =
-                    classify_account(0, &account, accounts, account_classification, None)?;
-                account_classification[0].write(classification);
-                accounts[0].write(account);
-            },
-            MaybeAccount::Duplicated(account_index) => {
-                let account_index = validated_duplicate_account_index(account_index, index)?;
-                accounts[0].write(accounts[account_index].assume_init_ref().clone());
-            },
-        }
-        index = 1;
+    match acc {
+        MaybeAccount::Account(account) => {
+            let classification =
+                classify_account(0, &account, accounts, account_classification, None)?;
+            account_classification[0].write(classification);
+            accounts[0].write(account);
+        },
+        MaybeAccount::Duplicated(_) => return Err(SwigError::InvalidAccountsLength.into()),
     }
+    let mut index: usize = 1;
 
-    // Create program scope cache if first account is a valid Swig account
-    let program_scope_cache = if index > 0 {
-        let first_account = accounts[0].assume_init_ref();
-        if first_account.owner() == &crate::ID {
-            let data = first_account.borrow_data_unchecked();
-            if data.len() >= Swig::LEN
-                && *data.get_unchecked(0) == Discriminator::SwigConfigAccount as u8
-            {
-                ProgramScopeCache::load_from_swig(data)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
+    let first_account = accounts[0].assume_init_ref();
+    // Non-Swig first accounts are valid for instructions that do not use the
+    // SignV2 account layout, so absence of a cache is not an error here.
+    let program_scope_cache = if is_swig_config_account(first_account) {
+        let data = first_account.borrow_data_unchecked();
+        ProgramScopeCache::load_from_swig(data)
     } else {
         None
     };
 
-    // Process remaining accounts using the cache
-    while let Ok(acc) = ctx.next_account() {
-        validate_account_slot(index, accounts.len(), account_classification.len())?;
+    let remaining_accounts =
+        usize::try_from(ctx.remaining()).map_err(|_| SwigError::InvalidAccountsLength)?;
+    let end = index
+        .checked_add(remaining_accounts)
+        .ok_or(SwigError::InvalidAccountsLength)?;
+    validate_account_capacity(end, accounts.len(), account_classification.len())?;
+
+    // Process the remaining known account count using the program-scope cache.
+    for _ in 0..remaining_accounts {
+        let acc = ctx
+            .next_account()
+            .map_err(|_| SwigError::InvalidAccountsLength)?;
         let (account, classification) = match acc {
             MaybeAccount::Account(account) => {
                 let classification = classify_account(
@@ -285,6 +292,7 @@ unsafe fn execute(
         index += 1;
     }
 
+    // Only the consumed prefix of the scratch buffers has been initialized.
     process_action(
         core::slice::from_raw_parts(accounts.as_ptr() as _, index),
         core::slice::from_raw_parts_mut(account_classification.as_mut_ptr() as _, index),
@@ -327,102 +335,85 @@ unsafe fn classify_account(
     account_classifications: &[MaybeUninit<AccountClassification>],
     program_scope_cache: Option<&ProgramScopeCache>,
 ) -> Result<AccountClassification, ProgramError> {
-    let mut target_index: usize = 0;
     match account.owner() {
         &crate::ID => {
-            let data = account.borrow_data_unchecked();
-            let first_byte = *data.get_unchecked(0);
-            match first_byte {
-                disc if disc == Discriminator::SwigConfigAccount as u8 && index == 0 => {
-                    Ok(AccountClassification::ThisSwigV2 {
-                        lamports: account.lamports(),
-                    })
-                },
-                disc if disc == Discriminator::SwigConfigAccount as u8 && index != 0 => {
-                    let first_account = accounts.get_unchecked(0).assume_init_ref();
-                    let first_data = first_account.borrow_data_unchecked();
+            if !is_swig_config_account(account) {
+                return Ok(AccountClassification::None);
+            }
 
-                    if first_account.owner() == &crate::ID
-                        && first_data.len() >= 8
-                        && *first_data.get_unchecked(0) == Discriminator::SwigConfigAccount as u8
-                    {
-                        Ok(AccountClassification::None)
-                    } else {
-                        Err(SwigError::InvalidAccountsSwigMustBeFirst.into())
-                    }
-                },
-                _ => Ok(AccountClassification::None),
+            if index == 0 {
+                return Ok(AccountClassification::ThisSwigV2 {
+                    lamports: account.lamports(),
+                });
+            }
+
+            let first_account = accounts.get_unchecked(0).assume_init_ref();
+            if is_swig_config_account(first_account) {
+                Ok(AccountClassification::None)
+            } else {
+                Err(SwigError::InvalidAccountsSwigMustBeFirst.into())
             }
         },
         &SYSTEM_PROGRAM_ID if index == 1 => {
             let first_account = accounts.get_unchecked(0).assume_init_ref();
-            let first_data = first_account.borrow_data_unchecked();
 
             // When the account is a Swig account, it's safe to assume the
             // account directly after will be the SwigWalletAddress. This is validated
             // further down in instructions relevant to the account structure via signer
             // seeds.
-            if first_account.owner() == &crate::ID
-                && first_data.len() >= Swig::LEN
-                && *first_data.get_unchecked(0) == Discriminator::SwigConfigAccount as u8
-            {
+            if is_swig_config_account(first_account) {
                 return Ok(AccountClassification::SwigWalletAddress);
             }
             Ok(AccountClassification::None)
         },
         &STAKING_ID => {
-            let data = account.borrow_data_unchecked();
-            // Check if this is a stake account by checking the data
-            if data.len() >= 200 && index > 0 {
-                // Verify if this stake account belongs to the swig
-                // First get the authorized withdrawer from the stake account data
-                // In stake account data, the authorized withdrawer is at offset 44 (36 + 8) for
-                // 32 bytes
-                let authorized_withdrawer = unsafe { data.get_unchecked(44..76) };
-
-                // Check if the withdrawer is the swig account
-                if sol_memcmp(
-                    accounts.get_unchecked(0).assume_init_ref().key(),
-                    authorized_withdrawer,
-                    32,
-                ) == 0
-                {
-                    // Extract the stake state from the account
-                    // The state enum is at offset 196 (36 + 8 + 32 + 32 + 8 + 8 + 32 + 4 + 8 + 16 +
-                    // 8 + 4) for 4 bytes
-                    let state_value = u32::from_le_bytes(
-                        data.get_unchecked(196..200)
-                            .try_into()
-                            .map_err(|_| ProgramError::InvalidAccountData)?,
-                    );
-
-                    let state = match state_value {
-                        0 => swig_state::StakeAccountState::Uninitialized,
-                        1 => swig_state::StakeAccountState::Initialized,
-                        2 => swig_state::StakeAccountState::Stake,
-                        3 => swig_state::StakeAccountState::RewardsPool,
-                        _ => return Err(ProgramError::InvalidAccountData),
-                    };
-                    // Extract the stake amount from the account
-                    // The delegated stake amount is at offset 184 (36 + 8 + 32 + 32 + 8 + 8 + 32 +
-                    // 4 + 8 + 16) for 8 bytes
-                    let stake_amount = u64::from_le_bytes(
-                        data.get_unchecked(184..192)
-                            .try_into()
-                            .map_err(|_| ProgramError::InvalidAccountData)?,
-                    );
-
-                    return Ok(AccountClassification::SwigStakeAccount {
-                        state,
-                        balance: stake_amount,
-                        spent: 0,
-                    });
-                }
+            if index == 0 {
+                return Ok(AccountClassification::None);
             }
-            Ok(AccountClassification::None)
+
+            let data = account.borrow_data_unchecked();
+            if data.len() < 200 {
+                return Ok(AccountClassification::None);
+            }
+
+            // Stake account authorized withdrawer is at offset 44 for 32 bytes.
+            let authorized_withdrawer = data.get_unchecked(44..76);
+            if sol_memcmp(
+                accounts.get_unchecked(0).assume_init_ref().key(),
+                authorized_withdrawer,
+                32,
+            ) != 0
+            {
+                return Ok(AccountClassification::None);
+            }
+
+            // Stake state is at offset 196; delegated stake amount is at 184.
+            let state_value = u32::from_le_bytes(
+                data.get_unchecked(196..200)
+                    .try_into()
+                    .map_err(|_| ProgramError::InvalidAccountData)?,
+            );
+            let state = match state_value {
+                0 => StakeAccountState::Uninitialized,
+                1 => StakeAccountState::Initialized,
+                2 => StakeAccountState::Stake,
+                3 => StakeAccountState::RewardsPool,
+                _ => return Err(ProgramError::InvalidAccountData),
+            };
+            let stake_amount = u64::from_le_bytes(
+                data.get_unchecked(184..192)
+                    .try_into()
+                    .map_err(|_| ProgramError::InvalidAccountData)?,
+            );
+
+            Ok(AccountClassification::SwigStakeAccount {
+                state,
+                balance: stake_amount,
+                spent: 0,
+            })
         },
         #[cfg(not(feature = "program_scope_test"))]
-        &SPL_TOKEN_2022_ID | &SPL_TOKEN_ID if account.data_len() >= 165 && index > 0 => unsafe {
+        &SPL_TOKEN_2022_ID | &SPL_TOKEN_ID if index > 0 && account.data_len() >= 165 => {
             let data = account.borrow_data_unchecked();
             let token_authority = data.get_unchecked(32..64);
 
@@ -432,56 +423,50 @@ unsafe fn classify_account(
                 32,
             ) == 0;
 
-            let matches_swig_wallet_address = if index > 1 {
-                // Only check wallet address if account[1] is actually classified as
-                // SwigWalletAddress
-                if matches!(
+            let matches_swig_wallet_address = index > 1
+                && matches!(
                     account_classifications.get_unchecked(1).assume_init_ref(),
                     AccountClassification::SwigWalletAddress
-                ) {
-                    sol_memcmp(
-                        accounts.get_unchecked(1).assume_init_ref().key(),
-                        token_authority,
-                        32,
-                    ) == 0
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
+                )
+                && sol_memcmp(
+                    accounts.get_unchecked(1).assume_init_ref().key(),
+                    token_authority,
+                    32,
+                ) == 0;
 
-            if matches_swig_account || matches_swig_wallet_address {
-                Ok(AccountClassification::SwigTokenAccount {
-                    balance: u64::from_le_bytes(
-                        data.get_unchecked(64..72)
-                            .try_into()
-                            .map_err(|_| ProgramError::InvalidAccountData)?,
-                    ),
-                    spent: 0,
-                })
-            } else {
-                Ok(AccountClassification::None)
+            if !matches_swig_account && !matches_swig_wallet_address {
+                return Ok(AccountClassification::None);
             }
+
+            Ok(AccountClassification::SwigTokenAccount {
+                balance: u64::from_le_bytes(
+                    data.get_unchecked(64..72)
+                        .try_into()
+                        .map_err(|_| ProgramError::InvalidAccountData)?,
+                ),
+                spent: 0,
+            })
         },
         _ => {
-            if index > 0 {
-                // Use the program scope cache if available
-                if let Some(cache) = program_scope_cache {
-                    if let Some((role_id, program_scope)) =
-                        cache.find_program_scope(account.key().as_ref())
-                    {
-                        let data = account.borrow_data_unchecked();
-                        let balance = read_program_scope_account_balance(data, &program_scope)?;
-                        return Ok(AccountClassification::ProgramScope {
-                            role_index: role_id,
-                            balance,
-                            spent: 0,
-                        });
-                    }
-                }
+            if index == 0 {
+                return Ok(AccountClassification::None);
             }
-            Ok(AccountClassification::None)
+
+            let Some(cache) = program_scope_cache else {
+                return Ok(AccountClassification::None);
+            };
+            let Some((role_id, program_scope)) = cache.find_program_scope(account.key().as_ref())
+            else {
+                return Ok(AccountClassification::None);
+            };
+
+            let data = account.borrow_data_unchecked();
+            let balance = read_program_scope_account_balance(data, &program_scope)?;
+            Ok(AccountClassification::ProgramScope {
+                role_index: role_id,
+                balance,
+                spent: 0,
+            })
         },
     }
 }
@@ -508,9 +493,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_account_slot_rejects_array_capacity_overflow() {
-        assert_invalid_accounts_length(validate_account_slot(3, 3, 4));
-        assert_invalid_accounts_length(validate_account_slot(3, 4, 3));
+    fn validate_account_capacity_rejects_array_capacity_overflow() {
+        assert_invalid_accounts_length(validate_account_capacity(4, 3, 4));
+        assert_invalid_accounts_length(validate_account_capacity(4, 4, 3));
     }
 
     #[test]

--- a/program/tests/add_authority_test.rs
+++ b/program/tests/add_authority_test.rs
@@ -9,7 +9,12 @@ use common::*;
 use solana_sdk::{signature::Keypair, signer::Signer};
 use swig_interface::{AuthorityConfig, ClientAction};
 use swig_state::{
-    action::manage_authority::ManageAuthority, authority::AuthorityType, swig::SwigWithRoles,
+    action::{
+        manage_authority::ManageAuthority, sol_limit::SolLimit,
+        sol_recurring_limit::SolRecurringLimit,
+    },
+    authority::AuthorityType,
+    swig::SwigWithRoles,
 };
 
 #[test_log::test]
@@ -114,6 +119,53 @@ fn test_cannot_add_authority_with_zero_actions() {
         swig.state.roles, 1,
         "Should still have only the root authority"
     );
+}
+
+#[test_log::test]
+fn test_cannot_add_authority_with_duplicate_limit_family() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let result = add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::SolLimit(SolLimit { amount: 100 }),
+            ClientAction::SolRecurringLimit(SolRecurringLimit {
+                recurring_amount: 100,
+                window: 100,
+                last_reset: 0,
+                current_amount: 100,
+            }),
+        ],
+    );
+
+    assert!(
+        result.is_err(),
+        "Adding fixed and recurring SOL limits for one role should fail"
+    );
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    assert_eq!(swig.state.roles, 1);
 }
 
 #[test_log::test]

--- a/program/tests/sign_v2_cu_comparison.rs
+++ b/program/tests/sign_v2_cu_comparison.rs
@@ -1,0 +1,437 @@
+#![cfg(not(feature = "program_scope_test"))]
+
+mod common;
+use common::*;
+use litesvm_token::spl_token;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    native_token::LAMPORTS_PER_SOL,
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{AuthorityConfig, ClientAction, SignV2Instruction};
+use swig_state::{
+    action::{
+        all::All, program_all::ProgramAll, sol_destination_limit::SolDestinationLimit,
+        sol_limit::SolLimit, token_destination_limit::TokenDestinationLimit,
+        token_limit::TokenLimit,
+    },
+    authority::AuthorityType,
+    swig::{swig_account_seeds, swig_wallet_address_seeds},
+};
+
+const TRANSFER_LAMPORTS: u64 = LAMPORTS_PER_SOL / 10;
+const TOKEN_TRANSFER_AMOUNT: u64 = 100;
+
+#[test_log::test]
+fn compare_sign_v2_role_compute_units() {
+    let all = sign_with_all_role_cu();
+    let sol_limit = sign_with_sol_limit_role_cu();
+    let sol_limit_destination = sign_with_sol_limit_destination_role_cu();
+    let token_limit = sign_with_token_limit_role_cu();
+    let token_limit_destination = sign_with_token_limit_destination_role_cu();
+
+    println!("CU_COMPARE all {}", all);
+    println!("CU_COMPARE sol_limit {}", sol_limit);
+    println!("CU_COMPARE sol_limit_destination {}", sol_limit_destination);
+    println!("CU_COMPARE token_limit {}", token_limit);
+    println!(
+        "CU_COMPARE token_limit_destination {}",
+        token_limit_destination
+    );
+}
+
+fn sign_with_all_role_cu() -> u64 {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet_address =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+
+    create_swig_ed25519(&mut context, &authority, id).unwrap();
+    context
+        .svm
+        .airdrop(&swig_wallet_address, LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let inner_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet_address,
+        &recipient.pubkey(),
+        TRANSFER_LAMPORTS,
+    );
+
+    send_sign_v2(
+        &mut context,
+        &authority,
+        swig,
+        swig_wallet_address,
+        inner_ix,
+        0,
+    )
+}
+
+fn sign_with_sol_limit_role_cu() -> u64 {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let limited_authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&limited_authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet_address =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+
+    create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: limited_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::SolLimit(SolLimit {
+                amount: LAMPORTS_PER_SOL,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let inner_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet_address,
+        &recipient.pubkey(),
+        TRANSFER_LAMPORTS,
+    );
+
+    send_sign_v2(
+        &mut context,
+        &limited_authority,
+        swig,
+        swig_wallet_address,
+        inner_ix,
+        1,
+    )
+}
+
+fn sign_with_sol_limit_destination_role_cu() -> u64 {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let limited_authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&limited_authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet_address =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+
+    create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: limited_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::SolLimit(SolLimit {
+                amount: LAMPORTS_PER_SOL,
+            }),
+            ClientAction::SolDestinationLimit(SolDestinationLimit {
+                destination: recipient.pubkey().to_bytes(),
+                amount: LAMPORTS_PER_SOL,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let inner_ix = solana_system_interface::instruction::transfer(
+        &swig_wallet_address,
+        &recipient.pubkey(),
+        TRANSFER_LAMPORTS,
+    );
+
+    send_sign_v2(
+        &mut context,
+        &limited_authority,
+        swig,
+        swig_wallet_address,
+        inner_ix,
+        1,
+    )
+}
+
+fn sign_with_token_limit_role_cu() -> u64 {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let limited_authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&limited_authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet_address =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+
+    let mint = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint,
+        &recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+    mint_to(
+        &mut context.svm,
+        &mint,
+        &context.default_payer,
+        &swig_ata,
+        1_000,
+    )
+    .unwrap();
+
+    create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: limited_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::TokenLimit(TokenLimit {
+                token_mint: mint.to_bytes(),
+                current_amount: 1_000,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let inner_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &recipient_ata,
+        &swig_wallet_address,
+        &[],
+        TOKEN_TRANSFER_AMOUNT,
+    )
+    .unwrap();
+
+    send_sign_v2(
+        &mut context,
+        &limited_authority,
+        swig,
+        swig_wallet_address,
+        inner_ix,
+        1,
+    )
+}
+
+fn sign_with_token_limit_destination_role_cu() -> u64 {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let limited_authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&limited_authority.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet_address =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+
+    let mint = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint,
+        &recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+    mint_to(
+        &mut context.svm,
+        &mint,
+        &context.default_payer,
+        &swig_ata,
+        1_000,
+    )
+    .unwrap();
+
+    create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: limited_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::TokenLimit(TokenLimit {
+                token_mint: mint.to_bytes(),
+                current_amount: 1_000,
+            }),
+            ClientAction::TokenDestinationLimit(TokenDestinationLimit {
+                token_mint: mint.to_bytes(),
+                destination: recipient_ata.to_bytes(),
+                amount: 1_000,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let inner_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &recipient_ata,
+        &swig_wallet_address,
+        &[],
+        TOKEN_TRANSFER_AMOUNT,
+    )
+    .unwrap();
+
+    send_sign_v2(
+        &mut context,
+        &limited_authority,
+        swig,
+        swig_wallet_address,
+        inner_ix,
+        1,
+    )
+}
+
+fn send_sign_v2(
+    context: &mut SwigTestContext,
+    authority: &Keypair,
+    swig: Pubkey,
+    swig_wallet_address: Pubkey,
+    inner_ix: solana_sdk::instruction::Instruction,
+    role_id: u32,
+) -> u64 {
+    let sign_ix = SignV2Instruction::new_ed25519(
+        swig,
+        swig_wallet_address,
+        authority.pubkey(),
+        inner_ix,
+        role_id,
+    )
+    .unwrap();
+
+    let message = v0::Message::try_compile(
+        &authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(message), &[authority]).unwrap();
+    context
+        .svm
+        .send_transaction(tx)
+        .unwrap()
+        .compute_units_consumed
+}

--- a/program/tests/token_destination_limit_v2.rs
+++ b/program/tests/token_destination_limit_v2.rs
@@ -198,6 +198,134 @@ fn test_token_destination_limit_basic_v2() {
     );
 }
 
+/// TokenDestinationLimit must handle SPL Token TransferChecked instructions.
+#[test_log::test]
+fn test_token_destination_limit_transfer_checked_v2() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+
+    mint_to(
+        &mut context.svm,
+        &mint_pubkey,
+        &context.default_payer,
+        &swig_ata,
+        1000,
+    )
+    .unwrap();
+
+    create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let destination_limit_amount = 500u64;
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::TokenDestinationLimit(TokenDestinationLimit {
+                token_mint: mint_pubkey.to_bytes(),
+                destination: recipient_ata.to_bytes(),
+                amount: destination_limit_amount,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, 2_000_000_000)
+        .unwrap();
+
+    let transfer_amount = 300u64;
+    let transfer_ix = spl_token::instruction::transfer_checked(
+        &spl_token::ID,
+        &swig_ata,
+        &mint_pubkey,
+        &recipient_ata,
+        &swig_wallet_address,
+        &[],
+        transfer_amount,
+        9,
+    )
+    .unwrap();
+
+    let sign_ix = SignV2Instruction::new_ed25519(
+        swig,
+        swig_wallet_address,
+        second_authority.pubkey(),
+        transfer_ix,
+        1,
+    )
+    .unwrap();
+    let transfer_message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let transfer_tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(transfer_message), &[&second_authority])
+            .unwrap();
+
+    let result = context.svm.send_transaction(transfer_tx);
+    assert!(result.is_ok());
+
+    let swig_account = context.svm.get_account(&swig).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    let role = swig_state.get_role(1).unwrap().unwrap();
+    let combined_key = [mint_pubkey.to_bytes(), recipient_ata.to_bytes()].concat();
+    let dest_limit = role
+        .get_action::<TokenDestinationLimit>(&combined_key)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        dest_limit.amount,
+        destination_limit_amount - transfer_amount
+    );
+}
+
 /// Destination limits must validate every token transfer in one SignV2 payload.
 #[test_log::test]
 fn test_token_destination_limit_rejects_second_unmatched_transfer_v2() {

--- a/program/tests/update_authority_test.rs
+++ b/program/tests/update_authority_test.rs
@@ -19,7 +19,8 @@ use swig_interface::{
 use swig_state::{
     action::{
         all::All, manage_authority::ManageAuthority, program_curated::ProgramCurated,
-        sol_limit::SolLimit, token_limit::TokenLimit, Action, Permission,
+        sol_limit::SolLimit, sol_recurring_limit::SolRecurringLimit, token_limit::TokenLimit,
+        Action, Permission,
     },
     authority::AuthorityType,
     role::Position,
@@ -272,6 +273,68 @@ fn test_update_authority_rejects_malformed_program_curated_add_actions() -> anyh
         result.is_err(),
         "AddActions should fail when ProgramCurated payload length is zero"
     );
+
+    Ok(())
+}
+
+#[test_log::test]
+fn test_update_authority_rejects_duplicate_limit_family() -> anyhow::Result<()> {
+    let mut context = setup_test_context()?;
+
+    let root_authority = Keypair::new();
+    let id = [72u8; 32];
+    let (swig, _) = create_swig_ed25519(&mut context, &root_authority, id)?;
+
+    let second_authority = Keypair::new();
+    let second_authority_pubkey = second_authority.pubkey();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority_pubkey.as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )?;
+
+    let swig_account = context.svm.get_account(&swig).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data)
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize swig: {:?}", e))?;
+    let second_role_id = swig_data
+        .lookup_role_id(second_authority_pubkey.as_ref())
+        .map_err(|e| anyhow::anyhow!("Failed to lookup second role id: {:?}", e))?
+        .ok_or(anyhow::anyhow!("Second role not found"))?;
+
+    let result = update_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        second_role_id,
+        vec![
+            ClientAction::SolLimit(SolLimit { amount: 100 }),
+            ClientAction::SolRecurringLimit(SolRecurringLimit {
+                recurring_amount: 100,
+                window: 100,
+                last_reset: 0,
+                current_amount: 100,
+            }),
+        ],
+    );
+
+    assert!(
+        result.is_err(),
+        "Replacing actions with duplicate SOL limit family should fail"
+    );
+
+    let swig_account = context.svm.get_account(&swig).unwrap();
+    let swig_data = SwigWithRoles::from_bytes(&swig_account.data)
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize swig: {:?}", e))?;
+    let second_role = swig_data
+        .get_role(second_role_id)
+        .map_err(|e| anyhow::anyhow!("Failed to get second role: {:?}", e))?
+        .unwrap();
+    assert_eq!(second_role.position.num_actions(), 1);
 
     Ok(())
 }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -107,6 +107,8 @@ pub enum SwigStateError {
     PermissionLoadError,
     /// Adding an authority requires at least one action
     InvalidAuthorityMustHaveAtLeastOneAction,
+    /// Role action set contains duplicate enforcement entries
+    DuplicateAction,
 }
 
 /// Error types related to authentication operations.

--- a/state/src/swig.rs
+++ b/state/src/swig.rs
@@ -11,7 +11,7 @@ use no_padding::NoPadding;
 use pinocchio::{instruction::Seed, program_error::ProgramError};
 
 use crate::{
-    action::{program_scope::ProgramScope, Action, ActionLoader, Actionable},
+    action::{program_scope::ProgramScope, Action, ActionLoader, Actionable, Permission},
     authority::{
         ed25519::{ED25519Authority, Ed25519SessionAuthority},
         programexec::{session::ProgramExecSessionAuthority, ProgramExecAuthority},
@@ -96,6 +96,115 @@ pub fn sub_account_signer<'a>(
         role_id.into(),
         bump.as_ref().into(),
     ]
+}
+
+struct RoleActionKey<'a> {
+    kind: u16,
+    data: &'a [u8],
+}
+
+impl<'a> RoleActionKey<'a> {
+    #[inline(always)]
+    fn matches(&self, other: &Self) -> bool {
+        self.kind == other.kind && self.data == other.data
+    }
+}
+
+#[inline(always)]
+fn role_action_key<'a>(
+    permission: Permission,
+    action_data: &'a [u8],
+) -> Result<RoleActionKey<'a>, ProgramError> {
+    const PUBKEY_LEN: usize = 32;
+    const PROGRAM_SCOPE_TARGET_OFFSET: usize = 80;
+
+    let (kind, start, len) = match permission {
+        Permission::SolLimit | Permission::SolRecurringLimit => (1, 0, 0),
+        Permission::SolDestinationLimit | Permission::SolRecurringDestinationLimit => {
+            (2, 0, PUBKEY_LEN)
+        },
+        Permission::TokenLimit | Permission::TokenRecurringLimit => (3, 0, PUBKEY_LEN),
+        Permission::TokenDestinationLimit | Permission::TokenRecurringDestinationLimit => {
+            (4, 0, PUBKEY_LEN * 2)
+        },
+        Permission::StakeLimit | Permission::StakeRecurringLimit => (5, 0, 0),
+        Permission::Program => (Permission::Program as u16, 0, PUBKEY_LEN),
+        Permission::ProgramScope => (
+            Permission::ProgramScope as u16,
+            PROGRAM_SCOPE_TARGET_OFFSET,
+            PUBKEY_LEN,
+        ),
+        Permission::SubAccount => (Permission::SubAccount as u16, 0, PUBKEY_LEN),
+        _ => (permission as u16, 0, 0),
+    };
+
+    let end = start
+        .checked_add(len)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    if end > action_data.len() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    Ok(RoleActionKey {
+        kind,
+        data: &action_data[start..end],
+    })
+}
+
+#[inline(always)]
+fn read_role_action<'a>(
+    actions_data: &'a [u8],
+    cursor: usize,
+) -> Result<(usize, Permission, &'a [u8]), ProgramError> {
+    let header_end = cursor
+        .checked_add(Action::LEN)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    if header_end > actions_data.len() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let action = unsafe { Action::load_unchecked(&actions_data[cursor..header_end])? };
+    let action_end = header_end
+        .checked_add(action.length() as usize)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    if action_end > actions_data.len() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    Ok((
+        action_end,
+        action.permission()?,
+        &actions_data[header_end..action_end],
+    ))
+}
+
+/// Rejects duplicate role actions that would race for the same enforcement
+/// slot. Fixed and recurring limit variants share a key because the runtime
+/// charges only the first matching general or destination limit.
+pub fn validate_unique_role_actions(actions_data: &[u8]) -> Result<(), ProgramError> {
+    let mut cursor = 0;
+
+    while cursor < actions_data.len() {
+        let (next_cursor, permission, action_data) = read_role_action(actions_data, cursor)?;
+        let key = role_action_key(permission, action_data)?;
+
+        let mut compare_cursor = 0;
+        while compare_cursor < cursor {
+            let (next_compare_cursor, compare_permission, compare_action_data) =
+                read_role_action(actions_data, compare_cursor)?;
+            let compare_key = role_action_key(compare_permission, compare_action_data)?;
+
+            if key.matches(&compare_key) {
+                return Err(SwigStateError::DuplicateAction.into());
+            }
+
+            compare_cursor = next_compare_cursor;
+        }
+
+        cursor = next_cursor;
+    }
+
+    Ok(())
 }
 
 /// Builder for constructing and modifying Swig accounts.
@@ -264,6 +373,8 @@ impl<'a> SwigBuilder<'a> {
         if count == 0 {
             return Err(SwigStateError::InvalidAuthorityMustHaveAtLeastOneAction.into());
         }
+
+        validate_unique_role_actions(actions_data)?;
 
         Ok(count)
     }
@@ -744,7 +855,13 @@ impl<'a> SwigWithRoles<'a> {
 mod tests {
     use super::*;
     use crate::{
-        action::{all::All, manage_authority::ManageAuthority, sol_limit::SolLimit, Actionable},
+        action::{
+            all::All, manage_authority::ManageAuthority,
+            sol_destination_limit::SolDestinationLimit, sol_limit::SolLimit,
+            sol_recurring_destination_limit::SolRecurringDestinationLimit,
+            sol_recurring_limit::SolRecurringLimit, token_limit::TokenLimit,
+            token_recurring_limit::TokenRecurringLimit, Actionable,
+        },
         authority::ed25519::ED25519Authority,
         Transmutable,
     };
@@ -796,6 +913,104 @@ mod tests {
         let id = [1; 32];
         let bump = 255;
         (account_buffer, id, bump)
+    }
+
+    fn encoded_action(permission: Permission, action_data: &[u8]) -> Vec<u8> {
+        let header = Action::new(
+            permission,
+            action_data.len() as u16,
+            Action::LEN as u32 + action_data.len() as u32,
+        );
+        [header.into_bytes().unwrap(), action_data].concat()
+    }
+
+    fn assert_duplicate_action(result: Result<(), ProgramError>) {
+        assert!(matches!(
+            result,
+            Err(ProgramError::Custom(code)) if code == SwigStateError::DuplicateAction as u32
+        ));
+    }
+
+    #[test]
+    fn validate_unique_role_actions_rejects_duplicate_general_limit_family() {
+        let sol_limit = SolLimit { amount: 10 };
+        let sol_recurring_limit = SolRecurringLimit {
+            recurring_amount: 20,
+            window: 100,
+            last_reset: 0,
+            current_amount: 20,
+        };
+        let mut actions = encoded_action(SolLimit::TYPE, sol_limit.into_bytes().unwrap());
+        actions.extend_from_slice(&encoded_action(
+            SolRecurringLimit::TYPE,
+            sol_recurring_limit.into_bytes().unwrap(),
+        ));
+
+        assert_duplicate_action(validate_unique_role_actions(&actions));
+    }
+
+    #[test]
+    fn validate_unique_role_actions_rejects_duplicate_destination_limit_family() {
+        let sol_limit = SolDestinationLimit {
+            destination: [7; 32],
+            amount: 10,
+        };
+        let sol_recurring_limit = SolRecurringDestinationLimit {
+            destination: [7; 32],
+            recurring_amount: 20,
+            window: 100,
+            last_reset: 0,
+            current_amount: 20,
+        };
+        let mut actions =
+            encoded_action(SolDestinationLimit::TYPE, sol_limit.into_bytes().unwrap());
+        actions.extend_from_slice(&encoded_action(
+            SolRecurringDestinationLimit::TYPE,
+            sol_recurring_limit.into_bytes().unwrap(),
+        ));
+
+        assert_duplicate_action(validate_unique_role_actions(&actions));
+    }
+
+    #[test]
+    fn validate_unique_role_actions_allows_distinct_destination_limits() {
+        let first = SolDestinationLimit {
+            destination: [7; 32],
+            amount: 10,
+        };
+        let second = SolDestinationLimit {
+            destination: [8; 32],
+            amount: 10,
+        };
+        let mut actions = encoded_action(SolDestinationLimit::TYPE, first.into_bytes().unwrap());
+        actions.extend_from_slice(&encoded_action(
+            SolDestinationLimit::TYPE,
+            second.into_bytes().unwrap(),
+        ));
+
+        assert!(validate_unique_role_actions(&actions).is_ok());
+    }
+
+    #[test]
+    fn validate_unique_role_actions_rejects_duplicate_token_limit_family() {
+        let token_limit = TokenLimit {
+            token_mint: [3; 32],
+            current_amount: 10,
+        };
+        let token_recurring_limit = TokenRecurringLimit {
+            token_mint: [3; 32],
+            window: 100,
+            limit: 20,
+            current: 20,
+            last_reset: 0,
+        };
+        let mut actions = encoded_action(TokenLimit::TYPE, token_limit.into_bytes().unwrap());
+        actions.extend_from_slice(&encoded_action(
+            TokenRecurringLimit::TYPE,
+            token_recurring_limit.into_bytes().unwrap(),
+        ));
+
+        assert_duplicate_action(validate_unique_role_actions(&actions));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR is stacked on `codex/sign-v2-cu-comparison` and fixes the `InstructionHolder` scratch lifetime issue without adding heap allocation.

Key changes:
- replace returned slices into parser-local `MaybeUninit` arrays with a lending parser API: `InstructionIterator::process_next`
- add `InstructionScratch` fixed buffers for `AccountMeta`, original account indexes, and CPI `Account` values
- execute/inspect each parsed instruction inside the callback while scratch-backed slices are still valid
- update SignV2, SOL/token destination parsing, and SubAccountSignV1 call sites to use the fixed-scratch callback flow
- keep parse errors mapped at call sites while preserving callback permission/execution errors
- add a focused `InstructionHolder` borrow test for scratch-backed account metadata

## CU Benchmark

`cargo test -p swig --test sign_v2_cu_comparison -- --nocapture`

| Case | CU |
| --- | ---: |
| All | 2856 |
| SOL limit only | 4125 |
| SOL limit + destination | 4760 |
| Token limit only | 9559 |
| Token limit + destination | 10386 |

These match the current `codex/sign-v2-cu-comparison` results, so the fixed-scratch rewrite did not increase the LiteSVM CU harness numbers.

## Validation

- `cargo fmt`
- `cargo test -p swig-compact-instructions`
- `cargo test -p swig --test sub_account_test test_sub_account_sign -- --nocapture`
- `cargo test -p swig --test sign_v2 test_sign_v2_transfer_sol -- --nocapture`
- `cargo test -p swig --test sol_destination_limit_v2 --test token_destination_limit_v2 -- --nocapture`
- `cargo test -p swig --test sign_v2_cu_comparison -- --nocapture`
- `git diff --check`
- `cargo build-sbf --arch v1`
