### PR TITLE
fix: bound authority update size diff scan

### DIFF
--- a/program/src/actions/update_authority_v1.rs
+++ b/program/src/actions/update_authority_v1.rs
@@ -310,7 +310,15 @@ fn perform_replace_all_operation(
 
         // Update boundaries of all roles after this one
         let mut cursor = 0;
-        while cursor < (swig_roles.len() + size_diff as usize) {
+        let updated_data_len = (original_data_len as i64)
+            .checked_add(size_diff)
+            .ok_or(SwigError::StateError)?;
+        if updated_data_len < 0 || updated_data_len as usize > swig_roles.len() {
+            return Err(SwigError::StateError.into());
+        }
+        let updated_data_len = updated_data_len as usize;
+
+        while cursor < updated_data_len {
             if cursor + Position::LEN > swig_roles.len() {
                 break;
             }


### PR DESCRIPTION
## Summary
- compute the updated role data length with checked signed arithmetic
- avoid casting negative size diffs to usize in the boundary update scan

## Validation
- cargo fmt --all
- cargo test -p swig from_instruction_bytes_rejects_short_actions_payload

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anagrambuild/codesmith/swig-wallet/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784232780&installation_id=138016541&pr_number=173&repository=anagrambuild%2Fswig-wallet&return_to=https%3A%2F%2Fgithub.com%2Fanagrambuild%2Fswig-wallet%2Fpull%2F173&signature=14be39cdc779f92e9b719303ee5e2bcadc7260bb3ee0216f222db8a3312aebff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->