### PR TITLE
Rent-claimer: program changes

### DIFF
--- a/program/idl.json
+++ b/program/idl.json
@@ -617,6 +617,40 @@
         "type": "u8",
         "value": 16
       }
+    },
+    {
+      "name": "SetRentClaimerV1",
+      "accounts": [
+        {
+          "name": "swig",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the swig smart wallet"
+          ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "the payer"
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "the system program"
+          ]
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 17
+      }
     }
   ],
   "metadata": {

--- a/program/src/actions/add_authority_v1.rs
+++ b/program/src/actions/add_authority_v1.rs
@@ -15,6 +15,7 @@ use swig_state::{
     action::{all::All, manage_authority::ManageAuthority},
     authority::{authority_type_to_length, AuthorityType},
     role::Position,
+    tail::SavedTail,
     swig::{Swig, SwigBuilder},
     Discriminator, IntoBytes, SwigAuthenticateError, Transmutable, TransmutableMut,
 };
@@ -182,13 +183,14 @@ pub fn add_authority_v1(
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
     let swig_data_len = swig_account_data.len();
     let new_authority_type = AuthorityType::try_from(add_authority_v1.args.new_authority_type)?;
-    {
+    let (saved_tail, account_size) = {
         if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
             return Err(SwigError::InvalidSwigAccountDiscriminator.into());
         }
-        let (swig_header, swig_roles) =
-            unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-        let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+        let parts = Swig::split_parts_mut(swig_account_data)?;
+        let saved_tail = SavedTail::take(parts.tail)?;
+        let swig = parts.state;
+        let swig_roles = parts.roles;
         let acting_role = Swig::get_mut_role(add_authority_v1.args.acting_role_id, swig_roles)?;
         if acting_role.is_none() {
             return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
@@ -230,8 +232,10 @@ pub fn add_authority_v1(
         .map_err(|_| SwigError::InvalidAlignment)?
         .pad_to_align()
         .size();
-        ctx.accounts.swig.realloc(account_size, false)?;
-
+        (saved_tail, account_size)
+    };
+    ctx.accounts.swig.realloc(account_size, false)?;
+    {
         // Get current account lamports after reallocation
         let current_lamports = ctx.accounts.swig.lamports();
         let required_lamports = Rent::get()?.minimum_balance(account_size);
@@ -247,14 +251,28 @@ pub fn add_authority_v1(
             }
             .invoke()?;
         }
-    };
+    }
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-    let mut swig_builder = SwigBuilder::new_from_bytes(swig_account_data)?;
+    let (swig_header, roles_and_tail) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+    let roles_capacity_len = roles_and_tail
+        .len()
+        .checked_sub(saved_tail.len())
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let (swig_roles_capacity, _) =
+        unsafe { roles_and_tail.split_at_mut_unchecked(roles_capacity_len) };
+    let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+    let mut swig_builder = SwigBuilder {
+        role_buffer: swig_roles_capacity,
+        swig,
+    };
     swig_builder.add_role(
         new_authority_type,
         add_authority_v1.authority_data,
         add_authority_v1.actions,
     )?;
+    let roles_end = Swig::roles_end_offset(swig_account_data)?;
+    swig_account_data[roles_end..].fill(0);
+    saved_tail.restore_at(swig_account_data, roles_end)?;
     Ok(())
 }
 

--- a/program/src/actions/close_swig_v1.rs
+++ b/program/src/actions/close_swig_v1.rs
@@ -18,6 +18,7 @@ use swig_state::{
         all::All, close_swig_authority::CloseSwigAuthority, manage_authority::ManageAuthority,
     },
     swig::{swig_wallet_address_seeds, swig_wallet_address_signer, Swig},
+    tail::rent_claimer,
     Discriminator, IntoBytes, SwigAuthenticateError, Transmutable,
 };
 
