### PR TITLE
Fix SignV2 token destination TransferChecked limits

### DIFF
--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -72,6 +72,9 @@ const STAKE_BALANCE_RANGE: core::ops::Range<usize> = 184..192;
 
 /// Account state constants
 const TOKEN_ACCOUNT_INITIALIZED_STATE: u8 = 1;
+const SYSTEM_TRANSFER_DISCRIMINATOR: u32 = 2;
+const TOKEN_TRANSFER_DISCRIMINATOR: u8 = 3;
+const TOKEN_TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
 
 /// Empty exclude ranges for hash_except when no exclusions are needed
 const NO_EXCLUDE_RANGES: &[core::ops::Range<usize>] = &[];
@@ -475,6 +478,7 @@ pub fn sign_v2(
                         // Only check destination limits if they exist
                         if has_sol_destination_limits(actions)? {
                             let mut destination_limit_applied = false;
+                            let mut parsed_sol_spent = 0u64;
                             // Process SOL transfers using zero-copy callback approach
                             process_sol_transfers(
                                 sign_v2.instruction_payload,
@@ -482,6 +486,12 @@ pub fn sign_v2(
                                 all_accounts,
                                 ctx.accounts.swig_wallet_address.key(),
                                 |destination_pubkey, amount| -> Result<bool, ProgramError> {
+                                    let missing_permission =
+                                        SwigAuthenticateError::PermissionDeniedMissingPermission;
+                                    let next_parsed_sol_spent = parsed_sol_spent
+                                        .checked_add(amount)
+                                        .ok_or(missing_permission)?;
+                                    parsed_sol_spent = next_parsed_sol_spent;
                                     let dest_pubkey = destination_pubkey.as_ref();
 
                                     // First check recurring destination limits (higher precedence)
@@ -511,8 +521,10 @@ pub fn sign_v2(
                                 },
                             )?;
 
-                            // If destination limits exist but none matched, that's an error
-                            if !destination_limit_applied {
+                            // If destination limits exist, every actual debit must be parsed
+                            // and charged to a matching destination limit.
+                            let parsed_all_sol_spend = parsed_sol_spent == total_sol_spent;
+                            if !destination_limit_applied || !parsed_all_sol_spend {
                                 return Err(
                                     SwigAuthenticateError::PermissionDeniedMissingPermission.into(),
                                 );
@@ -576,6 +588,7 @@ pub fn sign_v2(
                         let source_account_key = unsafe { all_accounts.get_unchecked(index) }.key();
                         if has_token_destination_limits(actions, mint)? {
                             let mut destination_limit_applied = false;
+                            let mut parsed_token_spent = 0u64;
 
                             process_token_destinations(
                                 sign_v2.instruction_payload,
@@ -583,6 +596,12 @@ pub fn sign_v2(
                                 all_accounts,
                                 ctx.accounts.swig_wallet_address.key(),
                                 |destination, amount| -> Result<bool, ProgramError> {
+                                    let missing_permission =
+                                        SwigAuthenticateError::PermissionDeniedMissingPermission;
+                                    let next_parsed_token_spent = parsed_token_spent
+                                        .checked_add(amount)
+                                        .ok_or(missing_permission)?;
+                                    parsed_token_spent = next_parsed_token_spent;
                                     // Create the combined key [mint + destination] for matching
                                     let mut combined_key = [0u8; 64];
                                     combined_key[..32].copy_from_slice(mint);
@@ -615,7 +634,8 @@ pub fn sign_v2(
                                 },
                             )?;
 
-                            if !destination_limit_applied {
+                            let parsed_all_token_spend = parsed_token_spent == total_token_spent;
+                            if !destination_limit_applied || !parsed_all_token_spend {
                                 return Err(
                                     SwigAuthenticateError::PermissionDeniedMissingPermission.into(),
                                 );
@@ -846,14 +866,14 @@ where
 
         // Check if this is a System Program instruction
         if *instruction.program_id == crate::SYSTEM_PROGRAM_ID {
-            // Check if this is a Transfer instruction (discriminator = 2)
+            // Check if this is a Transfer instruction.
             if instruction.data.len() >= 12
                 && u32::from_le_bytes([
                     instruction.data[0],
                     instruction.data[1],
                     instruction.data[2],
                     instruction.data[3],
-                ]) == 2
+                ]) == SYSTEM_TRANSFER_DISCRIMINATOR
             {
                 // System Program Transfer instruction layout:
                 // - accounts[0]: source account (funding account)
@@ -926,35 +946,42 @@ where
         if *instruction.program_id == crate::SPL_TOKEN_ID
             || *instruction.program_id == crate::SPL_TOKEN_2022_ID
         {
-            // Check if this is a Transfer instruction (discriminator = 3)
-            if instruction.data.len() >= 9 && instruction.data[0] == 3 {
-                // SPL Token Transfer instruction layout:
-                // - accounts[0]: source token account
-                // - accounts[1]: destination token account
-                // - accounts[2]: authority
-                if instruction.accounts.len() >= 2 {
-                    let source_pubkey = &instruction.accounts[0].pubkey;
+            let destination_index = if instruction.data.len() >= 9
+                && instruction.accounts.len() >= 2
+                && instruction.data[0] == TOKEN_TRANSFER_DISCRIMINATOR
+            {
+                Some(1)
+            } else if instruction.data.len() >= 10
+                && instruction.accounts.len() >= 3
+                && instruction.data[0] == TOKEN_TRANSFER_CHECKED_DISCRIMINATOR
+            {
+                Some(2)
+            } else {
+                None
+            };
 
-                    // Check if this transfer is from our source account
-                    if *source_pubkey == source_account.as_ref() {
-                        let destination_pubkey = instruction.accounts[1].pubkey;
+            if let Some(destination_index) = destination_index {
+                let source_pubkey = &instruction.accounts[0].pubkey;
 
-                        let amount = u64::from_le_bytes([
-                            instruction.data[1],
-                            instruction.data[2],
-                            instruction.data[3],
-                            instruction.data[4],
-                            instruction.data[5],
-                            instruction.data[6],
-                            instruction.data[7],
-                            instruction.data[8],
-                        ]);
+                // Check if this transfer is from our source account
+                if *source_pubkey == source_account.as_ref() {
+                    let destination_pubkey = instruction.accounts[destination_index].pubkey;
 
-                        // Call the callback with the destination and transfer amount.
-                        if !callback(destination_pubkey, amount)? {
-                            return Ok(()); // Early exit if callback returns
-                                           // false
-                        }
+                    let amount = u64::from_le_bytes([
+                        instruction.data[1],
+                        instruction.data[2],
+                        instruction.data[3],
+                        instruction.data[4],
+                        instruction.data[5],
+                        instruction.data[6],
+                        instruction.data[7],
+                        instruction.data[8],
+                    ]);
+
+                    // Call the callback with the destination and transfer amount.
+                    if !callback(destination_pubkey, amount)? {
+                        return Ok(()); // Early exit if callback returns
+                                       // false
                     }
                 }
             }

--- a/program/tests/token_destination_limit_v2.rs
+++ b/program/tests/token_destination_limit_v2.rs
@@ -405,6 +405,360 @@ fn test_token_destination_limit_rejects_second_unmatched_transfer_v2() {
     assert_eq!(blocked_final_balance, blocked_initial_balance);
 }
 
+/// Token destination limits must support TransferChecked as a valid transfer
+/// form.
+#[test_log::test]
+fn test_token_destination_limit_allows_transfer_checked_v2() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&recipient.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+
+    mint_to(
+        &mut context.svm,
+        &mint_pubkey,
+        &context.default_payer,
+        &swig_ata,
+        1000,
+    )
+    .unwrap();
+
+    create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let destination_limit_amount = 500u64;
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::TokenDestinationLimit(TokenDestinationLimit {
+                token_mint: mint_pubkey.to_bytes(),
+                destination: recipient_ata.to_bytes(),
+                amount: destination_limit_amount,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, 2_000_000_000)
+        .unwrap();
+
+    let transfer_amount = 300u64;
+    let transfer_ix = spl_token::instruction::transfer_checked(
+        &spl_token::ID,
+        &swig_ata,
+        &mint_pubkey,
+        &recipient_ata,
+        &swig_wallet_address,
+        &[],
+        transfer_amount,
+        9,
+    )
+    .unwrap();
+
+    let sign_ix = SignV2Instruction::new_ed25519(
+        swig,
+        swig_wallet_address,
+        second_authority.pubkey(),
+        transfer_ix,
+        1,
+    )
+    .unwrap();
+
+    let message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&second_authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+
+    assert!(
+        result.is_ok(),
+        "TransferChecked should be charged against the destination limit: {:?}",
+        result.err()
+    );
+
+    let recipient_final_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+    assert_eq!(recipient_final_balance, transfer_amount);
+
+    let swig_account = context.svm.get_account(&swig).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    let role = swig_state.get_role(1).unwrap().unwrap();
+    let combined_key = [mint_pubkey.to_bytes(), recipient_ata.to_bytes()].concat();
+    let dest_limit = role
+        .get_action::<TokenDestinationLimit>(&combined_key)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        dest_limit.amount,
+        destination_limit_amount - transfer_amount
+    );
+}
+
+/// An allowed parsed transfer must not mask an unparsed TransferChecked debit.
+#[test_log::test]
+fn test_token_destination_limit_rejects_transfer_checked_bypass_v2() {
+    let mut context = setup_test_context().unwrap();
+    let swig_authority = Keypair::new();
+    let allowed_recipient = Keypair::new();
+    let blocked_recipient = Keypair::new();
+
+    context
+        .svm
+        .airdrop(&allowed_recipient.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&blocked_recipient.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&swig_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let allowed_recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &allowed_recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+    let blocked_recipient_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &blocked_recipient.pubkey(),
+        &context.default_payer,
+    )
+    .unwrap();
+
+    mint_to(
+        &mut context.svm,
+        &mint_pubkey,
+        &context.default_payer,
+        &swig_ata,
+        1000,
+    )
+    .unwrap();
+
+    create_swig_ed25519(&mut context, &swig_authority, id).unwrap();
+
+    let second_authority = Keypair::new();
+    context
+        .svm
+        .airdrop(&second_authority.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &swig_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: second_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ProgramAll(ProgramAll {}),
+            ClientAction::TokenDestinationLimit(TokenDestinationLimit {
+                token_mint: mint_pubkey.to_bytes(),
+                destination: allowed_recipient_ata.to_bytes(),
+                amount: 1000,
+            }),
+        ],
+    )
+    .unwrap();
+
+    context
+        .svm
+        .airdrop(&swig_wallet_address, 2_000_000_000)
+        .unwrap();
+
+    let allowed_transfer_ix = spl_token::instruction::transfer(
+        &spl_token::ID,
+        &swig_ata,
+        &allowed_recipient_ata,
+        &swig_wallet_address,
+        &[],
+        100,
+    )
+    .unwrap();
+    let blocked_transfer_checked_ix = spl_token::instruction::transfer_checked(
+        &spl_token::ID,
+        &swig_ata,
+        &mint_pubkey,
+        &blocked_recipient_ata,
+        &swig_wallet_address,
+        &[],
+        200,
+        9,
+    )
+    .unwrap();
+
+    let initial_accounts = vec![
+        AccountMeta::new(swig, false),
+        AccountMeta::new(swig_wallet_address, false),
+        AccountMeta::new_readonly(second_authority.pubkey(), true),
+    ];
+    let (final_accounts, compact_ixs) = compact_instructions(
+        swig,
+        initial_accounts,
+        vec![allowed_transfer_ix, blocked_transfer_checked_ix],
+    );
+    let instruction_payload = compact_ixs.into_bytes();
+    let sign_args = SignV2Args::new(1, instruction_payload.len() as u16);
+    let mut sign_ix_data = Vec::new();
+    sign_ix_data.extend_from_slice(sign_args.into_bytes().unwrap());
+    sign_ix_data.extend_from_slice(&instruction_payload);
+    sign_ix_data.push(2);
+
+    let sign_ix = Instruction {
+        program_id: swig::ID.into(),
+        accounts: final_accounts,
+        data: sign_ix_data,
+    };
+
+    let allowed_initial_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&allowed_recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+    let blocked_initial_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&blocked_recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+
+    let message = v0::Message::try_compile(
+        &second_authority.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&second_authority]).unwrap();
+
+    let result = context.svm.send_transaction(tx);
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(
+                SwigAuthenticateError::PermissionDeniedMissingPermission as u32
+            ),
+        )
+    );
+
+    let allowed_final_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&allowed_recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+    let blocked_final_balance = u64::from_le_bytes(
+        context
+            .svm
+            .get_account(&blocked_recipient_ata)
+            .unwrap()
+            .data
+            .get(64..72)
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+
+    assert_eq!(allowed_final_balance, allowed_initial_balance);
+    assert_eq!(blocked_final_balance, blocked_initial_balance);
+}
+
 /// Test token destination limit exceeded with SignV2
 #[test_log::test]
 fn test_token_destination_limit_exceeds_limit_v2() {


### PR DESCRIPTION
## Summary
- recognize SPL Token and Token-2022 `TransferChecked` destination accounts in SignV2 token destination-limit parsing
- require parsed destination-limit debits to reconcile with actual source balance deltas for SOL and token spends
- add regression coverage for legitimate `TransferChecked` and the mixed-transfer bypass shape

## Verification
- `cargo +nightly fmt`
- `cargo build-sbf --arch v1`
- `cargo test -p swig --test token_destination_limit_v2`
- `cargo test -p swig --test sol_destination_limit_v2`
- `cargo +nightly clippy --all-targets` (passes with existing warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anagrambuild/codesmith/swig-wallet/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783708669&installation_id=138016541&pr_number=168&repository=anagrambuild%2Fswig-wallet&return_to=https%3A%2F%2Fgithub.com%2Fanagrambuild%2Fswig-wallet%2Fpull%2F168&signature=9ede0d851f4069b75196a51cc1a891d3d4e20140c0930ed8010c448ff58cd150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->