### PR TITLE
state: split rent-claimer tail changes

### DIFF
--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -10,6 +10,7 @@ pub mod authority;
 pub mod constants;
 pub mod role;
 pub mod swig;
+pub mod tail;
 pub mod transmute;
 pub mod util;
 pub use transmute::{IntoBytes, Transmutable, TransmutableMut};
@@ -107,6 +108,9 @@ pub enum SwigStateError {
     PermissionLoadError,
     /// Adding an authority requires at least one action
     InvalidAuthorityMustHaveAtLeastOneAction,
+    /// Trailing region after the roles is neither empty nor a well-formed
+    /// rent-claimer tail entry.
+    InvalidRentClaimerLayout,
 }
 
 /// Error types related to authentication operations.

--- a/state/src/swig.rs
+++ b/state/src/swig.rs
@@ -427,6 +427,20 @@ pub struct Swig {
     pub _padding: [u8; 7],
 }
 
+/// Immutable split view of a Swig account buffer.
+pub struct SwigParts<'a> {
+    pub state: &'a Swig,
+    pub roles: &'a [u8],
+    pub tail: &'a [u8],
+}
+
+/// Mutable split view of a Swig account buffer.
+pub struct SwigPartsMut<'a> {
+    pub state: &'a mut Swig,
+    pub roles: &'a mut [u8],
+    pub tail: &'a mut [u8],
+}
+
 impl Swig {
     /// Creates a new Swig account.
     pub fn new(id: [u8; 32], bump: u8, wallet_bump: u8) -> Self {
@@ -441,15 +455,81 @@ impl Swig {
         }
     }
 
+    /// Returns the absolute end offset of the roles region in the full account buffer.
+    ///
+    /// Layout:
+    /// `[Swig::LEN header][roles bytes][optional tail bytes]`
+    pub fn roles_end_offset(account_data: &[u8]) -> Result<usize, ProgramError> {
+        if account_data.len() < Swig::LEN {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let state = unsafe { Swig::load_unchecked(&account_data[..Swig::LEN])? };
+        let roles_and_tail = &account_data[Swig::LEN..];
+        let mut cursor = 0usize;
+
+        for _ in 0..state.roles {
+            if cursor + Position::LEN > roles_and_tail.len() {
+                return Err(ProgramError::InvalidAccountData);
+            }
+
+            let position = unsafe {
+                Position::load_unchecked(&roles_and_tail[cursor..cursor + Position::LEN])?
+            };
+            let boundary = position.boundary() as usize;
+            if boundary < cursor + Position::LEN || boundary > roles_and_tail.len() {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            cursor = boundary;
+        }
+
+        Ok(Swig::LEN + cursor)
+    }
+
+    /// Splits a full account buffer into `[roles, tail]` slices.
+    pub fn split_roles_and_tail<'a>(
+        account_data: &'a [u8],
+    ) -> Result<(&'a [u8], &'a [u8]), ProgramError> {
+        let parts = Self::split_parts(account_data)?;
+        Ok((parts.roles, parts.tail))
+    }
+
+    /// Mutable variant of [`Self::split_roles_and_tail`].
+    pub fn split_roles_and_tail_mut<'a>(
+        account_data: &'a mut [u8],
+    ) -> Result<(&'a mut [u8], &'a mut [u8]), ProgramError> {
+        let parts = Self::split_parts_mut(account_data)?;
+        Ok((parts.roles, parts.tail))
+    }
+
+    /// Splits a full account buffer into typed header state + roles + tail.
+    pub fn split_parts<'a>(account_data: &'a [u8]) -> Result<SwigParts<'a>, ProgramError> {
+        let roles_end = Self::roles_end_offset(account_data)?;
+        let state = unsafe { Swig::load_unchecked(&account_data[..Swig::LEN])? };
+        let roles = &account_data[Swig::LEN..roles_end];
+        let tail = &account_data[roles_end..];
+        Ok(SwigParts { state, roles, tail })
+    }
+
+    /// Mutable variant of [`Self::split_parts`].
+    pub fn split_parts_mut<'a>(account_data: &'a mut [u8]) -> Result<SwigPartsMut<'a>, ProgramError> {
+        let roles_end = Self::roles_end_offset(account_data)?;
+        let roles_len = roles_end - Swig::LEN;
+        let (swig_header, roles_and_tail) = account_data.split_at_mut(Swig::LEN);
+        let (roles, tail) = roles_and_tail.split_at_mut(roles_len);
+        let state = unsafe { Swig::load_mut_unchecked(swig_header)? };
+        Ok(SwigPartsMut { state, roles, tail })
+    }
+
     /// Gets a mutable reference to a role by ID.
     pub fn get_mut_role(id: u32, roles: &mut [u8]) -> Result<Option<RoleMut<'_>>, ProgramError> {
         let mut cursor = 0;
         let mut found_offset = None;
         let roles_len = roles.len();