@@ -103,8 +104,10 @@ pub fn close_swig_v1(
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
 
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_unchecked(swig_header)? };
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
+    let configured_rent_claimer = rent_claimer::read_strict(parts.tail)?;
 
     // Verify swig_wallet_address is the correct PDA
     let (expected_wallet_address, _wallet_bump) = pinocchio::pubkey::find_program_address(
@@ -146,6 +149,11 @@ pub fn close_swig_v1(
     let has_close = role.get_action::<CloseSwigAuthority>(&[])?.is_some();
     if !has_all && !has_manage && !has_close {
         return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+    }
+    if let Some(claimer) = configured_rent_claimer {
+        if ctx.accounts.destination.key().as_ref() != claimer.as_ref() {
+            return Err(SwigError::InvalidRentClaimerDestination.into());
+        }
     }
 
     // Store swig values before dropping borrow

--- a/program/src/actions/close_token_account_v1.rs
+++ b/program/src/actions/close_token_account_v1.rs
@@ -18,6 +18,7 @@ use swig_state::{
         all::All, close_swig_authority::CloseSwigAuthority, manage_authority::ManageAuthority,
     },
     swig::{swig_account_signer, swig_wallet_address_seeds, swig_wallet_address_signer, Swig},
+    tail::rent_claimer,
     Discriminator, IntoBytes, SwigAuthenticateError, Transmutable,
 };
 
@@ -116,7 +117,7 @@ pub fn close_token_account_v1(
     }
 
     // Get and authenticate role
-    let swig_roles = &swig_account_data[Swig::LEN..];
+    let swig_roles = Swig::split_parts(swig_account_data)?.roles;
     let role_opt = unsafe {
         let roles_ptr = swig_roles.as_ptr() as *mut u8;
         let roles_mut = core::slice::from_raw_parts_mut(roles_ptr, swig_roles.len());
@@ -152,6 +153,11 @@ pub fn close_token_account_v1(
     let has_close = role.get_action::<CloseSwigAuthority>(&[])?.is_some();
     if !has_all && !has_manage && !has_close {
         return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+    }
+    if let Some(claimer) = rent_claimer::read_strict(Swig::split_parts(swig_account_data)?.tail)? {
+        if ctx.accounts.destination.key().as_ref() != claimer.as_ref() {
+            return Err(SwigError::InvalidRentClaimerDestination.into());
+        }
     }
 
     // Use is_swig_v2 to determine expected authority

--- a/program/src/actions/create_session_v1.rs
+++ b/program/src/actions/create_session_v1.rs
@@ -137,7 +137,7 @@ pub fn create_session_v1(
     if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
-    let (_swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+    let swig_roles = Swig::split_parts_mut(swig_account_data)?.roles;
     let role = Swig::get_mut_role(create_session_v1.args.role_id, swig_roles)?;
     if role.is_none() {
         return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());

--- a/program/src/actions/create_sub_account_v1.rs
+++ b/program/src/actions/create_sub_account_v1.rs
@@ -154,9 +154,10 @@ pub fn create_sub_account_v1(
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
 
-    // Split the swig account data to get the header and roles
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_unchecked(swig_header)? };
+    // Split the swig account data to get the header and roles.
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
 
     // Get the role using the role_id from the instruction
     let role_opt = Swig::get_mut_role(create_sub_account.args.role_id, swig_roles)?;

--- a/program/src/actions/migrate_to_wallet_address_v1.rs
+++ b/program/src/actions/migrate_to_wallet_address_v1.rs
@@ -179,8 +179,7 @@ pub fn migrate_to_wallet_address_v1(
     // Authenticate and validate authority has All or ManageAuthority permission
     {
         let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-        let (_swig_header, swig_roles) =
-            unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+        let swig_roles = Swig::split_parts_mut(swig_account_data)?.roles;
         let role = Swig::get_mut_role(migrate.args.role_id, swig_roles)?
             .ok_or(SwigStateError::RoleNotFound)?;
 

--- a/program/src/actions/mod.rs
+++ b/program/src/actions/mod.rs
@@ -14,6 +14,7 @@ pub mod create_v1;
 pub mod migrate_to_wallet_address_v1;
 pub mod recover_authority_v1;
 pub mod remove_authority_v1;
+pub mod set_rent_claimer_v1;
 pub mod sign_v2;
 pub mod sub_account_sign_v1;
 pub mod toggle_sub_account_v1;
@@ -27,7 +28,8 @@ use pinocchio::{account_info::AccountInfo, msg, program_error::ProgramError, Pro
 use self::{
     add_authority_v1::*, close_swig_v1::*, close_token_account_v1::*, create_session_v1::*,
     create_sub_account_v1::*, create_v1::*, migrate_to_wallet_address_v1::*,
-    recover_authority_v1::*, remove_authority_v1::*, sign_v2::*, sub_account_sign_v1::*,
+    recover_authority_v1::*, remove_authority_v1::*, set_rent_claimer_v1::*, sign_v2::*,
+    sub_account_sign_v1::*,
     toggle_sub_account_v1::*, transfer_assets_v1::*, update_authority_v1::*,
     withdraw_from_sub_account_v1::*,
 };
@@ -37,7 +39,7 @@ use crate::{
             AddAuthorityV1Accounts, CloseSwigV1Accounts, CloseTokenAccountV1Accounts,
             CreateSessionV1Accounts, CreateSubAccountV1Accounts, CreateV1Accounts,
             MigrateToWalletAddressV1Accounts, RecoverAuthorityV1Accounts,
-            RemoveAuthorityV1Accounts, SignV2Accounts, SubAccountSignV1Accounts,
+            RemoveAuthorityV1Accounts, SetRentClaimerV1Accounts, SignV2Accounts, SubAccountSignV1Accounts,
             ToggleSubAccountV1Accounts, TransferAssetsV1Accounts, UpdateAuthorityV1Accounts,
             WithdrawFromSubAccountV1Accounts,
         },
@@ -101,6 +103,7 @@ pub fn process_action(
         SwigInstruction::CloseTokenAccountV1 => process_close_token_account_v1(accounts, data),
         SwigInstruction::CloseSwigV1 => process_close_swig_v1(accounts, data),
         SwigInstruction::RecoverAuthorityV1 => process_recover_authority_v1(accounts, data),
+        SwigInstruction::SetRentClaimerV1 => process_set_rent_claimer_v1(accounts, data),
     }
 }
 
@@ -236,4 +239,10 @@ fn process_close_token_account_v1(accounts: &[AccountInfo], data: &[u8]) -> Prog
 fn process_close_swig_v1(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let account_ctx = CloseSwigV1Accounts::context(accounts)?;
     close_swig_v1(account_ctx, accounts, data)
+}
+
+/// Processes a SetRentClaimerV1 instruction.
+fn process_set_rent_claimer_v1(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
+    let account_ctx = SetRentClaimerV1Accounts::context(accounts)?;
+    set_rent_claimer_v1(account_ctx, data, accounts)
 }

--- a/program/src/actions/recover_authority_v1.rs
+++ b/program/src/actions/recover_authority_v1.rs
@@ -123,8 +123,9 @@ pub fn recover_authority_v1(
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
 
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
 
     {
         let acting_role = Swig::get_mut_role(recover.args.acting_role_id, swig_roles)?

--- a/program/src/actions/remove_authority_v1.rs
+++ b/program/src/actions/remove_authority_v1.rs
@@ -12,8 +12,9 @@ use pinocchio::{
 use swig_assertions::{check_bytes_match, check_self_owned};
 use swig_state::{
     action::{all::All, manage_authority::ManageAuthority},
+    tail::SavedTail,
     swig::{Swig, SwigBuilder},
-    Discriminator, IntoBytes, SwigAuthenticateError, Transmutable,
+    Discriminator, IntoBytes, SwigAuthenticateError, Transmutable, TransmutableMut,
 };
 
 use crate::{
@@ -153,14 +154,18 @@ pub fn remove_authority_v1(
         return Err(SwigAuthenticateError::PermissionDeniedCannotRemoveRootAuthority.into());
     }
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    let data_len = swig_account_data.len();
+    let swig_lamports = unsafe { *ctx.accounts.swig.borrow_lamports_unchecked() };
     // All validation and processing as a closure to avoid borrowing
     // swig_account_data for too long
-    {
+    let (saved_tail, removed) = {
         if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
             return Err(SwigError::InvalidSwigAccountDiscriminator.into());
         }
-        let (_swig_header, swig_roles) =
-            unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+        let parts = Swig::split_parts_mut(swig_account_data)?;
+        let saved_tail = SavedTail::take(parts.tail)?;
+        let swig = parts.state;
+        let swig_roles = parts.roles;
         {
             let acting_role =
                 Swig::get_mut_role(remove_authority_v1.args.acting_role_id, swig_roles)?;
@@ -205,14 +210,14 @@ pub fn remove_authority_v1(
         if role_to_remove.is_none() {
             return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
         }
-    }
-
-    // Calculate the new size and remove the role
-    let data_len = swig_account_data.len();
-    let swig_lamports = unsafe { *ctx.accounts.swig.borrow_lamports_unchecked() };
-    let mut swig_builder = SwigBuilder::new_from_bytes(swig_account_data)?;
-    // Remove the role
-    let removed = swig_builder.remove_role(remove_authority_v1.args.authority_to_remove_id)?;
+        let mut swig_builder = SwigBuilder {
+            role_buffer: swig_roles,
+            swig,
+        };
+        // Remove the role.
+        let removed = swig_builder.remove_role(remove_authority_v1.args.authority_to_remove_id)?;
+        (saved_tail, removed)
+    };
     // realloc the account
 
     let new_size = data_len - removed.1;
@@ -225,6 +230,10 @@ pub fn remove_authority_v1(
         *ctx.accounts.payer.borrow_mut_lamports_unchecked() = ctx.accounts.payer.lamports() + diff;
     };
     ctx.accounts.swig.realloc(new_size, false)?;
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    let roles_end = Swig::roles_end_offset(swig_account_data)?;
+    swig_account_data[roles_end..].fill(0);
+    saved_tail.restore_at(swig_account_data, roles_end)?;
 
     Ok(())
 }

--- a/program/src/actions/set_rent_claimer_v1.rs
+++ b/program/src/actions/set_rent_claimer_v1.rs
@@ -1,0 +1,173 @@
+use no_padding::NoPadding;
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    sysvars::{clock::Clock, rent::Rent, Sysvar},
+    ProgramResult,
+};
+use pinocchio_system::instructions::Transfer;
+use swig_assertions::{check_bytes_match, check_self_owned};
+use swig_state::{
+    action::{all::All, close_swig_authority::CloseSwigAuthority},
+    swig::Swig,
+    tail::rent_claimer,
+    Discriminator, IntoBytes, SwigAuthenticateError, Transmutable,
+};
+
+use crate::{
+    error::SwigError,
+    instruction::{
+        accounts::{Context, SetRentClaimerV1Accounts},
+        SwigInstruction,
+    },
+};
+
+#[repr(C, align(8))]
+#[derive(Debug, NoPadding)]
+pub struct SetRentClaimerV1Args {
+    pub discriminator: SwigInstruction,
+    pub _padding: [u8; 2],
+    pub role_id: u32,
+    pub rent_claimer: [u8; 32],
+}
+
+impl SetRentClaimerV1Args {
+    pub fn new(role_id: u32, rent_claimer: [u8; 32]) -> Self {
+        Self {
+            discriminator: SwigInstruction::SetRentClaimerV1,
+            _padding: [0; 2],
+            role_id,
+            rent_claimer,
+        }
+    }
+}
+
+impl Transmutable for SetRentClaimerV1Args {
+    const LEN: usize = core::mem::size_of::<Self>();
+}
+
+impl IntoBytes for SetRentClaimerV1Args {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+pub struct SetRentClaimerV1<'a> {
+    pub args: &'a SetRentClaimerV1Args,
+    pub authority_payload: &'a [u8],
+    pub data_payload: &'a [u8],
+}
+
+impl<'a> SetRentClaimerV1<'a> {
+    pub fn from_instruction_bytes(data: &'a [u8]) -> Result<Self, ProgramError> {
+        if data.len() < SetRentClaimerV1Args::LEN {
+            return Err(SwigError::InvalidSwigSetRentClaimerInstructionDataTooShort.into());
+        }
+        let (args_data, authority_payload) = data.split_at(SetRentClaimerV1Args::LEN);
+        let args = unsafe { SetRentClaimerV1Args::load_unchecked(args_data)? };
+        Ok(Self {
+            args,
+            authority_payload,
+            data_payload: args_data,
+        })
+    }
+}
+
+pub fn set_rent_claimer_v1(
+    ctx: Context<SetRentClaimerV1Accounts>,
+    data: &[u8],
+    all_accounts: &[AccountInfo],
+) -> ProgramResult {
+    check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
+    check_bytes_match(
+        ctx.accounts.system_program.key(),
+        &pinocchio_system::ID,
+        32,
+        SwigError::InvalidSystemProgram,
+    )?;
+
+    let set_ix = SetRentClaimerV1::from_instruction_bytes(data)?;
+    if set_ix.args.rent_claimer == [0u8; 32] {
+        return Err(SwigError::InvalidRentClaimerValue.into());
+    }
+
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+    let old_len = swig_account_data.len();
+
+    {
+        let parts = Swig::split_parts_mut(swig_account_data)?;
+        let _swig = parts.state;
+        let acting_role = Swig::get_mut_role(set_ix.args.role_id, parts.roles)?
+            .ok_or(SwigError::InvalidAuthorityNotFoundByRoleId)?;
+
+        let slot = Clock::get()?.slot;
+        if acting_role.authority.session_based() {
+            acting_role.authority.authenticate_session(
+                all_accounts,
+                set_ix.authority_payload,
+                set_ix.data_payload,
+                slot,
+            )?;
+        } else {
+            acting_role.authority.authenticate(
+                all_accounts,
+                set_ix.authority_payload,
+                set_ix.data_payload,
+                slot,
+            )?;
+        }
+
+        let has_all = acting_role.get_action::<All>(&[])?.is_some();
+        let has_close = acting_role.get_action::<CloseSwigAuthority>(&[])?.is_some();
+        if !has_all && !has_close {
+            return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+        }
+
+        if rent_claimer::read_strict(parts.tail)?.is_some() {
+            return Err(SwigError::RentClaimerAlreadySet.into());
+        }
+    }
+
+    let new_len = old_len
+        .checked_add(rent_claimer::ENTRY_LEN)
+        .ok_or(ProgramError::InvalidAccountData)?;
+    ctx.accounts.swig.resize(new_len)?;
+
+    let current_lamports = ctx.accounts.swig.lamports();
+    let required_lamports = Rent::get()?.minimum_balance(new_len);
+    let cost = required_lamports
+        .checked_sub(current_lamports)
+        .unwrap_or_default();
+    if cost > 0 {
+        Transfer {
+            from: ctx.accounts.payer,
+            to: ctx.accounts.swig,
+            lamports: cost,
+        }
+        .invoke()?;
+    }
+
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    let entry = rent_claimer::entry(&set_ix.args.rent_claimer);
+    swig_account_data[old_len..old_len + rent_claimer::ENTRY_LEN].copy_from_slice(&entry);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_instruction_bytes_rejects_short_data() {
+        let data = vec![0u8; SetRentClaimerV1Args::LEN - 1];
+        assert!(matches!(
+            SetRentClaimerV1::from_instruction_bytes(&data),
+            Err(ProgramError::Custom(code))
+                if code == SwigError::InvalidSwigSetRentClaimerInstructionDataTooShort as u32
+        ));
+    }
+}

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -212,8 +212,9 @@ pub fn sign_v2(
     if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
     // The generic account classifier already identified account 0 as Swig config.
     // Keep this hot-path discriminator check as a local unsafe-read precondition.
     let Some(role) = Swig::get_mut_role(sign_v2.args.role_id, swig_roles)? else {

--- a/program/src/actions/sub_account_sign_v1.rs
+++ b/program/src/actions/sub_account_sign_v1.rs
@@ -143,8 +143,9 @@ pub fn sub_account_sign_v1(
     if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_unchecked(swig_header)? };
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
 
     let role_opt = Swig::get_mut_role(sign_v1.args.role_id, swig_roles)?;
     if role_opt.is_none() {

--- a/program/src/actions/toggle_sub_account_v1.rs
+++ b/program/src/actions/toggle_sub_account_v1.rs
@@ -146,9 +146,10 @@ pub fn toggle_sub_account_v1(
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
 
-    // Split the swig account data to get the header and roles
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_unchecked(swig_header)? };
+    // Split the swig account data to get the header and roles.
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
 
     msg!(
         "toggle_sub_account_v1: auth_role_id: {}",

--- a/program/src/actions/transfer_assets_v1.rs
+++ b/program/src/actions/transfer_assets_v1.rs
@@ -132,13 +132,13 @@ pub fn transfer_assets_v1(
 
     // Load and validate swig account
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_unchecked(&swig_header)? };
-
     // Verify the swig account has the correct discriminator
-    if unsafe { *swig_header.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
+    if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
 
     // Ensure this is a migrated swig account (has wallet_bump)
     if swig.wallet_bump == 0 {

--- a/program/src/actions/update_authority_v1.rs
+++ b/program/src/actions/update_authority_v1.rs
@@ -15,6 +15,7 @@ use swig_state::{
     action::{all::All, manage_authority::ManageAuthority, Action, ActionLoader},
     authority::{authority_type_to_length, AuthorityType},
     role::Position,
+    tail::SavedTail,
     swig::Swig,
     Discriminator, IntoBytes, SwigAuthenticateError, SwigStateError, Transmutable, TransmutableMut,
 };
@@ -282,7 +283,7 @@ impl<'a> UpdateAuthorityV1<'a> {
 /// Performs a replace-all operation on an authority's actions.
 fn perform_replace_all_operation(
     swig_roles: &mut [u8],
-    swig_data_len: usize,
+    current_roles_len: usize,
     authority_offset: usize,
     actions_offset: usize,
     current_actions_size: usize,
@@ -295,8 +296,7 @@ fn perform_replace_all_operation(
     if size_diff != 0 {
         // Need to shift data if size changed
         let role_end = actions_offset + current_actions_size;
-        let original_data_len = (swig_data_len as i64 - Swig::LEN as i64) as usize;
-        let remaining_data_len = original_data_len - role_end;
+        let remaining_data_len = current_roles_len - role_end;
 
         if size_diff > 0 {
             // Growing: shift data to the right
@@ -318,8 +318,9 @@ fn perform_replace_all_operation(
 
         // Update boundaries of all roles after this one
         let mut cursor = 0;
-        while cursor < (swig_roles.len() + size_diff as usize) {
-            if cursor + Position::LEN > swig_roles.len() {
+        let new_roles_len = (current_roles_len as i64 + size_diff) as usize;
+        while cursor < new_roles_len {
+            if cursor + Position::LEN > new_roles_len {
                 break;
             }
             let position = unsafe {
@@ -348,7 +349,8 @@ fn perform_replace_all_operation(
         position.num_actions = calculate_num_actions(new_actions)? as u16;
     }
 
-    if actions_offset + new_actions_size > swig_roles.len() {
+    let final_roles_len = (current_roles_len as i64 + size_diff) as usize;
+    if actions_offset + new_actions_size > final_roles_len {
         return Err(SwigError::StateError.into());
     }
 
@@ -399,7 +401,7 @@ fn perform_replace_all_operation(
 /// Performs an add-actions operation on an authority.
 fn perform_add_actions_operation(
     swig_roles: &mut [u8],
-    swig_data_len: usize,
+    current_roles_len: usize,
     authority_offset: usize,
     actions_offset: usize,
     current_actions_size: usize,
@@ -419,7 +421,7 @@ fn perform_add_actions_operation(
     // Use replace_all logic with combined actions
     perform_replace_all_operation(
         swig_roles,
-        swig_data_len,
+        current_roles_len,
         authority_offset,
         actions_offset,
         current_actions_size,
@@ -431,7 +433,7 @@ fn perform_add_actions_operation(
 /// Performs a remove-actions-by-type operation on an authority.
 fn perform_remove_by_type_operation(
     swig_roles: &mut [u8],
-    swig_data_len: usize,
+    current_roles_len: usize,
     authority_offset: usize,
     actions_offset: usize,
     current_actions_size: usize,
@@ -477,7 +479,7 @@ fn perform_remove_by_type_operation(
     // Use replace_all logic with filtered actions
     perform_replace_all_operation(
         swig_roles,
-        swig_data_len,
+        current_roles_len,
         authority_offset,
         actions_offset,
         current_actions_size,
@@ -489,7 +491,7 @@ fn perform_remove_by_type_operation(
 /// Performs a remove-actions-by-index operation on an authority.
 fn perform_remove_by_index_operation(
     swig_roles: &mut [u8],
-    swig_data_len: usize,
+    current_roles_len: usize,
     authority_offset: usize,
     actions_offset: usize,
     current_actions_size: usize,
@@ -535,7 +537,7 @@ fn perform_remove_by_index_operation(
     // Use replace_all logic with filtered actions
     perform_replace_all_operation(
         swig_roles,
-        swig_data_len,
+        current_roles_len,
         authority_offset,
         actions_offset,
         current_actions_size,
@@ -578,83 +580,97 @@ pub fn update_authority_v1(
         ProgramError::InvalidInstructionData
     })?;
 
-    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-    let swig_data_len = swig_account_data.len();
-
-    if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
-        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
-    }
-
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
-
-    // Get and validate acting role
-    let acting_role = Swig::get_mut_role(update_authority_v1.args.acting_role_id, swig_roles)?;
-    if acting_role.is_none() {
-        return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
-    }
-    let acting_role = acting_role.unwrap();
-
-    // Authenticate the caller
-    let clock = Clock::get()?;
-    let slot = clock.slot;
-
-    if acting_role.authority.session_based() {
-        acting_role.authority.authenticate_session(
-            all_accounts,
-            update_authority_v1.authority_payload,
-            update_authority_v1.data_payload,
-            slot,
-        )?;
-    } else {
-        acting_role.authority.authenticate(
-            all_accounts,
-            update_authority_v1.authority_payload,
-            update_authority_v1.data_payload,
-            slot,
-        )?;
-    }
-
-    // Check permissions - same as add/remove authority
-    let all = acting_role.get_action::<All>(&[])?;
-    let manage_authority = acting_role.get_action::<ManageAuthority>(&[])?;
-
-    if all.is_none() && manage_authority.is_none() {
-        return Err(SwigAuthenticateError::PermissionDeniedToManageAuthority.into());
-    }
-
-    // Verify the authority to update exists and calculate size difference
-    let (current_actions_size, authority_offset, actions_offset) = {
-        let mut cursor = 0;
-        let mut found = false;
-        let mut auth_offset = 0;
-        let mut act_offset = 0;
-        let mut current_size = 0;
-
-        for _i in 0..swig.roles {
-            let position =
-                unsafe { Position::load_unchecked(&swig_roles[cursor..cursor + Position::LEN])? };
-
-            if position.id() == update_authority_v1.args.authority_to_update_id {
-                found = true;
-                auth_offset = cursor;
-                act_offset = cursor + Position::LEN + position.authority_length() as usize;
-                current_size = position.boundary() as usize - act_offset;
-                break;
-            }
-            cursor = position.boundary() as usize;
+    let operation = update_authority_v1.get_operation()?;
+    let mut account_len: usize;
+    let (
+        saved_tail,
+        current_roles_len,
+        current_actions_size,
+        authority_offset,
+        actions_offset,
+        prealloc_size_diff,
+    ) = {
+        let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+        account_len = swig_account_data.len();
+        if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+            return Err(SwigError::InvalidSwigAccountDiscriminator.into());
         }
 
-        if !found {
+        let parts = Swig::split_parts_mut(swig_account_data)?;
+        let saved_tail = SavedTail::take(parts.tail)?;
+        let swig = parts.state;
+        let swig_roles = parts.roles;
+        let roles_len = swig_roles.len();
+
+        // Get and validate acting role.
+        let acting_role = Swig::get_mut_role(update_authority_v1.args.acting_role_id, swig_roles)?;
+        if acting_role.is_none() {
             return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
         }
+        let acting_role = acting_role.unwrap();
 
-        (current_size, auth_offset, act_offset)
-    };
+        // Authenticate the caller.
+        let clock = Clock::get()?;
+        let slot = clock.slot;
+        if acting_role.authority.session_based() {
+            acting_role.authority.authenticate_session(
+                all_accounts,
+                update_authority_v1.authority_payload,
+                update_authority_v1.data_payload,
+                slot,
+            )?;
+        } else {
+            acting_role.authority.authenticate(
+                all_accounts,
+                update_authority_v1.authority_payload,
+                update_authority_v1.data_payload,
+                slot,
+            )?;
+        }
 
-    // Calculate size difference first
-    let operation = update_authority_v1.get_operation()?;
-    let size_diff = match operation {
+        // Check permissions - same as add/remove authority.
+        let all = acting_role.get_action::<All>(&[])?;
+        let manage_authority = acting_role.get_action::<ManageAuthority>(&[])?;
+        if all.is_none() && manage_authority.is_none() {
+            return Err(SwigAuthenticateError::PermissionDeniedToManageAuthority.into());
+        }
+
+        // Verify the authority to update exists and calculate offsets.
+        let (current_actions_size, authority_offset, actions_offset) = {
+            let mut cursor = 0usize;
+            let mut found = false;
+            let mut auth_offset = 0usize;
+            let mut act_offset = 0usize;
+            let mut current_size = 0usize;
+
+            for _ in 0..swig.roles {
+                if cursor + Position::LEN > roles_len {
+                    return Err(ProgramError::InvalidAccountData);
+                }
+                let position =
+                    unsafe { Position::load_unchecked(&swig_roles[cursor..cursor + Position::LEN])? };
+                let boundary = position.boundary() as usize;
+                if boundary < cursor + Position::LEN || boundary > roles_len {
+                    return Err(ProgramError::InvalidAccountData);
+                }
+
+                if position.id() == update_authority_v1.args.authority_to_update_id {
+                    found = true;
+                    auth_offset = cursor;
+                    act_offset = cursor + Position::LEN + position.authority_length() as usize;
+                    current_size = boundary - act_offset;
+                    break;
+                }
+                cursor = boundary;
+            }
+
+            if !found {
+                return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+            }
+            (current_size, auth_offset, act_offset)
+        };
+
+        let prealloc_size_diff = match operation {
         AuthorityUpdateOperation::ReplaceAll => {
             let new_actions = update_authority_v1.get_actions_data()?;
             new_actions.len() as i64 - current_actions_size as i64
@@ -673,11 +689,21 @@ pub fn update_authority_v1(
             // This is complex, so for now we'll calculate it in the operation function
             0 // Will be calculated in the operation
         },
+        };
+
+        (
+            saved_tail,
+            roles_len,
+            current_actions_size,
+            authority_offset,
+            actions_offset,
+            prealloc_size_diff,
+        )
     };
 
     // Handle account reallocation if size changed (before operations)
-    let new_reserved_lamports = if size_diff != 0 {
-        let new_size = (swig_data_len as i64 + size_diff) as usize;
+    if prealloc_size_diff > 0 {
+        let new_size = (account_len as i64 + prealloc_size_diff) as usize;
         let aligned_size =
             core::alloc::Layout::from_size_align(new_size, core::mem::size_of::<u64>())
                 .map_err(|_| SwigError::InvalidAlignment)?
@@ -685,6 +711,7 @@ pub fn update_authority_v1(
                 .size();
 
         ctx.accounts.swig.realloc(aligned_size, false)?;
+        account_len = aligned_size;
 
         let cost = Rent::get()?.minimum_balance(aligned_size);
         let current_lamports = unsafe { *ctx.accounts.swig.borrow_lamports_unchecked() };
@@ -699,73 +726,73 @@ pub fn update_authority_v1(
             }
             .invoke()?;
         }
-
-        cost
-    } else {
-        // No size change, so no need to transfer additional funds
-        0
-    };
+    }
 
     // Get fresh references to the swig account data after reallocation
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let _swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+    saved_tail.restore(swig_account_data)?;
+    let (_, swig_roles_and_tail) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+    let roles_capacity_len = swig_roles_and_tail
+        .len()
+        .checked_sub(saved_tail.len())
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let (swig_roles, _) =
+        unsafe { swig_roles_and_tail.split_at_mut_unchecked(roles_capacity_len) };
 
-    let mut size_diff = 0;
     // Now perform the operation with the reallocated account
-    match operation {
+    let size_diff = match operation {
         AuthorityUpdateOperation::ReplaceAll => {
             let new_actions = update_authority_v1.get_actions_data()?;
             perform_replace_all_operation(
                 swig_roles,
-                swig_data_len,
+                current_roles_len,
                 authority_offset,
                 actions_offset,
                 current_actions_size,
                 new_actions,
                 update_authority_v1.args.authority_to_update_id,
-            )?;
+            )?
         },
         AuthorityUpdateOperation::AddActions => {
             let new_actions = update_authority_v1.get_actions_data()?;
             perform_add_actions_operation(
                 swig_roles,
-                swig_data_len,
+                current_roles_len,
                 authority_offset,
                 actions_offset,
                 current_actions_size,
                 new_actions,
                 update_authority_v1.args.authority_to_update_id,
-            )?;
+            )?
         },
         AuthorityUpdateOperation::RemoveActionsByType => {
             let remove_types = update_authority_v1.get_remove_types()?;
-            size_diff = perform_remove_by_type_operation(
+            perform_remove_by_type_operation(
                 swig_roles,
-                swig_data_len,
+                current_roles_len,
                 authority_offset,
                 actions_offset,
                 current_actions_size,
                 remove_types,
                 update_authority_v1.args.authority_to_update_id,
-            )?;
+            )?
         },
         AuthorityUpdateOperation::RemoveActionsByIndex => {
             let remove_indices = update_authority_v1.get_remove_indices()?;
-            size_diff = perform_remove_by_index_operation(
+            perform_remove_by_index_operation(
                 swig_roles,
-                swig_data_len,
+                current_roles_len,
                 authority_offset,
                 actions_offset,
                 current_actions_size,
                 &remove_indices,
                 update_authority_v1.args.authority_to_update_id,
-            )?;
+            )?
         },
-    }
+    };
 
     if size_diff < 0 {
-        let new_size = (swig_data_len as i64 + size_diff) as usize;
+        let new_size = (account_len as i64 + size_diff) as usize;
         let aligned_size =
             core::alloc::Layout::from_size_align(new_size, core::mem::size_of::<u64>())
                 .map_err(|_| SwigError::InvalidAlignment)?
@@ -788,6 +815,10 @@ pub fn update_authority_v1(
             };
         }
     }
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    let roles_end = Swig::roles_end_offset(swig_account_data)?;
+    swig_account_data[roles_end..].fill(0);
+    saved_tail.restore_at(swig_account_data, roles_end)?;
 
     Ok(())
 }
@@ -795,6 +826,13 @@ pub fn update_authority_v1(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use swig_state::{
+        action::{all::All, manage_authority::ManageAuthority, Action, Actionable},
+        authority::{ed25519::ED25519Authority, AuthorityType},
+        swig::{Swig, SwigBuilder},
+        tail::{rent_claimer, SavedTail},
+        IntoBytes, TransmutableMut,
+    };
 
     #[test]
     fn from_instruction_bytes_rejects_short_actions_payload() {
@@ -807,5 +845,79 @@ mod tests {
             Err(ProgramError::Custom(code))
                 if code == SwigError::InvalidSwigUpdateAuthorityInstructionDataTooShort as u32
         ));
+    }
+
+    #[test]
+    fn perform_replace_all_growth_preserves_tail_region() -> Result<(), ProgramError> {
+        let mut account_buffer = vec![0u8; Swig::LEN + 256];
+        let swig = Swig::new([1u8; 32], 255, 0);
+        let mut builder = SwigBuilder::create(&mut account_buffer, swig)?;
+
+        let authority = ED25519Authority {
+            public_key: [2u8; 32],
+        };
+        let all_data = All {}.into_bytes()?;
+        let all_header = Action::new(
+            All::TYPE,
+            all_data.len() as u16,
+            Action::LEN as u32 + all_data.len() as u32,
+        );
+        let all_actions = [all_header.into_bytes()?, all_data].concat();
+        builder.add_role(AuthorityType::Ed25519, authority.into_bytes()?, &all_actions)?;
+        drop(builder);
+
+        let roles_end = Swig::roles_end_offset(&account_buffer)?;
+        account_buffer.truncate(roles_end);
+        let tail = rent_claimer::entry(&[77u8; 32]);
+        account_buffer.extend_from_slice(&tail);
+        let expected_tail = tail.to_vec();
+
+        let saved_tail = {
+            let (_, tail_slice) = Swig::split_roles_and_tail_mut(&mut account_buffer)?;
+            SavedTail::take(tail_slice)?
+        };
+
+        let ma_data = ManageAuthority {}.into_bytes()?;
+        let ma_header = Action::new(
+            ManageAuthority::TYPE,
+            ma_data.len() as u16,
+            Action::LEN as u32 + ma_data.len() as u32,
+        );
+        let grown_actions = [all_actions.as_slice(), ma_header.into_bytes()?, ma_data].concat();
+        let expected_diff = grown_actions.len() as i64 - all_actions.len() as i64;
+
+        account_buffer.resize((account_buffer.len() as i64 + expected_diff) as usize, 0);
+        saved_tail.restore(&mut account_buffer)?;
+
+        let (roles_len, authority_offset, actions_offset, current_actions_size) = {
+            let (roles, _) = Swig::split_roles_and_tail(&account_buffer)?;
+            let position = unsafe { Position::load_unchecked(&roles[..Position::LEN])? };
+            let authority_offset = 0usize;
+            let actions_offset = Position::LEN + position.authority_length() as usize;
+            let current_actions_size = position.boundary() as usize - actions_offset;
+            (roles.len(), authority_offset, actions_offset, current_actions_size)
+        };
+
+        {
+            let (swig_header, roles_and_tail) = account_buffer.split_at_mut(Swig::LEN);
+            let _swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+            let roles_capacity_len = roles_and_tail.len() - saved_tail.len();
+            let (roles_capacity, _) = roles_and_tail.split_at_mut(roles_capacity_len);
+            let applied = perform_replace_all_operation(
+                roles_capacity,
+                roles_len,
+                authority_offset,
+                actions_offset,
+                current_actions_size,
+                &grown_actions,
+                0,
+            )?;
+            assert_eq!(applied, expected_diff);
+        }
+
+        saved_tail.restore(&mut account_buffer)?;
+        let (_, tail_after) = Swig::split_roles_and_tail(&account_buffer)?;
+        assert_eq!(tail_after, expected_tail.as_slice());
+        Ok(())
     }
 }

--- a/program/src/actions/withdraw_from_sub_account_v1.rs
+++ b/program/src/actions/withdraw_from_sub_account_v1.rs
@@ -120,8 +120,12 @@ pub fn withdraw_from_sub_account_v1(
     )?;
     let withdraw = WithdrawFromSubAccountV1::from_instruction_bytes(data)?;
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_unchecked(&swig_header)? };
+    if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
 
     let swig_wallet_address_seeds = swig_wallet_address_seeds(ctx.accounts.swig.key().as_ref());
     // Validate that the swig wallet address is the correct PDA derived from the
@@ -133,10 +137,6 @@ pub fn withdraw_from_sub_account_v1(
         return Err(SwigError::InvalidSwigSubAccountSwigIdMismatch.into());
     }
 
-    // Verify the swig account has the correct discriminator
-    if unsafe { *swig_header.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
-        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
-    }
     // We'll get sub-account metadata from the SubAccount action later after
     // authentication
     let role_opt = Swig::get_mut_role(withdraw.args.role_id, swig_roles)?;

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -138,6 +138,14 @@ pub enum SwigError {
     RecoveryInvalidAuthorityLength,
     /// Recovery does not support this authority scheme
     UnsupportedRecoveryAuthorityScheme,
+    /// Set rent claimer instruction data is too short
+    InvalidSwigSetRentClaimerInstructionDataTooShort,
+    /// Rent claimer can only be set once
+    RentClaimerAlreadySet,
+    /// Rent claimer pubkey is invalid
+    InvalidRentClaimerValue,
+    /// Destination does not match configured rent claimer
+    InvalidRentClaimerDestination,
 }
 
 /// Implements conversion from SwigError to ProgramError.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -240,4 +240,15 @@ pub enum SwigInstruction {
     #[account(2, name="instructions", desc="the instructions sysvar account")]
     #[account(3, name="pending_recovery", desc="the recovery pending state account")]
     RecoverAuthorityV1 = 16,
+
+    /// Sets an immutable rent claimer for this swig wallet.
+    ///
+    /// Required accounts:
+    /// 1. `[writable]` Swig wallet account
+    /// 2. `[writable, signer]` Payer account
+    /// 3. System program account
+    #[account(0, writable, name="swig", desc="the swig smart wallet")]
+    #[account(1, writable, signer, name="payer", desc="the payer")]
+    #[account(2, name="system_program", desc="the system program")]
+    SetRentClaimerV1 = 17,
 }

--- a/program/tests/close_swig_test.rs
+++ b/program/tests/close_swig_test.rs
@@ -92,6 +92,228 @@ fn test_close_swig_ed25519() {
     );
 }
 
+#[test_log::test]
+fn test_close_swig_with_configured_rent_claimer_destination_mismatch_fails() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, claimer.pubkey())
+        .unwrap();
+
+    let wrong_destination = Keypair::new();
+    context.svm.airdrop(&wrong_destination.pubkey(), 0).unwrap();
+    let close_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        wrong_destination.pubkey(),
+        0,
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_err(),
+        "close must fail when destination != configured rent claimer"
+    );
+}
+
+#[test_log::test]
+fn test_close_swig_with_configured_rent_claimer_destination_match_succeeds() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, claimer.pubkey())
+        .unwrap();
+    let swig_lamports_before = context.svm.get_account(&swig_pubkey).unwrap().lamports;
+    let wallet_lamports_before = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    let claimer_lamports_before = context
+        .svm
+        .get_account(&claimer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let close_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        claimer.pubkey(),
+        0,
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(result.is_ok(), "close should succeed with pinned destination");
+
+    let claimer_lamports_after = context
+        .svm
+        .get_account(&claimer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    let expected_closed_account_rent = context.svm.minimum_balance_for_rent_exemption(1);
+    let expected_reclaimed = wallet_lamports_before
+        + swig_lamports_before.saturating_sub(expected_closed_account_rent);
+
+    let swig_lamports_after = context.svm.get_account(&swig_pubkey).unwrap().lamports;
+    let wallet_lamports_after = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    println!("claimer_lamports_before: {} after: {}", claimer_lamports_before, claimer_lamports_after);
+    println!("swig_wallet_lamports_before: {} after: {}", wallet_lamports_before, wallet_lamports_after);
+    println!("swig_lamports_before: {} after: {}", swig_lamports_before, swig_lamports_after);
+    println!("expected_closed_account_rent: {}", expected_closed_account_rent);
+    println!("expected_reclaimed: {}", expected_reclaimed);
+    assert_eq!(
+        claimer_lamports_after.saturating_sub(claimer_lamports_before),
+        expected_reclaimed,
+        "configured rent claimer should receive swig + wallet reclaimed rent"
+    );
+}
+
+#[test_log::test]
+fn test_rent_claimer_receives_rent_from_close_token_then_close_swig() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, claimer.pubkey())
+        .unwrap();
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_token_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let token_account_rent = context.svm.get_account(&swig_token_ata).unwrap().lamports;
+    let swig_lamports_before = context.svm.get_account(&swig_pubkey).unwrap().lamports;
+    let wallet_lamports_before = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    let claimer_lamports_before = context
+        .svm
+        .get_account(&claimer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let close_token_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        claimer.pubkey(),
+        spl_token::ID,
+        vec![swig_token_ata],
+        0,
+    )
+    .unwrap();
+    let close_token_msg = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_token_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let close_token_tx =
+        VersionedTransaction::try_new(close_token_msg, &[&context.default_payer, &authority])
+            .unwrap();
+    let close_token_result = context.svm.send_transaction(close_token_tx);
+    assert!(
+        close_token_result.is_ok(),
+        "token close should succeed with configured rent claimer"
+    );
+
+    let close_swig_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        claimer.pubkey(),
+        0,
+    )
+    .unwrap();
+    let close_swig_msg = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_swig_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let close_swig_tx =
+        VersionedTransaction::try_new(close_swig_msg, &[&context.default_payer, &authority])
+            .unwrap();
+    let close_swig_result = context.svm.send_transaction(close_swig_tx);
+    assert!(
+        close_swig_result.is_ok(),
+        "swig close should succeed with configured rent claimer"
+    );
+
+    let claimer_lamports_after = context
+        .svm
+        .get_account(&claimer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    let expected_closed_account_rent = context.svm.minimum_balance_for_rent_exemption(1);
+    let expected_total_reclaimed = token_account_rent
+        + wallet_lamports_before
+        + swig_lamports_before.saturating_sub(expected_closed_account_rent);
+    assert_eq!(
+        claimer_lamports_after.saturating_sub(claimer_lamports_before),
+        expected_total_reclaimed,
+        "claimer should receive rent from token close and swig close"
+    );
+}
+
 /// Test closing swig with ManageAuthority permission
 #[test_log::test]
 fn test_close_swig_with_manage_authority() {

--- a/program/tests/close_token_account_test.rs
+++ b/program/tests/close_token_account_test.rs
@@ -107,6 +107,123 @@ fn test_close_token_account_ed25519() {
     );
 }
 
+#[test_log::test]
+fn test_close_token_account_with_configured_rent_claimer_destination_mismatch_fails() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, claimer.pubkey())
+        .unwrap();
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_token_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+
+    let wrong_destination = Keypair::new();
+    let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        wrong_destination.pubkey(),
+        spl_token::ID,
+        vec![swig_token_ata],
+        0,
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_err(),
+        "close token should fail when destination != configured rent claimer"
+    );
+}
+
+#[test_log::test]
+fn test_close_token_account_with_configured_rent_claimer_destination_match_succeeds() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    );
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, claimer.pubkey())
+        .unwrap();
+
+    let mint_pubkey = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let swig_token_ata = setup_ata(
+        &mut context.svm,
+        &mint_pubkey,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let token_account_rent = context.svm.get_account(&swig_token_ata).unwrap().lamports;
+    let claimer_before = context
+        .svm
+        .get_account(&claimer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        authority.pubkey(),
+        claimer.pubkey(),
+        spl_token::ID,
+        vec![swig_token_ata],
+        0,
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(result.is_ok(), "close token should succeed with pinned destination");
+
+    let claimer_after = context
+        .svm
+        .get_account(&claimer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    assert_eq!(
+        claimer_after.saturating_sub(claimer_before),
+        token_account_rent,
+        "configured rent claimer should receive token account rent"
+    );
+}
+
 /// Test closing token account owned by swig (V1 style - fallback path)
 #[test_log::test]
 fn test_close_token_account_v1_style_authority() {

--- a/program/tests/common/mod.rs
+++ b/program/tests/common/mod.rs
@@ -13,8 +13,9 @@ use solana_sdk::{
 };
 use swig_interface::{
     swig, AddAuthorityInstruction, AuthorityConfig, ClientAction, CreateInstruction,
-    CreateSubAccountInstruction, SubAccountSignInstruction, ToggleSubAccountInstruction,
-    WithdrawFromSubAccountInstruction,
+    CreateSubAccountInstruction, RemoveAuthorityInstruction, SetRentClaimerV1Instruction,
+    SubAccountSignInstruction, ToggleSubAccountInstruction, UpdateAuthorityData,
+    UpdateAuthorityInstruction, WithdrawFromSubAccountInstruction,
 };
 use swig_state::{
     action::{all::All, manage_authority::ManageAuthority, sub_account::SubAccount},
@@ -100,6 +101,146 @@ pub fn add_authority_with_ed25519_root<'a>(
         .svm
         .send_transaction(tx)
         .map_err(|e| anyhow::anyhow!("Failed to send transaction {:?}", e))?;
+    Ok(bench)
+}
+
+pub fn set_rent_claimer_with_ed25519(
+    context: &mut SwigTestContext,
+    swig_pubkey: &Pubkey,
+    authority: &Keypair,
+    role_id: u32,
+    rent_claimer: Pubkey,
+) -> anyhow::Result<TransactionMetadata> {
+    context.svm.expire_blockhash();
+    let set_ix = SetRentClaimerV1Instruction::new_with_ed25519_authority(
+        *swig_pubkey,
+        context.default_payer.pubkey(),
+        authority.pubkey(),
+        role_id,
+        rent_claimer.to_bytes(),
+    )?;
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), set_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )?;
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[
+            context.default_payer.insecure_clone(),
+            authority.insecure_clone(),
+        ],
+    )?;
+    let bench = context
+        .svm
+        .send_transaction(tx)
+        .map_err(|e| anyhow::anyhow!("Failed to set rent claimer {:?}", e))?;
+    Ok(bench)
+}
+
+/// Removes an authority using the Ed25519 root authority (role 0) as the acting
+/// authority. Drives the `remove_authority_v1` realloc (shrink) path.
+pub fn remove_authority_with_ed25519_root(
+    context: &mut SwigTestContext,
+    swig_pubkey: &Pubkey,
+    acting_authority: &Keypair,
+    authority_to_remove_id: u32,
+) -> anyhow::Result<TransactionMetadata> {
+    context.svm.expire_blockhash();
+    let payer_pubkey = context.default_payer.pubkey();
+    let swig_account = context
+        .svm
+        .get_account(swig_pubkey)
+        .ok_or(anyhow::anyhow!("Swig account not found"))?;
+    let swig = SwigWithRoles::from_bytes(&swig_account.data)
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize swig {:?}", e))?;
+    let acting_role_id = swig
+        .lookup_role_id(acting_authority.pubkey().as_ref())
+        .map_err(|e| anyhow::anyhow!("Failed to lookup role id {:?}", e))?
+        .unwrap();
+
+    let remove_ix = RemoveAuthorityInstruction::new_with_ed25519_authority(
+        *swig_pubkey,
+        payer_pubkey,
+        acting_authority.pubkey(),
+        acting_role_id,
+        authority_to_remove_id,
+    )?;
+    let msg = v0::Message::try_compile(
+        &payer_pubkey,
+        &[
+            ComputeBudgetInstruction::set_compute_unit_limit(10_000_000),
+            remove_ix,
+        ],
+        &[],
+        context.svm.latest_blockhash(),
+    )?;
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[
+            context.default_payer.insecure_clone(),
+            acting_authority.insecure_clone(),
+        ],
+    )?;
+    let bench = context
+        .svm
+        .send_transaction(tx)
+        .map_err(|e| anyhow::anyhow!("Failed to remove authority {:?}", e))?;
+    Ok(bench)
+}
+
+/// Replaces an authority's actions using the Ed25519 root authority (role 0) as
+/// the acting authority. Drives the `update_authority_v1` realloc (grow/shrink)
+/// path depending on the relative action sizes.
+pub fn update_authority_replace_with_ed25519_root(
+    context: &mut SwigTestContext,
+    swig_pubkey: &Pubkey,
+    acting_authority: &Keypair,
+    authority_to_update_id: u32,
+    new_actions: Vec<ClientAction>,
+) -> anyhow::Result<TransactionMetadata> {
+    context.svm.expire_blockhash();
+    let payer_pubkey = context.default_payer.pubkey();
+    let swig_account = context
+        .svm
+        .get_account(swig_pubkey)
+        .ok_or(anyhow::anyhow!("Swig account not found"))?;
+    let swig = SwigWithRoles::from_bytes(&swig_account.data)
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize swig {:?}", e))?;
+    let acting_role_id = swig
+        .lookup_role_id(acting_authority.pubkey().as_ref())
+        .map_err(|e| anyhow::anyhow!("Failed to lookup role id {:?}", e))?
+        .unwrap();
+
+    let update_ix = UpdateAuthorityInstruction::new_with_ed25519_authority(
+        *swig_pubkey,
+        payer_pubkey,
+        acting_authority.pubkey(),
+        acting_role_id,
+        authority_to_update_id,
+        UpdateAuthorityData::ReplaceAll(new_actions),
+    )?;
+    let msg = v0::Message::try_compile(
+        &payer_pubkey,
+        &[
+            ComputeBudgetInstruction::set_compute_unit_limit(10_000_000),
+            update_ix,
+        ],
+        &[],
+        context.svm.latest_blockhash(),
+    )?;
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[
+            context.default_payer.insecure_clone(),
+            acting_authority.insecure_clone(),
+        ],
+    )?;
+    let bench = context
+        .svm
+        .send_transaction(tx)
+        .map_err(|e| anyhow::anyhow!("Failed to update authority {:?}", e))?;
     Ok(bench)
 }
 

--- a/program/tests/rent_claimer_matrix_test.rs
+++ b/program/tests/rent_claimer_matrix_test.rs
@@ -1,0 +1,1226 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! Edge-case matrix for the immutable rent-claimer tail feature.
+//!
+//! Focus areas (per the design doc):
+//!   * Changing swig sizes — `add` / `remove` / `update` authority must preserve
+//!     the 40-byte tail across every realloc (grow + shrink).
+//!   * Rent-claimer combinations — set semantics, the permission gate, the
+//!     close-path destination pin, rent accounting, and backward compatibility.
+//!
+//! Each section is labelled with its matrix id (A/B/C/D/F/G/H/I/K).
+
+mod common;
+
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::{LocalSigner, PrivateKeySigner};
+use common::*;
+use litesvm_token::spl_token;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{
+    AuthorityConfig, ClientAction, CloseSwigV1Instruction, CloseTokenAccountV1Instruction,
+    CreateInstruction, SetRentClaimerV1Instruction,
+};
+use swig_state::{
+    action::{
+        all::All, all_but_manage_authority::AllButManageAuthority,
+        close_swig_authority::CloseSwigAuthority, manage_authority::ManageAuthority,
+        sol_limit::SolLimit,
+    },
+    authority::{secp256k1::Secp256k1Authority, AuthorityType},
+    swig::{swig_account_seeds, swig_wallet_address_seeds, Swig, SwigWithRoles},
+    tail::rent_claimer,
+};
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+/// Reads the configured rent claimer straight from the on-chain account, going
+/// through the same strict tail parser the program uses.
+fn configured_claimer(context: &SwigTestContext, swig_pubkey: &Pubkey) -> Option<[u8; 32]> {
+    let account = context.svm.get_account(swig_pubkey).unwrap();
+    let parts = Swig::split_parts(&account.data).unwrap();
+    rent_claimer::read_strict(parts.tail).unwrap().copied()
+}
+
+/// Number of roles currently stored on the swig.
+fn role_count(context: &SwigTestContext, swig_pubkey: &Pubkey) -> u16 {
+    let account = context.svm.get_account(swig_pubkey).unwrap();
+    SwigWithRoles::from_bytes(&account.data).unwrap().state.roles
+}
+
+fn account_len(context: &SwigTestContext, swig_pubkey: &Pubkey) -> usize {
+    context.svm.get_account(swig_pubkey).unwrap().data.len()
+}
+
+fn lamports_of(context: &SwigTestContext, key: &Pubkey) -> u64 {
+    context.svm.get_account(key).map(|a| a.lamports).unwrap_or(0)
+}
+
+fn wallet_address(swig_pubkey: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(
+        &swig_wallet_address_seeds(&swig_pubkey.to_bytes()),
+        &program_id(),
+    )
+    .0
+}
+
+/// Closes a swig with an Ed25519 authority and returns the transaction result.
+fn close_swig_ed25519(
+    context: &mut SwigTestContext,
+    swig_pubkey: &Pubkey,
+    authority: &Keypair,
+    role_id: u32,
+    destination: &Pubkey,
+) -> Result<litesvm::types::TransactionMetadata, litesvm::types::FailedTransactionMetadata> {
+    let close_ix = CloseSwigV1Instruction::new_with_ed25519_authority(
+        *swig_pubkey,
+        wallet_address(swig_pubkey),
+        authority.pubkey(),
+        *destination,
+        role_id,
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, authority]).unwrap();
+    context.svm.send_transaction(tx)
+}
+
+fn secp256k1_counter(
+    context: &SwigTestContext,
+    swig_pubkey: &Pubkey,
+    wallet: &PrivateKeySigner,
+) -> u32 {
+    let account = context.svm.get_account(swig_pubkey).unwrap();
+    let swig = SwigWithRoles::from_bytes(&account.data).unwrap();
+    let eth_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+    let role_id = swig.lookup_role_id(&eth_pubkey[1..]).unwrap().unwrap();
+    let role = swig.get_role(role_id).unwrap().unwrap();
+    role.authority
+        .as_any()
+        .downcast_ref::<Secp256k1Authority>()
+        .unwrap()
+        .signature_odometer
+}
+
+fn create_test_secp256r1_keypair() -> (openssl::ec::EcKey<openssl::pkey::Private>, [u8; 33]) {
+    use openssl::{
+        bn::BigNumContext,
+        ec::{EcGroup, EcKey, PointConversionForm},
+        nid::Nid,
+    };
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    let signing_key = EcKey::generate(&group).unwrap();
+    let mut ctx = BigNumContext::new().unwrap();
+    let pubkey_bytes = signing_key
+        .public_key()
+        .to_bytes(&group, PointConversionForm::COMPRESSED, &mut ctx)
+        .unwrap();
+    (signing_key, pubkey_bytes.try_into().unwrap())
+}
+
+// ===========================================================================
+// A. SetRentClaimerV1 — core set semantics
+// ===========================================================================
+
+/// A5: setting the claimer to the swig account's own pubkey is allowed (no
+/// special-casing) — first-write-wins still applies.
+#[test_log::test]
+fn a5_set_claimer_to_swig_itself_succeeds() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, swig_pubkey).unwrap();
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(swig_pubkey.to_bytes()));
+}
+
+/// A6: setting the claimer to the acting authority's own pubkey is allowed.
+/// (The §3 attack is only relevant to *mutation*, which v1 forbids.)
+#[test_log::test]
+fn a6_set_claimer_to_acting_authority_succeeds() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, authority.pubkey())
+        .unwrap();
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(authority.pubkey().to_bytes())
+    );
+}
+
+/// A8: an unknown `role_id` must fail and must not write a tail.
+#[test_log::test]
+fn a8_set_with_unknown_role_id_fails() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    // Role 7 does not exist; signing key is the real root.
+    let result =
+        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 7, Keypair::new().pubkey());
+    assert!(result.is_err(), "unknown role_id must fail");
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+}
+
+// ===========================================================================
+// B. Permission gate
+// ===========================================================================
+
+/// B2: a role holding only `CloseSwigAuthority` may perform the one-time set.
+#[test_log::test]
+fn b2_close_swig_authority_can_set() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let closer = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: closer.pubkey().as_ref(),
+        },
+        vec![ClientAction::CloseSwigAuthority(CloseSwigAuthority {})],
+    )
+    .unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &closer, 1, claimer).unwrap();
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+}
+
+/// B3: `ManageAuthority` alone is explicitly insufficient to set.
+#[test_log::test]
+fn b3_manage_authority_cannot_set() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let manager = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: manager.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    let result =
+        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &manager, 1, Keypair::new().pubkey());
+    assert!(result.is_err(), "ManageAuthority must not be able to set the rent claimer");
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+}
+
+/// B4: pin the behavior of `AllButManageAuthority`. The doc only authorizes
+/// `All` and `CloseSwigAuthority`, and the handler checks exactly those two, so
+/// `AllButManageAuthority` must be rejected.
+#[test_log::test]
+fn b4_all_but_manage_authority_cannot_set() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let broad = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: broad.pubkey().as_ref(),
+        },
+        vec![ClientAction::AllButManageAuthority(AllButManageAuthority {})],
+    )
+    .unwrap();
+
+    let result =
+        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &broad, 1, Keypair::new().pubkey());
+    assert!(
+        result.is_err(),
+        "AllButManageAuthority is not one of the two authorized set permissions"
+    );
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+}
+
+// ===========================================================================
+// C. Authority-type coverage for set
+// ===========================================================================
+
+/// C3: a Secp256k1 root authority can set the rent claimer.
+#[test_log::test]
+fn c3_secp256k1_authority_can_set() {
+    let mut context = setup_test_context().unwrap();
+    let wallet = LocalSigner::random();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_secp256k1(&mut context, &wallet, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    let next_counter = secp256k1_counter(&context, &swig_pubkey, &wallet) + 1;
+    let signing_fn = |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        wallet.sign_hash_sync(&B256::from(hash)).unwrap().as_bytes()
+    };
+
+    let set_ix = SetRentClaimerV1Instruction::new_with_secp256k1_authority(
+        swig_pubkey,
+        context.default_payer.pubkey(),
+        signing_fn,
+        0, // current_slot
+        next_counter,
+        0, // role_id
+        claimer.to_bytes(),
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), set_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(result.is_ok(), "secp256k1 set failed: {:?}", result.err());
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+}
+
+/// C6: a Secp256r1 root authority can set the rent claimer.
+#[test_log::test]
+fn c6_secp256r1_authority_can_set() {
+    let mut context = setup_test_context().unwrap();
+    let (signing_key, public_key) = create_test_secp256r1_keypair();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_secp256r1(&mut context, &public_key, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    let authority_fn = |message_hash: &[u8]| -> [u8; 64] {
+        use solana_secp256r1_program::sign_message;
+        sign_message(message_hash, &signing_key.private_key_to_der().unwrap()).unwrap()
+    };
+
+    let set_ixs = SetRentClaimerV1Instruction::new_with_secp256r1_authority(
+        swig_pubkey,
+        context.default_payer.pubkey(),
+        authority_fn,
+        0, // current_slot
+        1, // counter
+        0, // role_id
+        claimer.to_bytes(),
+        &public_key,
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                set_ixs[0].clone(),
+                set_ixs[1].clone(),
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(result.is_ok(), "secp256r1 set failed: {:?}", result.err());
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+}
+
+// ===========================================================================
+// D. Changing swig sizes — tail preservation across realloc
+// ===========================================================================
+
+/// D1: adding an authority (grow) preserves a previously-set tail.
+#[test_log::test]
+fn d1_add_authority_preserves_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
+    let len_before = account_len(&context, &swig_pubkey);
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: Keypair::new().pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(role_count(&context, &swig_pubkey), 2);
+    assert!(account_len(&context, &swig_pubkey) > len_before, "account should have grown");
+    // Tail must remain a clean single entry — read_strict would error otherwise.
+}
+
+/// D2: adding an authority when there is NO tail must not synthesize one.
+#[test_log::test]
+fn d2_add_authority_without_tail_creates_no_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: Keypair::new().pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+}
+
+/// D3: adding authorities of different types (different role sizes) preserves
+/// the tail.
+#[test_log::test]
+fn d3_add_mixed_authority_types_preserves_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
+
+    // Ed25519 authority (32-byte authority).
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: Keypair::new().pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+
+    // Secp256k1 authority (64-byte authority) — a different role size.
+    let secp = LocalSigner::random();
+    let eth_pubkey = secp
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256k1,
+            authority: &eth_pubkey[1..],
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 5 })],
+    )
+    .unwrap();
+
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(role_count(&context, &swig_pubkey), 3);
+}
+
+/// D5: multiple sequential grows keep the tail intact after every realloc.
+#[test_log::test]
+fn d5_multiple_adds_preserve_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
+
+    for i in 0..4u64 {
+        add_authority_with_ed25519_root(
+            &mut context,
+            &swig_pubkey,
+            &root,
+            AuthorityConfig {
+                authority_type: AuthorityType::Ed25519,
+                authority: Keypair::new().pubkey().as_ref(),
+            },
+            vec![ClientAction::SolLimit(SolLimit { amount: i + 1 })],
+        )
+        .unwrap();
+        assert_eq!(
+            configured_claimer(&context, &swig_pubkey),
+            Some(claimer.to_bytes()),
+            "tail corrupted after add #{i}"
+        );
+    }
+    assert_eq!(role_count(&context, &swig_pubkey), 5);
+}
+
+/// D6: after growing the roles, the close path still enforces the pinned tail.
+#[test_log::test]
+fn d6_close_enforced_after_grow() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer.pubkey()).unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: Keypair::new().pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+
+    // Wrong destination still rejected.
+    let wrong = Keypair::new().pubkey();
+    assert!(
+        close_swig_ed25519(&mut context, &swig_pubkey, &root, 0, &wrong).is_err(),
+        "close to wrong destination must fail even after a grow"
+    );
+    // Correct destination succeeds.
+    assert!(
+        close_swig_ed25519(&mut context, &swig_pubkey, &root, 0, &claimer.pubkey()).is_ok(),
+        "close to pinned claimer must succeed after a grow"
+    );
+}
+
+/// D7: removing a middle role (forces a shift of everything after it) must not
+/// corrupt the tail.
+#[test_log::test]
+fn d7_remove_middle_role_preserves_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let middle = Keypair::new();
+    let last = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: middle.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: last.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 2 })],
+    )
+    .unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
+    let len_before = account_len(&context, &swig_pubkey);
+
+    // Remove the middle role (id 1).
+    remove_authority_with_ed25519_root(&mut context, &swig_pubkey, &root, 1).unwrap();
+
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes()),
+        "tail corrupted by middle-role removal"
+    );
+    assert_eq!(role_count(&context, &swig_pubkey), 2);
+    assert!(account_len(&context, &swig_pubkey) < len_before, "account should have shrunk");
+}
+
+/// D8: removing the last role preserves the tail.
+#[test_log::test]
+fn d8_remove_last_role_preserves_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: Keypair::new().pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
+    remove_authority_with_ed25519_root(&mut context, &swig_pubkey, &root, 1).unwrap();
+
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(role_count(&context, &swig_pubkey), 1);
+}
+
+/// D10: removing an authority when there is no tail creates none.
+#[test_log::test]
+fn d10_remove_authority_without_tail_creates_no_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: Keypair::new().pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+    remove_authority_with_ed25519_root(&mut context, &swig_pubkey, &root, 1).unwrap();
+
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+    assert_eq!(role_count(&context, &swig_pubkey), 1);
+}
+
+/// D12 + D13: updating a role's actions to grow then shrink preserves the tail
+/// across the two-phase realloc in both directions.
+#[test_log::test]
+fn d12_update_authority_grow_then_shrink_preserves_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let target = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: target.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
+    let len_one_action = account_len(&context, &swig_pubkey);
+
+    // Grow: add a second action to role 1.
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        1,
+        vec![
+            ClientAction::ManageAuthority(ManageAuthority {}),
+            ClientAction::SolLimit(SolLimit { amount: 9 }),
+        ],
+    )
+    .unwrap();
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes()),
+        "tail corrupted by update-grow"
+    );
+    assert!(account_len(&context, &swig_pubkey) > len_one_action, "update should have grown");
+
+    // Shrink: drop back to a single action.
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        1,
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes()),
+        "tail corrupted by update-shrink"
+    );
+    assert_eq!(account_len(&context, &swig_pubkey), len_one_action);
+}
+
+/// D18: a previously-set claimer survives a full churn of grow → remove → update
+/// and remains immutable (a second set still fails).
+#[test_log::test]
+fn d18_claimer_survives_full_role_churn() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let a = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
+
+    // grow
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: a.pubkey().as_ref(),
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+    // update (grow)
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        1,
+        vec![
+            ClientAction::ManageAuthority(ManageAuthority {}),
+            ClientAction::SolLimit(SolLimit { amount: 3 }),
+        ],
+    )
+    .unwrap();
+    // shrink (remove)
+    remove_authority_with_ed25519_root(&mut context, &swig_pubkey, &root, 1).unwrap();
+
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+
+    // D19: still immutable after all the reallocs.
+    let second = set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        0,
+        Keypair::new().pubkey(),
+    );
+    assert!(second.is_err(), "claimer must stay immutable through role churn");
+}
+
+/// D17: setting the claimer AFTER growing the roles writes the tail at the
+/// correct (post-grow) end of the account.
+#[test_log::test]
+fn d17_add_then_set_writes_tail_at_correct_offset() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: Keypair::new().pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(role_count(&context, &swig_pubkey), 2);
+}
+
+// ===========================================================================
+// F. Close enforcement — CloseSwigV1
+// ===========================================================================
+
+/// F1: an unset wallet closes to any destination (today's behavior).
+#[test_log::test]
+fn f1_unset_close_allows_any_destination() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let destination = Keypair::new().pubkey();
+    let result = close_swig_ed25519(&mut context, &swig_pubkey, &root, 0, &destination);
+    assert!(result.is_ok(), "unset wallet should close to any destination: {:?}", result.err());
+}
+
+/// F4: a delegated `CloseSwigAuthority` role can wind the wallet down, but only
+/// to the pinned claimer (the core §9.3 security property).
+#[test_log::test]
+fn f4_delegated_close_authority_must_use_pinned_destination() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let closer = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer.pubkey()).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: closer.pubkey().as_ref(),
+        },
+        vec![ClientAction::CloseSwigAuthority(CloseSwigAuthority {})],
+    )
+    .unwrap();
+
+    // F5-style: delegated authority cannot redirect rent to itself.
+    assert!(
+        close_swig_ed25519(&mut context, &swig_pubkey, &closer, 1, &closer.pubkey()).is_err(),
+        "delegated close authority must not redirect rent"
+    );
+    // But it can still execute the close to the pinned claimer.
+    let claimer_before = lamports_of(&context, &claimer.pubkey());
+    assert!(
+        close_swig_ed25519(&mut context, &swig_pubkey, &closer, 1, &claimer.pubkey()).is_ok(),
+        "delegated close authority should close to the pinned claimer"
+    );
+    assert!(lamports_of(&context, &claimer.pubkey()) > claimer_before);
+}
+
+// ===========================================================================
+// G. Close enforcement — CloseTokenAccountV1
+// ===========================================================================
+
+/// G3: an unset wallet closes token accounts to any destination.
+#[test_log::test]
+fn g3_unset_token_close_allows_any_destination() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+    let swig_wallet_address = wallet_address(&swig_pubkey);
+
+    let mint = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let ata = setup_ata(&mut context.svm, &mint, &swig_wallet_address, &context.default_payer).unwrap();
+
+    let destination = Keypair::new().pubkey();
+    let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        root.pubkey(),
+        destination,
+        spl_token::ID,
+        vec![ata],
+        0,
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &root]).unwrap();
+    assert!(context.svm.send_transaction(tx).is_ok(), "unset token close to any dest should succeed");
+}
+
+/// G4 + G5: closing multiple token accounts in one ix routes to the pinned
+/// claimer (G4), and a wrong destination rejects them all (G5).
+#[test_log::test]
+fn g4_g5_multiple_token_accounts_respect_pin() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+    let swig_wallet_address = wallet_address(&swig_pubkey);
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer.pubkey()).unwrap();
+
+    let mint1 = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let mint2 = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let ata1 = setup_ata(&mut context.svm, &mint1, &swig_wallet_address, &context.default_payer).unwrap();
+    let ata2 = setup_ata(&mut context.svm, &mint2, &swig_wallet_address, &context.default_payer).unwrap();
+    let total_rent = lamports_of(&context, &ata1) + lamports_of(&context, &ata2);
+
+    // G5: wrong destination rejects all.
+    let wrong = Keypair::new().pubkey();
+    let close_wrong = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        root.pubkey(),
+        wrong,
+        spl_token::ID,
+        vec![ata1, ata2],
+        0,
+    )
+    .unwrap();
+    let msg = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_wrong],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(msg, &[&context.default_payer, &root]).unwrap();
+    assert!(context.svm.send_transaction(tx).is_err(), "wrong dest must reject all token closes");
+    // Nothing should have moved.
+    assert!(context.svm.get_account(&ata1).map(|a| a.lamports).unwrap_or(0) > 0);
+
+    // G4: correct destination routes all rent to the claimer.
+    let claimer_before = lamports_of(&context, &claimer.pubkey());
+    let close_ok = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        swig_wallet_address,
+        root.pubkey(),
+        claimer.pubkey(),
+        spl_token::ID,
+        vec![ata1, ata2],
+        0,
+    )
+    .unwrap();
+    let msg = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ok],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(msg, &[&context.default_payer, &root]).unwrap();
+    assert!(context.svm.send_transaction(tx).is_ok(), "pinned dest should close all token accounts");
+    assert_eq!(
+        lamports_of(&context, &claimer.pubkey()).saturating_sub(claimer_before),
+        total_rent,
+        "claimer should receive rent from both token accounts"
+    );
+}
+
+// ===========================================================================
+// H. Rent / lamport accounting
+// ===========================================================================
+
+/// H1: setting the claimer grows the account by exactly the tail entry and
+/// leaves it rent-exempt at the new size.
+#[test_log::test]
+fn h1_set_grows_by_entry_len_and_stays_rent_exempt() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+    let len_before = account_len(&context, &swig_pubkey);
+
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, Keypair::new().pubkey())
+        .unwrap();
+
+    let len_after = account_len(&context, &swig_pubkey);
+    assert_eq!(len_after - len_before, rent_claimer::ENTRY_LEN, "should grow by exactly 40 bytes");
+    assert_eq!(
+        lamports_of(&context, &swig_pubkey),
+        context.svm.minimum_balance_for_rent_exemption(len_after),
+        "swig must be rent-exempt at the new size"
+    );
+}
+
+/// H2: if the payer cannot fund the +40 bytes of rent exemption, the set fails
+/// and no tail is written.
+#[test_log::test]
+fn h2_insufficient_payer_fails_cleanly() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    // A payer with enough for the tx fee but not the rent-exemption delta.
+    let poor_payer = Keypair::new();
+    context.svm.airdrop(&poor_payer.pubkey(), 100_000).unwrap();
+
+    let set_ix = SetRentClaimerV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        poor_payer.pubkey(),
+        root.pubkey(),
+        0,
+        Keypair::new().pubkey().to_bytes(),
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &poor_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), set_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&poor_payer, &root]).unwrap();
+    assert!(context.svm.send_transaction(tx).is_err(), "underfunded payer must fail the set");
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+}
+
+/// H4: the +40 bytes of rent is reclaimed by the pinned claimer on close.
+#[test_log::test]
+fn h4_tail_rent_reclaimed_by_claimer_on_close() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+    let swig_wallet_address = wallet_address(&swig_pubkey);
+
+    let claimer = Keypair::new();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer.pubkey()).unwrap();
+
+    let swig_lamports_before = lamports_of(&context, &swig_pubkey);
+    let wallet_lamports_before = lamports_of(&context, &swig_wallet_address);
+    let claimer_before = lamports_of(&context, &claimer.pubkey());
+
+    assert!(close_swig_ed25519(&mut context, &swig_pubkey, &root, 0, &claimer.pubkey()).is_ok());
+
+    let closed_rent = context.svm.minimum_balance_for_rent_exemption(1);
+    let expected = wallet_lamports_before + swig_lamports_before.saturating_sub(closed_rent);
+    assert_eq!(
+        lamports_of(&context, &claimer.pubkey()).saturating_sub(claimer_before),
+        expected,
+        "claimer should reclaim the swig rent including the +40 byte tail"
+    );
+}
+
+// ===========================================================================
+// I. Backward compatibility
+// ===========================================================================
+
+/// I1: a wallet that never opts in behaves identically across its whole
+/// lifecycle and never grows a tail.
+#[test_log::test]
+fn i1_never_opt_in_lifecycle_has_no_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let extra = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: extra.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+
+    remove_authority_with_ed25519_root(&mut context, &swig_pubkey, &root, 1).unwrap();
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+
+    let destination = Keypair::new().pubkey();
+    assert!(
+        close_swig_ed25519(&mut context, &swig_pubkey, &root, 0, &destination).is_ok(),
+        "never-opted-in wallet should close to any destination"
+    );
+}
+
+// ===========================================================================
+// K. Lifecycle / first-write race
+// ===========================================================================
+
+/// K1: bundling `CreateV1 + SetRentClaimerV1` in one transaction sets the
+/// claimer atomically — the wallet is never observable in an unset state.
+#[test_log::test]
+fn k1_bundled_create_and_set_is_atomic() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let payer = context.default_payer.pubkey();
+
+    let (swig_pubkey, swig_bump) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
+    let (swig_wallet_address, wallet_bump) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig_pubkey.as_ref()), &program_id());
+
+    let create_ix = CreateInstruction::new(
+        swig_pubkey,
+        swig_bump,
+        payer,
+        swig_wallet_address,
+        wallet_bump,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::All(All {})],
+        id,
+    )
+    .unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    let set_ix = SetRentClaimerV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        payer,
+        authority.pubkey(),
+        0,
+        claimer.to_bytes(),
+    )
+    .unwrap();
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                create_ix,
+                set_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(result.is_ok(), "bundled create+set failed: {:?}", result.err());
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+}
+
+/// K2: with `CreateV1` alone, a different authority can win the first-write
+/// race; the original authority's later set then fails (immutable).
+#[test_log::test]
+fn k2_first_write_wins() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let other = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    // A second All authority is added.
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: other.pubkey().as_ref(),
+        },
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    // `other` wins the race.
+    let other_claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &other, 1, other_claimer).unwrap();
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(other_claimer.to_bytes()));
+
+    // root loses — the value is immutable.
+    let root_attempt =
+        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, Keypair::new().pubkey());
+    assert!(root_attempt.is_err(), "first write wins; later set must fail");
+    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(other_claimer.to_bytes()));
+}
+
+/// K3: two `SetRentClaimerV1` in a single transaction — the second fails, so the
+/// whole transaction is rejected and no tail is written.
+#[test_log::test]
+fn k3_two_sets_in_one_tx_fails() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+    let payer = context.default_payer.pubkey();
+
+    let set_ix_1 = SetRentClaimerV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        payer,
+        root.pubkey(),
+        0,
+        Keypair::new().pubkey().to_bytes(),
+    )
+    .unwrap();
+    let set_ix_2 = SetRentClaimerV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        payer,
+        root.pubkey(),
+        0,
+        Keypair::new().pubkey().to_bytes(),
+    )
+    .unwrap();
+
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                set_ix_1,
+                set_ix_2,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &root]).unwrap();
+    assert!(context.svm.send_transaction(tx).is_err(), "two sets in one tx must fail");
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+}

