### PR TITLE
Harden SignV2 instruction parsing

### DIFF
--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -139,11 +139,14 @@ impl<'a> SignV2<'a> {
         if data.len() < SignV2Args::LEN {
             return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
         }
-        let (inst, rest) = unsafe { data.split_at_unchecked(SignV2Args::LEN) };
+        let (inst, rest) = data.split_at(SignV2Args::LEN);
         let args = unsafe { SignV2Args::load_unchecked(inst)? };
+        let instruction_payload_len = args.instruction_payload_len as usize;
+        if rest.len() < instruction_payload_len {
+            return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
+        }
 
-        let (instruction_payload, authority_payload) =
-            unsafe { rest.split_at_unchecked(args.instruction_payload_len as usize) };
+        let (instruction_payload, authority_payload) = rest.split_at(instruction_payload_len);
 
         Ok(Self {
             args,
@@ -962,4 +965,47 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sign_v2_data(role_id: u32, instruction_payload: &[u8], authority_payload: &[u8]) -> Vec<u8> {
+        let args = SignV2Args::new(role_id, instruction_payload.len() as u16);
+        let mut data = Vec::new();
+        data.extend_from_slice(args.into_bytes().unwrap());
+        data.extend_from_slice(instruction_payload);
+        data.extend_from_slice(authority_payload);
+        data
+    }
+
+    #[test]
+    fn from_instruction_bytes_splits_instruction_and_authority_payload() {
+        let instruction_payload = [1, 2, 3, 4];
+        let authority_payload = [9, 8, 7];
+        let data = sign_v2_data(7, &instruction_payload, &authority_payload);
+
+        let parsed = SignV2::from_instruction_bytes(&data).unwrap();
+
+        assert_eq!(parsed.args.role_id, 7);
+        assert_eq!(parsed.instruction_payload, &instruction_payload);
+        assert_eq!(parsed.authority_payload, &authority_payload);
+    }
+
+    #[test]
+    fn from_instruction_bytes_rejects_truncated_instruction_payload() {
+        let args = SignV2Args::new(7, 4);
+        let mut data = Vec::new();
+        data.extend_from_slice(args.into_bytes().unwrap());
+        data.extend_from_slice(&[1, 2, 3]);
+
+        let result = SignV2::from_instruction_bytes(&data);
+
+        assert!(matches!(
+            result,
+            Err(ProgramError::Custom(code))
+                if code == SwigError::InvalidSwigSignInstructionDataTooShort as u32
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- replace unchecked SignV2 header/instruction payload splits with checked slice splitting
- return `InvalidSwigSignInstructionDataTooShort` when the declared instruction payload length exceeds the remaining data
- add focused parser tests for valid splitting and truncated instruction payloads

## Notes
- This is the non-breaking split from #162. It intentionally does not change the secp256k1/r1 signature preimage or bind `role_id` yet.

## Tests
- `rustup run nightly rustfmt --edition 2021 program/src/actions/sign_v2.rs`
- `cargo test -p swig from_instruction_bytes --lib`
- `cargo +stable clippy -p swig --lib --tests`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anagrambuild/codesmith/swig-wallet/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783711677&installation_id=138016541&pr_number=169&repository=anagrambuild%2Fswig-wallet&return_to=https%3A%2F%2Fgithub.com%2Fanagrambuild%2Fswig-wallet%2Fpull%2F169&signature=00ec97cbb61115419ee135937e183543a32d50fdc15b33d7ab90485e9693298b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->