### PR TITLE
fix: propagate authority update size diff

### DIFF
--- a/program/src/actions/update_authority_v1.rs
+++ b/program/src/actions/update_authority_v1.rs
@@ -703,9 +703,8 @@ pub fn update_authority_v1(
     let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
     let _swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
 
-    let mut size_diff = 0;
     // Now perform the operation with the reallocated account
-    match operation {
+    let size_diff = match operation {
         AuthorityUpdateOperation::ReplaceAll => {
             let new_actions = update_authority_v1.get_actions_data()?;
             perform_replace_all_operation(
@@ -716,7 +715,7 @@ pub fn update_authority_v1(
                 current_actions_size,
                 new_actions,
                 update_authority_v1.args.authority_to_update_id,
-            )?;
+            )?
         },
         AuthorityUpdateOperation::AddActions => {
             let new_actions = update_authority_v1.get_actions_data()?;
@@ -728,11 +727,11 @@ pub fn update_authority_v1(
                 current_actions_size,
                 new_actions,
                 update_authority_v1.args.authority_to_update_id,
-            )?;
+            )?
         },
         AuthorityUpdateOperation::RemoveActionsByType => {
             let remove_types = update_authority_v1.get_remove_types()?;
-            size_diff = perform_remove_by_type_operation(
+            perform_remove_by_type_operation(
                 swig_roles,
                 swig_data_len,
                 authority_offset,
@@ -740,11 +739,11 @@ pub fn update_authority_v1(
                 current_actions_size,
                 remove_types,
                 update_authority_v1.args.authority_to_update_id,
-            )?;
+            )?
         },
         AuthorityUpdateOperation::RemoveActionsByIndex => {
             let remove_indices = update_authority_v1.get_remove_indices()?;
-            size_diff = perform_remove_by_index_operation(
+            perform_remove_by_index_operation(
                 swig_roles,
                 swig_data_len,
                 authority_offset,
@@ -752,9 +751,9 @@ pub fn update_authority_v1(
                 current_actions_size,
                 &remove_indices,
                 update_authority_v1.args.authority_to_update_id,
-            )?;
+            )?
         },
-    }
+    };
 
     if size_diff < 0 {
         let new_size = (swig_data_len as i64 + size_diff) as usize;


### PR DESCRIPTION
## Summary
- propagate the size diff returned by authority update operations
- allow shrink operations to reach the existing resize and rent refund path

## Validation
- cargo fmt --all
- cargo test -p swig from_instruction_bytes_rejects_short_actions_payload

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anagrambuild/codesmith/swig-wallet/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784232708&installation_id=138016541&pr_number=172&repository=anagrambuild%2Fswig-wallet&return_to=https%3A%2F%2Fgithub.com%2Fanagrambuild%2Fswig-wallet%2Fpull%2F172&signature=288e6e384ed74b7481126b8c818c9c93222176d192c2f9ba2b6f69139dd5ced5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->