--- a/program/tests/rent_claimer_roles_invariant_test.rs
+++ b/program/tests/rent_claimer_roles_invariant_test.rs
@@ -1,0 +1,492 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! Roles ⟂ tail invariance.
+//!
+//! These tests assert that the presence or absence of the rent-claimer tail does
+//! NOT affect the roles in any way, and that the roles keep working across every
+//! mutation while the rent claimer (when set) is preserved byte-for-byte.
+//!
+//! Two complementary angles:
+//!   * **Differential** — run the *same* role operations on two wallets that share
+//!     identical authorities; one carries a tail, one does not. The roles region
+//!     must come out byte-for-byte identical.
+//!   * **Functional** — after mutating roles on a tailed wallet, the roles still
+//!     authenticate and authorize real work (adding authorities, and a SignV2
+//!     SOL spend), and the claimer value never changes.
+
+mod common;
+
+use common::*;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{AuthorityConfig, ClientAction, SignV2Instruction};
+use swig_state::{
+    action::{all::All, manage_authority::ManageAuthority, sol_limit::SolLimit},
+    authority::AuthorityType,
+    swig::{swig_wallet_address_seeds, Swig, SwigWithRoles},
+    tail::rent_claimer,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn account_data(context: &SwigTestContext, swig: &Pubkey) -> Vec<u8> {
+    context.svm.get_account(swig).unwrap().data
+}
+
+/// The roles region only (header + tail excluded). This is what must be
+/// invariant to the tail.
+fn roles_bytes(context: &SwigTestContext, swig: &Pubkey) -> Vec<u8> {
+    let data = account_data(context, swig);
+    Swig::split_parts(&data).unwrap().roles.to_vec()
+}
+
+fn configured_claimer(context: &SwigTestContext, swig: &Pubkey) -> Option<[u8; 32]> {
+    let data = account_data(context, swig);
+    rent_claimer::read_strict(Swig::split_parts(&data).unwrap().tail)
+        .unwrap()
+        .copied()
+}
+
+fn role_count(context: &SwigTestContext, swig: &Pubkey) -> u16 {
+    let data = account_data(context, swig);
+    SwigWithRoles::from_bytes(&data).unwrap().state.roles
+}
+
+fn has_role_for(context: &SwigTestContext, swig: &Pubkey, authority: &Pubkey) -> bool {
+    let data = account_data(context, swig);
+    SwigWithRoles::from_bytes(&data)
+        .unwrap()
+        .lookup_role_id(authority.as_ref())
+        .unwrap()
+        .is_some()
+}
+
+fn ed_config(authority: &Pubkey) -> AuthorityConfig<'_> {
+    AuthorityConfig {
+        authority_type: AuthorityType::Ed25519,
+        authority: authority.as_ref(),
+    }
+}
+
+/// Creates a pair of swigs sharing the same root keypair — one plain, one with a
+/// rent-claimer tail set. Returns `(plain, tailed)`.
+fn create_pair(
+    context: &mut SwigTestContext,
+    root: &Keypair,
+    claimer: &Pubkey,
+) -> (Pubkey, Pubkey) {
+    let (plain, _) = create_swig_ed25519(context, root, rand::random::<[u8; 32]>()).unwrap();
+    let (tailed, _) = create_swig_ed25519(context, root, rand::random::<[u8; 32]>()).unwrap();
+    set_rent_claimer_with_ed25519(context, &tailed, root, 0, *claimer).unwrap();
+    (plain, tailed)
+}
+
+// ===========================================================================
+// Differential — roles region must be byte-identical with vs without a tail
+// ===========================================================================
+
+/// Adding the same authorities to a plain wallet and to a tailed wallet yields an
+/// identical roles region. The tail neither shifts nor perturbs role bytes.
+#[test_log::test]
+fn roles_identical_after_add_regardless_of_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let claimer = Keypair::new().pubkey();
+    let (plain, tailed) = create_pair(&mut context, &root, &claimer);
+
+    // Baseline: role 0 only — already identical.
+    assert_eq!(roles_bytes(&context, &plain), roles_bytes(&context, &tailed));
+
+    // Same authority keypairs + same actions applied to BOTH wallets.
+    // (`ClientAction` isn't `Clone`, so build a fresh vec per call.)
+    let extra = [Keypair::new(), Keypair::new(), Keypair::new()];
+    for (i, kp) in extra.iter().enumerate() {
+        let amount = (i as u64) + 1;
+        let mk = || vec![ClientAction::SolLimit(SolLimit { amount })];
+        add_authority_with_ed25519_root(&mut context, &plain, &root, ed_config(&kp.pubkey()), mk())
+            .unwrap();
+        add_authority_with_ed25519_root(&mut context, &tailed, &root, ed_config(&kp.pubkey()), mk())
+            .unwrap();
+
+        assert_eq!(
+            roles_bytes(&context, &plain),
+            roles_bytes(&context, &tailed),
+            "roles diverged after add #{i}"
+        );
+    }
+
+    // The tail is unaffected the whole time; the plain wallet never grew one.
+    assert_eq!(configured_claimer(&context, &tailed), Some(claimer.to_bytes()));
+    assert_eq!(configured_claimer(&context, &plain), None);
+}
+
+/// Removing a middle role shifts everything after it. The resulting roles region
+/// is identical whether or not a tail sits past the roles.
+#[test_log::test]
+fn roles_identical_after_remove_middle_regardless_of_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let claimer = Keypair::new().pubkey();
+    let (plain, tailed) = create_pair(&mut context, &root, &claimer);
+
+    let a = Keypair::new();
+    let b = Keypair::new();
+    let c = Keypair::new();
+    for kp in [&a, &b, &c] {
+        let mk = || vec![ClientAction::SolLimit(SolLimit { amount: 7 })];
+        add_authority_with_ed25519_root(&mut context, &plain, &root, ed_config(&kp.pubkey()), mk())
+            .unwrap();
+        add_authority_with_ed25519_root(&mut context, &tailed, &root, ed_config(&kp.pubkey()), mk())
+            .unwrap();
+    }
+    assert_eq!(roles_bytes(&context, &plain), roles_bytes(&context, &tailed));
+
+    // Remove the middle role (id 2 = `b`) on both.
+    remove_authority_with_ed25519_root(&mut context, &plain, &root, 2).unwrap();
+    remove_authority_with_ed25519_root(&mut context, &tailed, &root, 2).unwrap();
+
+    assert_eq!(
+        roles_bytes(&context, &plain),
+        roles_bytes(&context, &tailed),
+        "roles diverged after middle-role removal"
+    );
+    assert_eq!(configured_claimer(&context, &tailed), Some(claimer.to_bytes()));
+    // `b` is gone, `a` and `c` remain — on both wallets identically.
+    assert!(!has_role_for(&context, &tailed, &b.pubkey()));
+    assert!(has_role_for(&context, &tailed, &a.pubkey()));
+    assert!(has_role_for(&context, &tailed, &c.pubkey()));
+}
+
+/// Updating a role's actions (grow then shrink) produces an identical roles
+/// region with or without a tail.
+#[test_log::test]
+fn roles_identical_after_update_regardless_of_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let claimer = Keypair::new().pubkey();
+    let (plain, tailed) = create_pair(&mut context, &root, &claimer);
+
+    let target = Keypair::new();
+    let mk_init = || vec![ClientAction::ManageAuthority(ManageAuthority {})];
+    add_authority_with_ed25519_root(&mut context, &plain, &root, ed_config(&target.pubkey()), mk_init())
+        .unwrap();
+    add_authority_with_ed25519_root(&mut context, &tailed, &root, ed_config(&target.pubkey()), mk_init())
+        .unwrap();
+
+    // Grow.
+    let mk_grown = || {
+        vec![
+            ClientAction::ManageAuthority(ManageAuthority {}),
+            ClientAction::SolLimit(SolLimit { amount: 42 }),
+        ]
+    };
+    update_authority_replace_with_ed25519_root(&mut context, &plain, &root, 1, mk_grown()).unwrap();
+    update_authority_replace_with_ed25519_root(&mut context, &tailed, &root, 1, mk_grown()).unwrap();
+    assert_eq!(
+        roles_bytes(&context, &plain),
+        roles_bytes(&context, &tailed),
+        "roles diverged after update-grow"
+    );
+
+    // Shrink.
+    let mk_shrunk = || vec![ClientAction::SolLimit(SolLimit { amount: 42 })];
+    update_authority_replace_with_ed25519_root(&mut context, &plain, &root, 1, mk_shrunk()).unwrap();
+    update_authority_replace_with_ed25519_root(&mut context, &tailed, &root, 1, mk_shrunk()).unwrap();
+    assert_eq!(
+        roles_bytes(&context, &plain),
+        roles_bytes(&context, &tailed),
+        "roles diverged after update-shrink"
+    );
+    assert_eq!(configured_claimer(&context, &tailed), Some(claimer.to_bytes()));
+}
+
+// ===========================================================================
+// Functional — roles keep working with a tail present; claimer stays put
+// ===========================================================================
+
+/// An authority added alongside a tail is fully functional: it can itself manage
+/// authorities. The claimer is untouched by that nested mutation.
+#[test_log::test]
+fn added_role_is_functional_with_tail_present() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let manager = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig, &root, 0, claimer).unwrap();
+
+    // Add an All authority (role 1) while the tail exists.
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed_config(&manager.pubkey()),
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    // The newly added role exercises its own authority: it adds role 2.
+    let downstream = Keypair::new();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &manager,
+        ed_config(&downstream.pubkey()),
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+
+    assert_eq!(role_count(&context, &swig), 3);
+    assert!(has_role_for(&context, &swig, &downstream.pubkey()));
+    assert_eq!(configured_claimer(&context, &swig), Some(claimer.to_bytes()));
+}
+
+/// After removing a middle role on a tailed wallet, the surviving roles keep
+/// their authority/permissions and still work.
+#[test_log::test]
+fn surviving_roles_functional_after_remove_with_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let mid = Keypair::new();
+    let survivor = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig, &root, 0, claimer).unwrap();
+
+    // role 1 = mid (All), role 2 = survivor (All)
+    add_authority_with_ed25519_root(&mut context, &swig, &root, ed_config(&mid.pubkey()), vec![ClientAction::All(All {})]).unwrap();
+    add_authority_with_ed25519_root(&mut context, &swig, &root, ed_config(&survivor.pubkey()), vec![ClientAction::All(All {})]).unwrap();
+
+    // Remove the middle role.
+    remove_authority_with_ed25519_root(&mut context, &swig, &root, 1).unwrap();
+    assert!(!has_role_for(&context, &swig, &mid.pubkey()));
+
+    // `survivor` still authenticates + authorizes: it adds a new authority.
+    let downstream = Keypair::new();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &survivor,
+        ed_config(&downstream.pubkey()),
+        vec![ClientAction::SolLimit(SolLimit { amount: 3 })],
+    )
+    .unwrap();
+
+    assert!(has_role_for(&context, &swig, &downstream.pubkey()));
+    assert_eq!(configured_claimer(&context, &swig), Some(claimer.to_bytes()));
+}
+
+/// An `update` to a role's permissions takes real effect even with a tail set:
+/// a SolLimit-only role cannot manage authorities until updated to gain
+/// ManageAuthority — and the claimer is preserved throughout.
+#[test_log::test]
+fn update_changes_effective_permissions_with_tail() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let worker = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig, &root, 0, claimer).unwrap();
+
+    // role 1 = worker with only SolLimit — cannot manage authorities.
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed_config(&worker.pubkey()),
+        vec![ClientAction::SolLimit(SolLimit { amount: 5 })],
+    )
+    .unwrap();
+
+    let before = add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &worker,
+        ed_config(&Keypair::new().pubkey()),
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    );
+    assert!(before.is_err(), "SolLimit-only role must not manage authorities");
+
+    // Grant ManageAuthority via update (root acting).
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        1,
+        vec![
+            ClientAction::SolLimit(SolLimit { amount: 5 }),
+            ClientAction::ManageAuthority(ManageAuthority {}),
+        ],
+    )
+    .unwrap();
+
+    // Now the same operation succeeds.
+    let added = Keypair::new();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &worker,
+        ed_config(&added.pubkey()),
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+    assert!(has_role_for(&context, &swig, &added.pubkey()));
+    assert_eq!(configured_claimer(&context, &swig), Some(claimer.to_bytes()));
+}
+
+/// A role can actually SPEND from the wallet (SignV2 SOL transfer) with the tail
+/// present — both the root role and a later-added role.
+#[test_log::test]
+fn roles_can_sign_v2_spend_with_tail_present() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    context.svm.airdrop(&root.pubkey(), 20_000_000_000).unwrap();
+    let (swig, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig, &root, 0, claimer).unwrap();
+
+    // Add an All authority that we'll also spend with.
+    let spender = Keypair::new();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed_config(&spender.pubkey()),
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    // Fund the wallet PDA.
+    let fund_ix = solana_system_interface::instruction::transfer(
+        &root.pubkey(),
+        &swig_wallet_address,
+        2_000_000_000,
+    );
+    let fund_msg = v0::Message::try_compile(&root.pubkey(), &[fund_ix], &[], context.svm.latest_blockhash()).unwrap();
+    context
+        .svm
+        .send_transaction(VersionedTransaction::try_new(VersionedMessage::V0(fund_msg), &[&root]).unwrap())
+        .unwrap();
+
+    // Helper closure: spend `amount` via SignV2 using `(authority, role_id)`.
+    let mut spend = |context: &mut SwigTestContext, authority: &Keypair, role_id: u32, amount: u64| {
+        let recipient = Keypair::new().pubkey();
+        let transfer_ix =
+            solana_system_interface::instruction::transfer(&swig_wallet_address, &recipient, amount);
+        let sign_ix =
+            SignV2Instruction::new_ed25519(swig, swig_wallet_address, authority.pubkey(), transfer_ix, role_id)
+                .unwrap();
+        let msg = v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[sign_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap();
+        let tx = VersionedTransaction::try_new(
+            VersionedMessage::V0(msg),
+            &[&context.default_payer, authority],
+        )
+        .unwrap();
+        let result = context.svm.send_transaction(tx);
+        assert!(result.is_ok(), "SignV2 spend failed: {:?}", result.err());
+        (recipient, amount)
+    };
+
+    // Root (role 0) spends.
+    let (r1, a1) = spend(&mut context, &root, 0, 100_000_000);
+    assert_eq!(context.svm.get_account(&r1).map(|a| a.lamports).unwrap_or(0), a1);
+
+    // Added authority (role 1) spends.
+    let (r2, a2) = spend(&mut context, &spender, 1, 150_000_000);
+    assert_eq!(context.svm.get_account(&r2).map(|a| a.lamports).unwrap_or(0), a2);
+
+    // The tail survived all of the signing activity.
+    assert_eq!(configured_claimer(&context, &swig), Some(claimer.to_bytes()));
+}
+
+// ===========================================================================
+// Claimer byte-identity through heavy churn
+// ===========================================================================
+
+/// Through a long sequence of add/update/remove operations, the claimer value is
+/// preserved byte-for-byte (not merely "present").
+#[test_log::test]
+fn claimer_is_byte_identical_through_heavy_churn() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    let expected = Some(claimer.to_bytes());
+    set_rent_claimer_with_ed25519(&mut context, &swig, &root, 0, claimer).unwrap();
+    assert_eq!(configured_claimer(&context, &swig), expected);
+
+    // Add four authorities (roles 1..=4).
+    let kps: Vec<Keypair> = (0..4).map(|_| Keypair::new()).collect();
+    for kp in &kps {
+        add_authority_with_ed25519_root(
+            &mut context,
+            &swig,
+            &root,
+            ed_config(&kp.pubkey()),
+            vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+        )
+        .unwrap();
+        assert_eq!(configured_claimer(&context, &swig), expected);
+    }
+
+    // Update one (grow), update it back (shrink).
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        2,
+        vec![
+            ClientAction::SolLimit(SolLimit { amount: 1 }),
+            ClientAction::ManageAuthority(ManageAuthority {}),
+        ],
+    )
+    .unwrap();
+    assert_eq!(configured_claimer(&context, &swig), expected);
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        2,
+        vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
+    )
+    .unwrap();
+    assert_eq!(configured_claimer(&context, &swig), expected);
+
+    // Remove roles from the middle outward.
+    for remove_id in [2u32, 4, 1, 3] {
+        remove_authority_with_ed25519_root(&mut context, &swig, &root, remove_id).unwrap();
+        assert_eq!(
+            configured_claimer(&context, &swig),
+            expected,
+            "claimer changed after removing role {remove_id}"
+        );
+    }
+
+    // Back to just the root role, claimer still intact.
+    assert_eq!(role_count(&context, &swig), 1);
+    assert_eq!(configured_claimer(&context, &swig), expected);
+}