-        if roles_len < Swig::LEN {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        for _i in 0..roles_len {
+        while cursor < roles_len {
+            if cursor + Position::LEN > roles_len {
+                return Err(ProgramError::InvalidAccountData);
+            }
             let offset = cursor + Position::LEN;
             let position =
                 unsafe { Position::load_unchecked(roles.get_unchecked(cursor..offset))? };
@@ -457,7 +537,11 @@ impl Swig {
                 found_offset = Some(cursor);
                 break;
             }
-            cursor = position.boundary() as usize;
+            let boundary = position.boundary() as usize;
+            if boundary < offset || boundary > roles_len {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            cursor = boundary;
         }
         if let Some(offset) = found_offset {
             let (position, remaning) =
@@ -539,8 +623,9 @@ impl<'a> SwigWithRoles<'a> {
             return Err(ProgramError::InvalidAccountData);
         }
 
+        let roles_end = Swig::roles_end_offset(bytes)?;
         let state = unsafe { Swig::load_unchecked(&bytes[..Swig::LEN])? };
-        let roles = &bytes[Swig::LEN..];
+        let roles = &bytes[Swig::LEN..roles_end];
 
         Ok(SwigWithRoles { state, roles })
     }
@@ -746,6 +831,7 @@ mod tests {
     use crate::{
         action::{all::All, manage_authority::ManageAuthority, sol_limit::SolLimit, Actionable},
         authority::ed25519::ED25519Authority,
+        tail::{rent_claimer, SavedTail},
         Transmutable,
     };
 
@@ -2009,6 +2095,182 @@ mod tests {
             "Second role should not exist after removal"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_role_with_tail_preserves_tail_bytes() -> Result<(), ProgramError> {
+        let (mut account_buffer, id, bump) = setup_precise_test_buffer(2, Action::LEN + 8);
+        let swig = Swig::new(id, bump, 0);
+        let mut builder = SwigBuilder::create(&mut account_buffer, swig)?;
+
+        let authority1 = ED25519Authority {
+            public_key: [8; 32],
+        };
+        let action_data = All {}.into_bytes()?;
+        let action = Action::new(
+            All::TYPE,
+            action_data.len() as u16,
+            Action::LEN as u32 + action_data.len() as u32,
+        );
+        let actions_data = [action.into_bytes()?, action_data].concat();
+        builder.add_role(AuthorityType::Ed25519, authority1.into_bytes()?, &actions_data)?;
+        drop(builder);
+
+        let roles_end = Swig::roles_end_offset(&account_buffer)?;
+        account_buffer.truncate(roles_end);
+        let tail = rent_claimer::entry(&[42u8; 32]);
+        account_buffer.extend_from_slice(&tail);
+        let expected_tail = tail.to_vec();
+
+        let saved_tail = {
+            let (_, tail_slice) = Swig::split_roles_and_tail_mut(&mut account_buffer)?;
+            SavedTail::take(tail_slice)?
+        };
+
+        let role_size = Position::LEN + ED25519Authority::LEN + actions_data.len();
+        let old_len = account_buffer.len();
+        let new_len = old_len + role_size;
+        account_buffer.resize(new_len, 0);
+        saved_tail.restore(&mut account_buffer)?;
+
+        {
+            let (swig_header, roles_and_tail) = account_buffer.split_at_mut(Swig::LEN);
+            let roles_capacity_len = roles_and_tail.len() - saved_tail.len();
+            let (roles_capacity, _) = roles_and_tail.split_at_mut(roles_capacity_len);
+            let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+            let mut builder = SwigBuilder {
+                role_buffer: roles_capacity,
+                swig,
+            };
+            let authority2 = ED25519Authority {
+                public_key: [9; 32],
+            };
+            builder.add_role(AuthorityType::Ed25519, authority2.into_bytes()?, &actions_data)?;
+        }
+        saved_tail.restore(&mut account_buffer)?;
+
+        let (_, tail_after) = Swig::split_roles_and_tail(&account_buffer)?;
+        assert_eq!(tail_after, expected_tail.as_slice());
+        assert_eq!(SwigWithRoles::from_bytes(&account_buffer)?.state.roles, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_tail_restore_at_roles_end_with_alignment_padding_gap() -> Result<(), ProgramError> {
+        // Build a swig account with one role whose boundary is intentionally
+        // non-8-aligned to simulate future non-8-aligned role layouts.
+        let mut account_buffer = vec![0u8; Swig::LEN + 128];
+        let mut swig = Swig::new([3u8; 32], 255, 0);
+        swig.roles = 1;
+        swig.role_counter = 1;
+        account_buffer[..Swig::LEN].copy_from_slice(swig.into_bytes()?);
+
+        let role_boundary = Position::LEN + 9;
+        {
+            let position = unsafe {
+                Position::load_mut_unchecked(
+                    &mut account_buffer[Swig::LEN..Swig::LEN + Position::LEN],
+                )?
+            };
+            position.authority_type = AuthorityType::Ed25519 as u16;
+            position.authority_length = 1;
+            position.num_actions = 1;
+            position.boundary = role_boundary as u32;
+            position.id = 0;
+        }
+
+        let roles_end = Swig::roles_end_offset(&account_buffer)?;
+        account_buffer.truncate(roles_end);
+        let claimer = [66u8; 32];
+        let tail = rent_claimer::entry(&claimer);
+        account_buffer.extend_from_slice(&tail);
+
+        let saved_tail = {
+            let (_, tail_slice) = Swig::split_roles_and_tail_mut(&mut account_buffer)?;
+            SavedTail::take(tail_slice)?
+        };
+
+        // Simulate a growth realloc that rounds up to alignment and leaves stale bytes.
+        let grown_size = account_buffer
+            .len()
+            .checked_add(3)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        let padded_size = core::alloc::Layout::from_size_align(grown_size, core::mem::size_of::<u64>())
+            .map_err(|_| ProgramError::InvalidAccountData)?
+            .pad_to_align()
+            .size();
+        account_buffer.resize(padded_size, 0xAB);
+
+        // New handler flow: zero from roles_end onward, then restore tail flush at roles_end.
+        let roles_end = Swig::roles_end_offset(&account_buffer)?;
+        account_buffer[roles_end..].fill(0);
+        saved_tail.restore_at(&mut account_buffer, roles_end)?;
+
+        let parts = Swig::split_parts(&account_buffer)?;
+        let parsed = rent_claimer::read_strict(parts.tail)?;
+        assert_eq!(parsed, Some(&claimer));
+        assert!(roles_end + rent_claimer::ENTRY_LEN <= account_buffer.len());
+        assert!(parts.tail[rent_claimer::ENTRY_LEN..]
+            .iter()
+            .all(|byte| *byte == 0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_remove_role_with_tail_preserves_tail_bytes() -> Result<(), ProgramError> {
+        let (mut account_buffer, id, bump) = setup_precise_test_buffer(3, Action::LEN + 8);
+        let swig = Swig::new(id, bump, 0);
+        let mut builder = SwigBuilder::create(&mut account_buffer, swig)?;
+
+        let action_data = All {}.into_bytes()?;
+        let action = Action::new(
+            All::TYPE,
+            action_data.len() as u16,
+            Action::LEN as u32 + action_data.len() as u32,
+        );
+        let actions_data = [action.into_bytes()?, action_data].concat();
+        let authority1 = ED25519Authority {
+            public_key: [10; 32],
+        };
+        let authority2 = ED25519Authority {
+            public_key: [11; 32],
+        };
+        builder.add_role(AuthorityType::Ed25519, authority1.into_bytes()?, &actions_data)?;
+        builder.add_role(AuthorityType::Ed25519, authority2.into_bytes()?, &actions_data)?;
+        drop(builder);
+
+        let roles_end = Swig::roles_end_offset(&account_buffer)?;
+        account_buffer.truncate(roles_end);
+        let tail = rent_claimer::entry(&[24u8; 32]);
+        account_buffer.extend_from_slice(&tail);
+        let expected_tail = tail.to_vec();
+
+        let saved_tail = {
+            let (_, tail_slice) = Swig::split_roles_and_tail_mut(&mut account_buffer)?;
+            SavedTail::take(tail_slice)?
+        };
+
+        let removed = {
+            let (swig_header, roles_and_tail) = account_buffer.split_at_mut(Swig::LEN);
+            let roles_len = roles_and_tail.len() - saved_tail.len();
+            let (roles, _) = roles_and_tail.split_at_mut(roles_len);
+            let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+            let mut builder = SwigBuilder {
+                role_buffer: roles,
+                swig,
+            };
+            builder.remove_role(1)?
+        };
+
+        let old_len = account_buffer.len();
+        let new_len = old_len - removed.1;
+        account_buffer.resize(new_len, 0);
+        saved_tail.restore(&mut account_buffer)?;
+
+        let (_, tail_after) = Swig::split_roles_and_tail(&account_buffer)?;
+        assert_eq!(tail_after, expected_tail.as_slice());
+        assert_eq!(SwigWithRoles::from_bytes(&account_buffer)?.state.roles, 1);
         Ok(())
     }
 }

--- a/state/src/tail/mod.rs
+++ b/state/src/tail/mod.rs
@@ -244,12 +244,27 @@ impl SavedTail {
         self.len == 0
     }
 
-    /// Writes the saved tail back at the very end of the (already-resized) account buffer.
-    pub fn restore(&self, account_data: &mut [u8]) {
+    /// Writes the saved tail at `offset`.
+    pub fn restore_at(&self, account_data: &mut [u8], offset: usize) -> Result<(), ProgramError> {
         if self.len == 0 {
-            return;    // no-op when there was no tail
+            return Ok(());    // no-op when there was no tail
         }
-        let end = account_data.len();
-        account_data[end - self.len..end].copy_from_slice(&self.bytes[..self.len]); // write the tail back
+        let end = offset
+            .checked_add(self.len)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        if end > account_data.len() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        account_data[offset..end].copy_from_slice(&self.bytes[..self.len]); // write the tail back
+        Ok(())
+    }
+
+    /// Writes the saved tail back at the very end of the (already-resized) account buffer.
+    pub fn restore(&self, account_data: &mut [u8]) -> Result<(), ProgramError> {
+        let offset = account_data
+            .len()
+            .checked_sub(self.len)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        self.restore_at(account_data, offset)
     }
 }

--- a/state/src/tail/mod.rs
+++ b/state/src/tail/mod.rs
@@ -1,0 +1,255 @@
+//! Swig account "tail": optional, discriminated data appended after the roles.
+//!
+//! Layout of a swig account:
+//!
+//! ```text
+//! [ Swig header (48 B) ][ roles_data (N B) ][ optional tail ]
+//! ```
+//!
+//! The tail is detected purely by account length (see
+//! [`crate::swig::Swig::roles_end_offset`]); no header field is used, so wallets
+//! that never opt in are byte-for-byte unchanged.
+//!
+//! Each tail entry is a length-prefixed, versioned, **typed** TLV record:
+//!
+//! ```text
+//! offset 0: kind       u8      kind of data (see TailKind)
+//! offset 1: version    u8
+//! offset 2: value_len  u16     length of `value`
+//! offset 4: reserved   u8;4    zero
+//! offset 8: value      [u8; value_len]
+//! ```
+//!
+//! The 8-byte typed header is what makes the tail extensible: a new tail feature
+//! (e.g. an auth lock) gets its own [`TailKind`] and a sibling module here, with
+//! no changes to `swig.rs`. v1 ships a single tail type — [`rent_claimer`].
+
+pub mod rent_claimer;
+
+use core::convert::TryInto;
+use pinocchio::program_error::ProgramError;
+use crate::SwigStateError;
+
+/// Length of every tail entry header: `[kind][version][value_len:u16][reserved:u8;4]`.
+pub const TAIL_HEADER_LEN: usize = 8;
+
+/// Structured view of the 8-byte header common to each tail entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TailHeader {
+    pub kind: u8,
+    pub version: u8,
+    pub value_len: u16,
+    pub payload: [u8; 4],
+}
+
+impl TailHeader {
+    /// Parses a header from the beginning of `bytes`.
+    pub fn parse(bytes: &[u8]) -> Result<Self, TailReadError> {
+        if bytes.len() < TAIL_HEADER_LEN {
+            return Err(TailReadError::TooShort);
+        }
+
+        let value_len_bytes: [u8; 2] = bytes[2..4]
+            .try_into()
+            .map_err(|_| TailReadError::TooShort)?;
+        let payload: [u8; 4] = bytes[4..8]
+            .try_into()
+            .map_err(|_| TailReadError::TooShort)?;
+
+        Ok(Self {
+            kind: bytes[0],
+            version: bytes[1],
+            value_len: u16::from_le_bytes(value_len_bytes),
+            payload,
+        })
+    }
+
+    /// Total bytes consumed by this entry: header + value bytes.
+    pub fn total_len(&self) -> Result<usize, TailReadError> {
+        TAIL_HEADER_LEN
+            .checked_add(self.value_len as usize)
+            .ok_or(TailReadError::LengthOverflow)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TailReadError {
+    TooShort,
+    UnknownKind(u8),
+    LengthOverflow,
+    InvalidKind { expected: u8, found: u8 },
+    InvalidValueLen { expected: usize, found: usize },
+}
+
+impl From<TailReadError> for ProgramError {
+    fn from(_: TailReadError) -> Self {
+        SwigStateError::InvalidRentClaimerLayout.into()
+    }
+}
+
+/// Shared parsing behavior for concrete typed tail descriptors.
+pub trait TailDescriptor<'a>: Sized {
+    const KIND: TailKind;
+
+    /// Build a concrete typed entry from a parsed header and its value bytes.
+    fn from_parts(header: TailHeader, value: &'a [u8]) -> Result<Self, TailReadError>;
+
+    /// Reads a descriptor that starts at `buf[0]`.
+    fn read(buf: &'a [u8]) -> Result<(Self, usize), TailReadError> {
+        let header = TailHeader::parse(buf)?;
+        let found = header.kind;
+        let expected = Self::KIND as u8;
+        if found != expected {
+            return Err(TailReadError::InvalidKind { expected, found });
+        }
+
+        let end = header.total_len()?;
+        if buf.len() < end {
+            return Err(TailReadError::TooShort);
+        }
+        let value = &buf[TAIL_HEADER_LEN..end];
+
+        Ok((Self::from_parts(header, value)?, end))
+    }
+}
+
+/// A raw tail entry for kinds not yet modeled in code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownTailEntry<'a> {
+    pub header: TailHeader,
+    pub value: &'a [u8],
+}
+
+/// A parsed tail entry, dispatching to known concrete types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnyTailEntry<'a> {
+    RentClaimer(rent_claimer::RentClaimerEntry<'a>),
+    Unknown(UnknownTailEntry<'a>),
+}
+
+impl<'a> AnyTailEntry<'a> {
+    /// Reads the first entry from `buf`.
+    pub fn read(buf: &'a [u8]) -> Result<(Self, usize), TailReadError> {
+        let header = TailHeader::parse(buf)?;
+        match TailKind::from_u8(header.kind) {
+            Some(TailKind::RentClaimer) => {
+                let (entry, consumed) = rent_claimer::RentClaimerEntry::read(buf)?;
+                Ok((Self::RentClaimer(entry), consumed))
+            }
+            None => {
+                let end = header.total_len()?;
+                if buf.len() < end {
+                    return Err(TailReadError::TooShort);
+                }
+                Ok((
+                    Self::Unknown(UnknownTailEntry {
+                        header,
+                        value: &buf[TAIL_HEADER_LEN..end],
+                    }),
+                    end,
+                ))
+            }
+        }
+    }
+
+    /// Parses every contiguous tail entry in `buf`.
+    pub fn read_all(mut buf: &'a [u8]) -> Result<Vec<Self>, TailReadError> {
+        let mut entries = Vec::new();
+        while !buf.is_empty() {
+            let (entry, consumed) = Self::read(buf)?;
+            entries.push(entry);
+            buf = &buf[consumed..];
+        }
+        Ok(entries)
+    }
+}
+
+/// Scans a heterogenous tail buffer and returns the first entry of descriptor type `T`.
+pub fn read_first_of<'a, T: TailDescriptor<'a>>(
+    mut buf: &'a [u8],
+) -> Result<Option<T>, TailReadError> {
+    while !buf.is_empty() {
+        let header = TailHeader::parse(buf)?;
+        // Skip by full entry size: header bytes + value bytes.
+        let entry_len = header.total_len()?;
+        if buf.len() < entry_len {
+            return Err(TailReadError::TooShort);
+        }
+
+        if header.kind == T::KIND.as_u8() {
+            let (typed, _) = T::read(buf)?;
+            return Ok(Some(typed));
+        }
+
+        buf = &buf[entry_len..];
+    }
+    Ok(None)
+}
+
+
+
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TailKind {
+    /// A single immutable rent-claimer pubkey ([`rent_claimer`]).
+    RentClaimer = 1,
+}
+
+
+
+impl TailKind {
+    /// Parses a kind byte, or `None` for an unknown kind.
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            x if x == TailKind::RentClaimer as u8 => Some(TailKind::RentClaimer),
+            _ => None,
+        }
+    }
+
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+/// The largest tail any current tail type can produce. Used to allocate a scratch buffer for realloc handlers.
+pub const MAX_TAIL_LEN: usize = rent_claimer::ENTRY_LEN;
+
+/// A stack copy of the account tail, captured before a roles realloc so it can
+/// be restored afterwards. Used to store the tail before and after a roles realloc.
+pub struct SavedTail {
+    bytes: [u8; MAX_TAIL_LEN],
+    len: usize,     // actual length of the tail
+}
+
+impl SavedTail {
+    /// Copies the tail (the bytes after `roles_end`) onto the stack.
+    pub fn take(tail_data: &[u8]) -> Result<Self, ProgramError> {
+        let len = tail_data.len();
+        if len > MAX_TAIL_LEN {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let mut bytes = [0u8; MAX_TAIL_LEN];
+        bytes[..len].copy_from_slice(tail_data);
+        Ok(Self { bytes, len })
+    }
+
+    /// Length of the captured tail (`0` when the wallet has no tail).
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether no tail was captured.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Writes the saved tail back at the very end of the (already-resized) account buffer.
+    pub fn restore(&self, account_data: &mut [u8]) {
+        if self.len == 0 {
+            return;    // no-op when there was no tail
+        }
+        let end = account_data.len();
+        account_data[end - self.len..end].copy_from_slice(&self.bytes[..self.len]); // write the tail back
+    }
+}

--- a/state/src/tail/rent_claimer.rs
+++ b/state/src/tail/rent_claimer.rs
@@ -7,6 +7,7 @@ use pinocchio::program_error::ProgramError;
 
 use crate::{
     tail::{read_first_of, TailDescriptor, TailHeader, TailKind, TailReadError, TAIL_HEADER_LEN},
+    SwigStateError,
 };
 
 pub const VERSION: u8 = 1;
@@ -44,6 +45,39 @@ impl<'a> TailDescriptor<'a> for RentClaimerEntry<'a> {
 /// Reads through the tail data of different tail types until it finds a rent-claimer tail entry.
 pub fn read(tail_data: &[u8]) -> Result<Option<&[u8; 32]>, ProgramError> {
     Ok(read_first_of::<RentClaimerEntry<'_>>(tail_data)?.map(|entry| entry.claimer))
+}
+
+/// Strict parser for the swig trailing region.
+///
+/// Accepted layouts:
+/// - empty tail (unset): `[]`
+/// - all-zero tail bytes (unset)
+/// - one rent-claimer entry (`ENTRY_LEN` bytes), optionally followed by zero padding
+///
+/// Any other shape or malformed header is rejected.
+pub fn read_strict(tail_data: &[u8]) -> Result<Option<&[u8; 32]>, ProgramError> {
+    if tail_data.is_empty() || tail_data.iter().all(|byte| *byte == 0) {
+        return Ok(None);
+    }
+    if tail_data.len() < ENTRY_LEN {
+        return Err(SwigStateError::InvalidRentClaimerLayout.into());
+    }
+
+    let (entry, consumed) = RentClaimerEntry::read(&tail_data[..ENTRY_LEN])?;
+    if consumed != ENTRY_LEN {
+        return Err(SwigStateError::InvalidRentClaimerLayout.into());
+    }
+    if entry.header.version != VERSION {
+        return Err(SwigStateError::InvalidRentClaimerLayout.into());
+    }
+    if entry.header.payload != [0u8; 4] {
+        return Err(SwigStateError::InvalidRentClaimerLayout.into());
+    }
+    if tail_data[ENTRY_LEN..].iter().any(|byte| *byte != 0) {
+        return Err(SwigStateError::InvalidRentClaimerLayout.into());
+    }
+
+    Ok(Some(entry.claimer))
 }
 
 /// Serializes a rent-claimer tail entry ready to append to the account buffer.
@@ -97,12 +131,21 @@ mod tests {
     }
 
     #[test]
+    fn read_strict_returns_none_for_empty_tail() {
+        let parsed = read_strict(&[]).expect("empty buffer should parse");
+        assert!(parsed.is_none());
+    }
+
+    #[test]
     fn read_returns_claimer_for_single_rent_entry() {
         let claimer = [11u8; VALUE_LEN];
         let tail = entry(&claimer);
 
         let parsed = read(&tail).expect("rent entry should parse");
         assert_eq!(parsed, Some(&claimer));
+
+        let strict = read_strict(&tail).expect("strict read should parse");
+        assert_eq!(strict, Some(&claimer));
     }
 
     #[test]
@@ -130,6 +173,46 @@ mod tests {
     }
 
     #[test]
+    fn read_strict_rejects_newer_rent_version() {
+        let claimer = [33u8; VALUE_LEN];
+        let mut tail = entry(&claimer);
+        tail[1] = VERSION + 1;
+
+        let err = read_strict(&tail).expect_err("strict parser rejects unknown version");
+        assert_eq!(
+            err,
+            ProgramError::Custom(SwigStateError::InvalidRentClaimerLayout as u32)
+        );
+    }
+
+    #[test]
+    fn read_strict_rejects_non_zero_reserved_bytes() {
+        let claimer = [88u8; VALUE_LEN];
+        let mut tail = entry(&claimer);
+        tail[4] = 1;
+
+        let err = read_strict(&tail).expect_err("strict parser rejects non-zero reserved bytes");
+        assert_eq!(
+            err,
+            ProgramError::Custom(SwigStateError::InvalidRentClaimerLayout as u32)
+        );
+    }
+
+    #[test]
+    fn read_strict_rejects_tail_len_other_than_empty_or_single_entry() {
+        let claimer = [99u8; VALUE_LEN];
+        let mut tail = Vec::new();
+        tail.extend_from_slice(&entry(&claimer));
+        tail.extend_from_slice(&entry(&claimer));
+
+        let err = read_strict(&tail).expect_err("strict parser rejects extra entries");
+        assert_eq!(
+            err,
+            ProgramError::Custom(SwigStateError::InvalidRentClaimerLayout as u32)
+        );
+    }
+
+    #[test]
     fn read_errors_on_truncated_rent_value() {
         let mut tail = entry(&[44u8; VALUE_LEN]).to_vec();
         tail.pop();
@@ -139,6 +222,88 @@ mod tests {
             err,
             ProgramError::Custom(SwigStateError::InvalidRentClaimerLayout as u32)
         );
+    }
+
+    fn assert_invalid_layout(tail: &[u8]) {
+        let err = read_strict(tail).expect_err("strict parser must reject malformed tail");
+        assert_eq!(
+            err,
+            ProgramError::Custom(SwigStateError::InvalidRentClaimerLayout as u32)
+        );
+    }
+
+    #[test]
+    fn read_strict_rejects_wrong_kind_byte() {
+        // Correct overall length (ENTRY_LEN) but the kind byte is not RentClaimer.
+        let claimer = [5u8; VALUE_LEN];
+        let mut tail = entry(&claimer);
+        tail[0] = TailKind::RentClaimer.as_u8() + 1;
+        assert_invalid_layout(&tail);
+    }
+
+    #[test]
+    fn read_strict_rejects_zero_kind_byte() {
+        let claimer = [6u8; VALUE_LEN];
+        let mut tail = entry(&claimer);
+        tail[0] = 0;
+        assert_invalid_layout(&tail);
+    }
+
+    #[test]
+    fn read_strict_rejects_inconsistent_value_len_field() {
+        // Buffer is ENTRY_LEN long, but the header claims a value_len other than 32.
+        for bad_value_len in [0u16, 1, 16, 31, 33, 64, u16::MAX] {
+            let claimer = [9u8; VALUE_LEN];
+            let mut tail = entry(&claimer);
+            tail[2..4].copy_from_slice(&bad_value_len.to_le_bytes());
+            assert_invalid_layout(&tail);
+        }
+    }
+
+    #[test]
+    fn read_strict_accepts_entry_with_trailing_zero_padding() {
+        let claimer = [101u8; VALUE_LEN];
+        for pad in 1usize..=7 {
+            let mut tail = entry(&claimer).to_vec();
+            tail.extend_from_slice(&vec![0u8; pad]);
+            let parsed = read_strict(&tail).expect("entry + zero padding should parse");
+            assert_eq!(parsed, Some(&claimer));
+        }
+    }
+
+    #[test]
+    fn read_strict_accepts_non_empty_all_zero_tail_as_unset() {
+        for len in [1usize, 7, 8, 16, 32, 39, 41, 48, 72, 80, 120] {
+            let tail = vec![0u8; len];
+            let parsed = read_strict(&tail).expect("all-zero tail should parse as unset");
+            assert_eq!(parsed, None);
+        }
+    }
+
+    #[test]
+    fn read_strict_rejects_entry_with_non_zero_trailing_bytes() {
+        let claimer = [102u8; VALUE_LEN];
+        let mut tail = entry(&claimer).to_vec();
+        tail.extend_from_slice(&[0, 0, 7, 0]);
+        assert_invalid_layout(&tail);
+    }
+
+    #[test]
+    fn read_strict_rejects_each_individually_nonzero_reserved_byte() {
+        for reserved_index in 4..TAIL_HEADER_LEN {
+            let claimer = [12u8; VALUE_LEN];
+            let mut tail = entry(&claimer);
+            tail[reserved_index] = 1;
+            assert_invalid_layout(&tail);
+        }
+    }
+
+    #[test]
+    fn read_strict_accepts_exactly_one_well_formed_entry() {
+        let claimer = [200u8; VALUE_LEN];
+        let tail = entry(&claimer);
+        let parsed = read_strict(&tail).expect("well-formed single entry must parse");
+        assert_eq!(parsed, Some(&claimer));
     }
 
     #[test]

--- a/state/src/tail/rent_claimer.rs
+++ b/state/src/tail/rent_claimer.rs
@@ -1,0 +1,187 @@
+//! Rent-claimer tail entry: a single immutable pubkey that close instructions
+//! must route rent to. See [`crate::tail`] for the tail framework.
+
+use core::convert::TryInto;
+
+use pinocchio::program_error::ProgramError;
+
+use crate::{
+    tail::{read_first_of, TailDescriptor, TailHeader, TailKind, TailReadError, TAIL_HEADER_LEN},
+};
+
+pub const VERSION: u8 = 1;
+pub const VALUE_LEN: usize = 32;
+pub const ENTRY_LEN: usize = TAIL_HEADER_LEN + VALUE_LEN;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RentClaimerEntry<'a> {
+    pub header: TailHeader,
+    pub claimer: &'a [u8; VALUE_LEN],
+}
+
+impl<'a> TailDescriptor<'a> for RentClaimerEntry<'a> {
+    const KIND: TailKind = TailKind::RentClaimer;
+
+    fn from_parts(header: TailHeader, value: &'a [u8]) -> Result<Self, TailReadError> {
+        if value.len() != VALUE_LEN {
+            return Err(TailReadError::InvalidValueLen {
+                expected: VALUE_LEN,
+                found: value.len(),
+            });
+        }
+
+        let claimer: &[u8; VALUE_LEN] = value
+            .try_into()
+            .map_err(|_| TailReadError::InvalidValueLen {
+                expected: VALUE_LEN,
+                found: value.len(),
+            })?;
+        Ok(Self { header, claimer })
+    }
+}
+
+
+/// Reads through the tail data of different tail types until it finds a rent-claimer tail entry.
+pub fn read(tail_data: &[u8]) -> Result<Option<&[u8; 32]>, ProgramError> {
+    Ok(read_first_of::<RentClaimerEntry<'_>>(tail_data)?.map(|entry| entry.claimer))
+}
+
+/// Serializes a rent-claimer tail entry ready to append to the account buffer.
+/// The single source of truth for the on-chain byte layout.
+pub fn entry(claimer: &[u8; 32]) -> [u8; ENTRY_LEN] {
+    let mut buf = [0u8; ENTRY_LEN];
+    buf[0] = TailKind::RentClaimer.as_u8();
+    buf[1] = VERSION;
+    buf[2..4].copy_from_slice(&(VALUE_LEN as u16).to_le_bytes());
+    // bytes [4..8] reserved, left zero.
+    buf[TAIL_HEADER_LEN..].copy_from_slice(claimer);
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use pinocchio::program_error::ProgramError;
+
+    use super::*;
+    use crate::{tail::read_first_of, SwigStateError};
+
+    fn unknown_entry(kind: u8, version: u8, value_fill: u8) -> [u8; ENTRY_LEN] {
+        let mut buf = [0u8; ENTRY_LEN];
+        buf[0] = kind;
+        buf[1] = version;
+        buf[2..4].copy_from_slice(&(VALUE_LEN as u16).to_le_bytes());
+        buf[TAIL_HEADER_LEN..].fill(value_fill);
+        buf
+    }
+
+    #[test]
+    fn entry_serializes_expected_layout() {
+        let claimer = [7u8; VALUE_LEN];
+        let serialized = entry(&claimer);
+
+        assert_eq!(serialized.len(), ENTRY_LEN);
+        assert_eq!(serialized[0], TailKind::RentClaimer.as_u8());
+        assert_eq!(serialized[1], VERSION);
+        assert_eq!(
+            serialized[2..4],
+            (VALUE_LEN as u16).to_le_bytes(),
+        );
+        assert_eq!(serialized[4..8], [0u8; 4]);
+        assert_eq!(serialized[TAIL_HEADER_LEN..], claimer);
+    }
+
+    #[test]
+    fn read_returns_none_for_empty_tail() {
+        let parsed = read(&[]).expect("empty buffer should parse");
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn read_returns_claimer_for_single_rent_entry() {
+        let claimer = [11u8; VALUE_LEN];
+        let tail = entry(&claimer);
+
+        let parsed = read(&tail).expect("rent entry should parse");
+        assert_eq!(parsed, Some(&claimer));
+    }
+
+    #[test]
+    fn read_skips_unknown_kind_and_finds_rent_entry() {
+        let mut tail = Vec::new();
+        // Unknown kind, version 1, value_len 4, reserved 4 bytes.
+        tail.extend_from_slice(&[99u8, 1, 4, 0, 0, 0, 0, 0]);
+        tail.extend_from_slice(&[1, 2, 3, 4]);
+
+        let claimer = [21u8; VALUE_LEN];
+        tail.extend_from_slice(&entry(&claimer));
+
+        let parsed = read(&tail).expect("mixed tail should parse");
+        assert_eq!(parsed, Some(&claimer));
+    }
+
+    #[test]
+    fn read_does_not_reject_newer_rent_version() {
+        let claimer = [33u8; VALUE_LEN];
+        let mut tail = entry(&claimer);
+        tail[1] = VERSION + 1;
+
+        let parsed = read(&tail).expect("version is informational");
+        assert_eq!(parsed, Some(&claimer));
+    }
+
+    #[test]
+    fn read_errors_on_truncated_rent_value() {
+        let mut tail = entry(&[44u8; VALUE_LEN]).to_vec();
+        tail.pop();
+
+        let err = read(&tail).expect_err("truncated value must fail");
+        assert_eq!(
+            err,
+            ProgramError::Custom(SwigStateError::InvalidRentClaimerLayout as u32)
+        );
+    }
+
+    #[test]
+    fn read_first_of_handles_120_byte_tail_with_rent_at_start() {
+        let claimer = [55u8; VALUE_LEN];
+        let mut tail = Vec::new();
+        tail.extend_from_slice(&entry(&claimer));
+        tail.extend_from_slice(&unknown_entry(99, 1, 9));
+        tail.extend_from_slice(&unknown_entry(100, 2, 10));
+        assert_eq!(tail.len(), 120);
+
+        let parsed = read_first_of::<RentClaimerEntry<'_>>(&tail)
+            .expect("valid mixed tail should parse")
+            .expect("rent claimer must be present");
+
+        assert_eq!(parsed.header.kind, TailKind::RentClaimer.as_u8());
+        assert_eq!(parsed.header.version, VERSION);
+        assert_eq!(parsed.header.value_len as usize, VALUE_LEN);
+        assert_eq!(parsed.claimer, &claimer);
+
+        let parsed_claimer = read(&tail).expect("read should succeed");
+        assert_eq!(parsed_claimer, Some(&claimer));
+    }
+
+    #[test]
+    fn read_first_of_handles_120_byte_tail_with_rent_in_middle() {
+        let claimer = [77u8; VALUE_LEN];
+        let mut tail = Vec::new();
+        tail.extend_from_slice(&unknown_entry(90, 3, 4));
+        tail.extend_from_slice(&entry(&claimer));
+        tail.extend_from_slice(&unknown_entry(91, 4, 5));
+        assert_eq!(tail.len(), 120);
+
+        let parsed = read_first_of::<RentClaimerEntry<'_>>(&tail)
+            .expect("valid mixed tail should parse")
+            .expect("rent claimer must be present");
+
+        assert_eq!(parsed.header.kind, TailKind::RentClaimer.as_u8());
+        assert_eq!(parsed.header.version, VERSION);
+        assert_eq!(parsed.header.value_len as usize, VALUE_LEN);
+        assert_eq!(parsed.claimer, &claimer);
+
+        let parsed_claimer = read(&tail).expect("read should succeed");
+        assert_eq!(parsed_claimer, Some(&claimer));
+    }
+}


### PR DESCRIPTION
## Summary
- replay state crate changes from `815197d..HEAD` into the first stacked branch
- include tail parsing/splitting primitives and strict rent-claimer hardening in state
- keep this PR state-scoped to unblock downstream crate PRs

## Test plan
- [x] `cargo test -p swig-state`
- [x] tree identity verified at stack tip after layering