### PR TITLE
Authenticate MigrateToWalletAddress authority

### DIFF
--- a/program/src/actions/migrate_to_wallet_address_v1.rs
+++ b/program/src/actions/migrate_to_wallet_address_v1.rs
@@ -6,19 +6,17 @@
 /// migrated Swig account.
 use no_padding::NoPadding;
 use pinocchio::{
+    account_info::AccountInfo,
     msg,
     program_error::ProgramError,
-    sysvars::{rent::Rent, Sysvar},
+    sysvars::{clock::Clock, rent::Rent, Sysvar},
     ProgramResult,
 };
 use swig_assertions::{check_self_pda, check_system_owner, check_zero_data};
 use swig_state::{
     action::{all::All, manage_authority::ManageAuthority},
-    swig::{
-        swig_account_seeds_with_bump, swig_account_signer, swig_wallet_address_seeds_with_bump,
-        swig_wallet_address_signer, Swig, SwigWithRoles,
-    },
-    Discriminator, IntoBytes, SwigStateError, Transmutable,
+    swig::{swig_wallet_address_seeds_with_bump, Swig},
+    Discriminator, IntoBytes, SwigAuthenticateError, SwigStateError, Transmutable,
 };
 
 use crate::{
@@ -34,12 +32,14 @@ use crate::{
 /// # Fields
 /// * `discriminator` - The instruction type identifier
 /// * `wallet_address_bump` - Bump seed for the wallet address PDA
+/// * `role_id` - ID of the role authorizing the migration
 #[repr(C, align(8))]
 #[derive(Debug, NoPadding)]
 pub struct MigrateToWalletAddressV1Args {
     discriminator: SwigInstruction,
     pub wallet_address_bump: u8,
-    pub _padding: [u8; 5], // Explicit padding to align to 8 bytes
+    pub _padding: u8,
+    pub role_id: u32,
 }
 
 impl MigrateToWalletAddressV1Args {
@@ -47,11 +47,13 @@ impl MigrateToWalletAddressV1Args {
     ///
     /// # Arguments
     /// * `wallet_address_bump` - Bump seed for wallet address PDA derivation
-    pub fn new(wallet_address_bump: u8) -> Self {
+    /// * `role_id` - ID of the role authorizing the migration
+    pub fn new(wallet_address_bump: u8, role_id: u32) -> Self {
         Self {
             discriminator: SwigInstruction::MigrateToWalletAddressV1,
             wallet_address_bump,
-            _padding: [0; 5],
+            _padding: 0,
+            role_id,
         }
     }
 }
@@ -69,6 +71,8 @@ impl IntoBytes for MigrateToWalletAddressV1Args {
 /// Struct representing the complete migrate instruction data.
 pub struct MigrateToWalletAddressV1<'a> {
     pub args: &'a MigrateToWalletAddressV1Args,
+    pub authority_payload: &'a [u8],
+    pub data_payload: &'a [u8],
 }
 
 impl<'a> MigrateToWalletAddressV1<'a> {
@@ -84,8 +88,13 @@ impl<'a> MigrateToWalletAddressV1<'a> {
         if bytes.len() < MigrateToWalletAddressV1Args::LEN {
             return Err(SwigError::InvalidSwigCreateInstructionDataTooShort.into());
         }
-        let args = unsafe { MigrateToWalletAddressV1Args::load_unchecked(bytes)? };
-        Ok(Self { args })
+        let (args_data, authority_payload) = bytes.split_at(MigrateToWalletAddressV1Args::LEN);
+        let args = unsafe { MigrateToWalletAddressV1Args::load_unchecked(args_data)? };
+        Ok(Self {
+            args,
+            authority_payload,
+            data_payload: args_data,
+        })
     }
 }
 
@@ -124,6 +133,7 @@ impl Transmutable for OldSwig {
 /// # Arguments
 /// * `ctx` - The account context for the migration
 /// * `migrate_data` - Raw migration instruction data
+/// * `all_accounts` - All accounts passed to the instruction for authority auth
 ///
 /// # Returns
 /// * `ProgramResult` - Success or error status
@@ -131,55 +141,72 @@ impl Transmutable for OldSwig {
 pub fn migrate_to_wallet_address_v1(
     ctx: Context<MigrateToWalletAddressV1Accounts>,
     migrate_data: &[u8],
+    all_accounts: &[AccountInfo],
 ) -> ProgramResult {
     let migrate = MigrateToWalletAddressV1::from_instruction_bytes(migrate_data)?;
 
-    // Validate that the swig account has the correct discriminator
-    let swig_data = unsafe { ctx.accounts.swig.borrow_data_unchecked() };
-    if swig_data.len() < OldSwig::LEN {
-        return Err(SwigError::StateError.into());
-    }
+    let (old_swig_id, old_swig_bump, old_swig_roles, old_swig_role_counter) = {
+        // Validate that the swig account has the correct discriminator
+        let swig_data = unsafe { ctx.accounts.swig.borrow_data_unchecked() };
+        if swig_data.len() < OldSwig::LEN {
+            return Err(SwigError::StateError.into());
+        }
 
-    let discriminator = swig_data[0];
-    if discriminator != Discriminator::SwigConfigAccount as u8 {
-        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
-    }
+        let discriminator = swig_data[0];
+        if discriminator != Discriminator::SwigConfigAccount as u8 {
+            return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+        }
 
-    // Check if this account is already migrated (has wallet_bump field)
-    // We can detect this by checking if reserved_lamports field is 0 and if the
-    // 41st byte (wallet_bump position) is non-zero
-    let old_swig = unsafe { OldSwig::load_unchecked(&swig_data[..OldSwig::LEN])? };
-    let potential_wallet_bump = swig_data[40]; // Position where wallet_bump would be
+        // Check if this account is already migrated (has wallet_bump field)
+        // We can detect this by checking if reserved_lamports field is 0 and if the
+        // 41st byte (wallet_bump position) is non-zero
+        let old_swig = unsafe { OldSwig::load_unchecked(&swig_data[..OldSwig::LEN])? };
+        let potential_wallet_bump = swig_data[40]; // Position where wallet_bump would be
 
-    if old_swig.reserved_lamports == 0 && potential_wallet_bump != 0 {
-        msg!("Account appears to already be migrated");
-        return Err(SwigError::StateError.into());
-    }
+        if old_swig.reserved_lamports == 0 && potential_wallet_bump != 0 {
+            msg!("Account appears to already be migrated");
+            return Err(SwigError::StateError.into());
+        }
 
-    // Validate authority has All or ManageAuthority permission
-    let authority_pubkey = ctx.accounts.authority.key();
+        (
+            old_swig.id,
+            old_swig.bump,
+            old_swig.roles,
+            old_swig.role_counter,
+        )
+    };
 
-    // Check if authority has All or ManageAuthority permission
-    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data)?;
-    let role_id = swig_with_roles.lookup_role_id(authority_pubkey.as_ref())?;
+    // Authenticate and validate authority has All or ManageAuthority permission
+    {
+        let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+        let (_swig_header, swig_roles) =
+            unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+        let role = Swig::get_mut_role(migrate.args.role_id, swig_roles)?
+            .ok_or(SwigStateError::RoleNotFound)?;
 
-    match role_id {
-        Some(id) => {
-            let role = swig_with_roles
-                .get_role(id)?
-                .ok_or(SwigStateError::RoleNotFound)?;
+        let slot = Clock::get()?.slot;
+        if role.authority.session_based() {
+            role.authority.authenticate_session(
+                all_accounts,
+                migrate.authority_payload,
+                migrate.data_payload,
+                slot,
+            )?;
+        } else {
+            role.authority.authenticate(
+                all_accounts,
+                migrate.authority_payload,
+                migrate.data_payload,
+                slot,
+            )?;
+        }
 
-            let has_all_permission = role.get_action::<All>(&[])?.is_some();
-            let has_manage_authority = role.get_action::<ManageAuthority>(&[])?.is_some();
-            if !has_all_permission && !has_manage_authority {
-                msg!("Authority lacks All or ManageAuthority permission");
-                return Err(SwigError::InvalidAuthorityType.into());
-            }
-        },
-        None => {
-            msg!("Authority not found in wallet roles");
-            return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
-        },
+        let has_all_permission = role.get_action::<All>(&[])?.is_some();
+        let has_manage_authority = role.get_action::<ManageAuthority>(&[])?.is_some();
+        if !has_all_permission && !has_manage_authority {
+            msg!("Authority lacks All or ManageAuthority permission");
+            return Err(SwigAuthenticateError::PermissionDeniedToManageAuthority.into());
+        }
     }
 
     // Validate wallet address account
@@ -203,21 +230,21 @@ pub fn migrate_to_wallet_address_v1(
     )?;
 
     // Create the new Swig structure with wallet_bump
-    let new_swig = Swig::new(old_swig.id, old_swig.bump, wallet_address_bump);
+    let new_swig = Swig::new(old_swig_id, old_swig_bump, wallet_address_bump);
 
     // Ensure the role counter and roles count are preserved
     let mut new_swig_with_preserved_data = new_swig;
-    new_swig_with_preserved_data.roles = old_swig.roles;
-    new_swig_with_preserved_data.role_counter = old_swig.role_counter;
+    new_swig_with_preserved_data.roles = old_swig_roles;
+    new_swig_with_preserved_data.role_counter = old_swig_role_counter;
 
     // Update the Swig account data in-place
     // Only modify the first 48 bytes (Swig struct), leaving all role/action data
     // intact
-    drop(swig_data); // Release the borrow
-    let mut swig_data_mut = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-    let new_swig_bytes = new_swig_with_preserved_data.into_bytes()?;
-    swig_data_mut[..Swig::LEN].copy_from_slice(new_swig_bytes);
-    drop(swig_data_mut); // Release the borrow
+    {
+        let mut swig_data_mut = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+        let new_swig_bytes = new_swig_with_preserved_data.into_bytes()?;
+        swig_data_mut[..Swig::LEN].copy_from_slice(new_swig_bytes);
+    }
 
     // Create the wallet address account by transferring rent-exempt lamports
     let wallet_address_rent_exemption = Rent::get()?.minimum_balance(0); // 0 space for system account

--- a/program/src/actions/mod.rs
+++ b/program/src/actions/mod.rs
@@ -207,7 +207,7 @@ fn process_toggle_sub_account_v1(accounts: &[AccountInfo], data: &[u8]) -> Progr
 /// Migrates a Swig account to support wallet address feature.
 fn process_migrate_to_wallet_address_v1(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let account_ctx = MigrateToWalletAddressV1Accounts::context(accounts)?;
-    migrate_to_wallet_address_v1(account_ctx, data)
+    migrate_to_wallet_address_v1(account_ctx, data, accounts)
 }
 
 /// Processes a TransferAssetsV1 instruction.

--- a/program/tests/migrate_to_wallet_address_test.rs
+++ b/program/tests/migrate_to_wallet_address_test.rs
@@ -1,0 +1,142 @@
+#![cfg(not(feature = "program_scope_test"))]
+
+mod common;
+
+use common::*;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig::actions::migrate_to_wallet_address_v1::MigrateToWalletAddressV1Args;
+use swig_state::{
+    swig::{swig_wallet_address_seeds, Swig},
+    IntoBytes, Transmutable,
+};
+
+fn migrate_instruction(
+    swig: Pubkey,
+    authority: Pubkey,
+    payer: Pubkey,
+    swig_wallet_address: Pubkey,
+    wallet_address_bump: u8,
+    authority_is_signer: bool,
+) -> Instruction {
+    let mut data = MigrateToWalletAddressV1Args::new(wallet_address_bump, 0)
+        .into_bytes()
+        .expect("migrate args should serialize")
+        .to_vec();
+    data.push(1);
+
+    Instruction {
+        program_id: program_id(),
+        accounts: vec![
+            AccountMeta::new(swig, false),
+            AccountMeta::new_readonly(authority, authority_is_signer),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(swig_wallet_address, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ],
+        data,
+    }
+}
+
+fn setup_unmigrated_swig() -> (SwigTestContext, Keypair, Pubkey, Pubkey, u8) {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _bench) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    convert_swig_to_v1(&mut context, &swig);
+
+    let (swig_wallet_address, wallet_address_bump) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    (
+        context,
+        authority,
+        swig,
+        swig_wallet_address,
+        wallet_address_bump,
+    )
+}
+
+#[test_log::test]
+fn test_migration_rejects_nonsigner_authority() {
+    let (mut context, authority, swig, swig_wallet_address, wallet_address_bump) =
+        setup_unmigrated_swig();
+
+    let migrate_ix = migrate_instruction(
+        swig,
+        authority.pubkey(),
+        context.default_payer.pubkey(),
+        swig_wallet_address,
+        wallet_address_bump,
+        false,
+    );
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                migrate_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+
+    assert!(
+        result.is_err(),
+        "migration must fail when the role authority does not sign"
+    );
+}
+
+#[test_log::test]
+fn test_migration_accepts_authenticated_authority() {
+    let (mut context, authority, swig, swig_wallet_address, wallet_address_bump) =
+        setup_unmigrated_swig();
+
+    let migrate_ix = migrate_instruction(
+        swig,
+        authority.pubkey(),
+        context.default_payer.pubkey(),
+        swig_wallet_address,
+        wallet_address_bump,
+        true,
+    );
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                migrate_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+
+    assert!(
+        result.is_ok(),
+        "authenticated migration should succeed: {:?}",
+        result.err()
+    );
+
+    let swig_account = context.svm.get_account(&swig).unwrap();
+    let migrated_swig = unsafe { Swig::load_unchecked(&swig_account.data[..Swig::LEN]).unwrap() };
+    assert_eq!(migrated_swig.wallet_bump, wallet_address_bump);
+}


### PR DESCRIPTION
## Summary
- require `MigrateToWalletAddressV1` to authenticate the selected role before migration
- select the acting role by `role_id` and pass trailing instruction bytes as the authority payload
- add regression coverage for nonsigner migration rejection and authenticated migration success

## Linear
- SWI-484

## Validation
- cargo test -p swig --test migrate_to_wallet_address_test --no-run
- cargo build-sbf --arch v1
- cargo test -p swig --test migrate_to_wallet_address_test -- --nocapture
- cargo +stable clippy --workspace --all-targets