--- a/program/tests/set_rent_claimer_test.rs
+++ b/program/tests/set_rent_claimer_test.rs
@@ -1,0 +1,128 @@
+#![cfg(not(feature = "program_scope_test"))]
+
+mod common;
+
+use common::*;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{AuthorityConfig, ClientAction, SetRentClaimerV1Instruction};
+use swig_state::{
+    action::sol_limit::SolLimit,
+    authority::AuthorityType,
+    swig::Swig,
+    tail::rent_claimer,
+};
+
+#[test_log::test]
+fn test_set_rent_claimer_happy_path() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let claimer = Keypair::new();
+
+    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, claimer.pubkey())
+        .unwrap();
+
+    let swig_account = context.svm.get_account(&swig_pubkey).unwrap();
+    let parts = Swig::split_parts(&swig_account.data).unwrap();
+    let parsed = rent_claimer::read_strict(parts.tail).unwrap();
+    assert_eq!(parsed, Some(&claimer.pubkey().to_bytes()));
+}
+
+#[test_log::test]
+fn test_set_rent_claimer_rejects_zero_pubkey() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    let set_ix = SetRentClaimerV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        context.default_payer.pubkey(),
+        authority.pubkey(),
+        0,
+        [0u8; 32],
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), set_ix],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(result.is_err(), "zero rent claimer pubkey must fail");
+}
+
+#[test_log::test]
+fn test_set_rent_claimer_is_one_shot() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        0,
+        Keypair::new().pubkey(),
+    )
+    .unwrap();
+
+    let second = set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        0,
+        Keypair::new().pubkey(),
+    );
+    assert!(second.is_err(), "rent claimer should be immutable");
+}
+
+#[test_log::test]
+fn test_set_rent_claimer_requires_permission() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let limited = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    context
+        .svm
+        .airdrop(&limited.pubkey(), 10_000_000_000)
+        .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: limited.pubkey().as_ref(),
+        },
+        vec![ClientAction::SolLimit(SolLimit { amount: 1_000_000 })],
+    )
+    .unwrap();
+
+    let result = set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &limited,
+        1,
+        Keypair::new().pubkey(),
+    );
+    assert!(
+        result.is_err(),
+        "authority without All/CloseSwigAuthority must fail"
+    );
+}


### PR DESCRIPTION
## Summary
- replay all `program/**` changes from `815197d..HEAD` on top of the state stack branch
- include rent-claimer instruction wiring, close-path enforcement, action changes, IDL updates, and integration tests
- keep this PR program-scoped with no interface or rust-sdk file changes

## PR Stack
- This is **2/4**
- Previous: [#179](https://github.com/anagrambuild/swig-wallet/pull/179)
- Next: [#181](https://github.com/anagrambuild/swig-wallet/pull/181)
- Then: [#182](https://github.com/anagrambuild/swig-wallet/pull/182)

## Test plan
- [x] compile/test covered in prior unified run
- [x] stack layering validated locally