### PR TITLE
Rent-claimer: sdk changes

### DIFF
--- a/rust-sdk/src/client_role.rs
+++ b/rust-sdk/src/client_role.rs
@@ -1,7 +1,8 @@
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use swig_interface::{
     AddAuthorityInstruction, AuthorityConfig, ClientAction, CreateSessionInstruction,
-    CreateSubAccountInstruction, RemoveAuthorityInstruction, SignV2Instruction,
+    CreateSubAccountInstruction, RemoveAuthorityInstruction, SetRentClaimerV1Instruction,
+    SignV2Instruction,
     SubAccountSignInstruction, ToggleSubAccountInstruction, UpdateAuthorityData,
     UpdateAuthorityInstruction, WithdrawFromSubAccountInstruction,
 };
@@ -117,6 +118,16 @@ pub trait ClientRole {
         role_id: u32,
         auth_role_id: u32,
         enabled: bool,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError>;
+
+    /// Creates a set rent claimer instruction.
+    fn set_rent_claimer_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        rent_claimer: Pubkey,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError>;
 
@@ -364,6 +375,25 @@ impl ClientRole for Ed25519ClientRole {
                 role_id,
                 auth_role_id,
                 enabled,
+            )?,
+        ])
+    }
+
+    fn set_rent_claimer_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        rent_claimer: Pubkey,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Ok(vec![
+            SetRentClaimerV1Instruction::new_with_ed25519_authority(
+                swig_account,
+                payer,
+                self.authority,
+                role_id,
+                rent_claimer.to_bytes(),
             )?,
         ])
     }
@@ -684,6 +714,29 @@ impl ClientRole for Secp256k1ClientRole {
                 role_id,
                 auth_role_id,
                 enabled,
+            )?,
+        ])
+    }
+
+    fn set_rent_claimer_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        rent_claimer: Pubkey,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        Ok(vec![
+            SetRentClaimerV1Instruction::new_with_secp256k1_authority(
+                swig_account,
+                payer,
+                &self.signing_fn,
+                current_slot,
+                new_odometer,
+                role_id,
+                rent_claimer.to_bytes(),
             )?,
         ])
     }
@@ -1045,6 +1098,28 @@ impl ClientRole for Secp256r1ClientRole {
         Ok(instructions)
     }
 
+    fn set_rent_claimer_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        rent_claimer: Pubkey,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        Ok(SetRentClaimerV1Instruction::new_with_secp256r1_authority(
+            swig_account,
+            payer,
+            &self.signing_fn,
+            current_slot,
+            new_odometer,
+            role_id,
+            rent_claimer.to_bytes(),
+            &self.authority,
+        )?)
+    }
+
     fn authority_type(&self) -> AuthorityType {
         AuthorityType::Secp256r1
     }
@@ -1332,6 +1407,26 @@ impl ClientRole for Ed25519SessionClientRole {
                 role_id,
                 auth_role_id,
                 enabled,
+            )?,
+        ])
+    }
+
+    fn set_rent_claimer_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        rent_claimer: Pubkey,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            SetRentClaimerV1Instruction::new_with_ed25519_authority(
+                swig_account,
+                payer,
+                session_key,
+                role_id,
+                rent_claimer.to_bytes(),
             )?,
         ])
     }
@@ -1650,6 +1745,26 @@ impl ClientRole for Secp256k1SessionClientRole {
                 role_id,
                 auth_role_id,
                 enabled,
+            )?,
+        ])
+    }
+
+    fn set_rent_claimer_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        rent_claimer: Pubkey,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            SetRentClaimerV1Instruction::new_with_ed25519_authority(
+                swig_account,
+                payer,
+                session_key,
+                role_id,
+                rent_claimer.to_bytes(),
             )?,
         ])
     }
@@ -1973,6 +2088,26 @@ impl ClientRole for Secp256r1SessionClientRole {
                 role_id,
                 auth_role_id,
                 enabled,
+            )?,
+        ])
+    }
+
+    fn set_rent_claimer_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        rent_claimer: Pubkey,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            SetRentClaimerV1Instruction::new_with_ed25519_authority(
+                swig_account,
+                payer,
+                session_key,
+                role_id,
+                rent_claimer.to_bytes(),
             )?,
         ])
     }
@@ -2389,6 +2524,19 @@ where
             enabled,
         )
         .map_err(|e| SwigError::InterfaceError(e.to_string()))
+    }
+
+    fn set_rent_claimer_instruction(
+        &self,
+        _swig_account: Pubkey,
+        _payer: Pubkey,
+        _role_id: u32,
+        _rent_claimer: Pubkey,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Err(SwigError::InterfaceError(
+            "ProgramExec does not support SetRentClaimerV1".to_string(),
+        ))
     }
 
     fn authority_type(&self) -> AuthorityType {

--- a/rust-sdk/src/instruction_builder.rs
+++ b/rust-sdk/src/instruction_builder.rs
@@ -265,6 +265,21 @@ impl SwigInstructionBuilder {
         )
     }
 
+    /// Creates instruction(s) to set the immutable rent claimer on the wallet.
+    pub fn set_rent_claimer(
+        &self,
+        rent_claimer: Pubkey,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        self.client_role.set_rent_claimer_instruction(
+            self.swig_account,
+            self.payer,
+            self.role_id,
+            rent_claimer,
+            current_slot,
+        )
+    }
+
     /// Returns the public key of the Swig account
     ///
     /// # Returns

--- a/rust-sdk/src/tests/ix_builder/mod.rs
+++ b/rust-sdk/src/tests/ix_builder/mod.rs
@@ -48,6 +48,7 @@ pub mod destination_tests;
 pub mod program_all_tests;
 pub mod program_exec_tests;
 pub mod program_scope_tests;
+pub mod rent_claimer_tests;
 pub mod secp256r1_tests;
 pub mod session_tests;
 pub mod sign_v2_tests;

--- a/rust-sdk/src/tests/ix_builder/rent_claimer_tests.rs
+++ b/rust-sdk/src/tests/ix_builder/rent_claimer_tests.rs
@@ -1,0 +1,139 @@
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::LocalSigner;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    signature::{Keypair, Signer},
+    transaction::VersionedTransaction,
+};
+use swig_state::{swig::Swig, tail::rent_claimer};
+
+use super::*;
+use crate::{error::SwigError, Ed25519ClientRole, Secp256k1ClientRole};
+
+#[test_log::test]
+fn test_set_rent_claimer_with_ed25519_builder_sets_tail() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [41u8; 32];
+    let authority = Keypair::new();
+    let role_id = 0u32;
+    let (swig_key, _, _) = create_swig_ed25519(&mut context, &authority, swig_id).unwrap();
+
+    let builder = SwigInstructionBuilder::new(
+        swig_id,
+        Box::new(Ed25519ClientRole::new(authority.pubkey())),
+        context.default_payer.pubkey(),
+        role_id,
+    );
+
+    let claimer = Keypair::new().pubkey();
+    let set_ixs = builder.set_rent_claimer(claimer, None).unwrap();
+    assert_eq!(set_ixs.len(), 1);
+
+    let msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &set_ixs,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(msg),
+        &[&context.default_payer, &authority],
+    )
+    .unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_ok(),
+        "set rent claimer transaction failed: {:?}",
+        result.err()
+    );
+
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    let parts = Swig::split_parts(&swig_account.data).unwrap();
+    let parsed = rent_claimer::read_strict(parts.tail).unwrap();
+    assert_eq!(parsed, Some(&claimer.to_bytes()));
+}
+
+#[test_log::test]
+fn test_set_rent_claimer_with_ed25519_builder_is_one_shot() {
+    let mut context = setup_test_context().unwrap();
+    let swig_id = [42u8; 32];
+    let authority = Keypair::new();
+    let role_id = 0u32;
+    let (_swig_key, _, _) = create_swig_ed25519(&mut context, &authority, swig_id).unwrap();
+
+    let builder = SwigInstructionBuilder::new(
+        swig_id,
+        Box::new(Ed25519ClientRole::new(authority.pubkey())),
+        context.default_payer.pubkey(),
+        role_id,
+    );
+
+    let first_ixs = builder
+        .set_rent_claimer(Keypair::new().pubkey(), None)
+        .unwrap();
+    let first_msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &first_ixs,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let first_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(first_msg),
+        &[&context.default_payer, &authority],
+    )
+    .unwrap();
+    let first_result = context.svm.send_transaction(first_tx);
+    assert!(first_result.is_ok(), "first set should succeed");
+
+    let second_ixs = builder
+        .set_rent_claimer(Keypair::new().pubkey(), None)
+        .unwrap();
+    let second_msg = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &second_ixs,
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let second_tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(second_msg),
+        &[&context.default_payer, &authority],
+    )
+    .unwrap();
+    let second_result = context.svm.send_transaction(second_tx);
+    assert!(second_result.is_err(), "second set must fail (immutable)");
+}
+
+#[test_log::test]
+fn test_set_rent_claimer_secp256k1_requires_current_slot() {
+    let wallet = LocalSigner::random();
+    let secp_pubkey = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+
+    let wallet_clone = wallet.clone();
+    let signing_fn = move |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        let hash = B256::from(hash);
+        wallet_clone.sign_hash_sync(&hash).unwrap().as_bytes()
+    };
+
+    let builder = SwigInstructionBuilder::new(
+        [43u8; 32],
+        Box::new(Secp256k1ClientRole::new(secp_pubkey, Box::new(signing_fn))),
+        Pubkey::new_unique(),
+        0,
+    );
+
+    let err = builder
+        .set_rent_claimer(Pubkey::new_unique(), None)
+        .expect_err("secp256k1 set_rent_claimer should require current slot");
+    assert!(matches!(err, SwigError::CurrentSlotNotSet));
+}


### PR DESCRIPTION
## Summary
- replay `rust-sdk/**` changes from `815197d..HEAD` on top of the interface stack branch
- include client role/instruction builder updates and ix-builder rent-claimer coverage
- keep this PR rust-sdk scoped and final in the stack

## PR Stack
- This is **4/4** (top of stack)
- Previous: [#181](https://github.com/anagrambuild/swig-wallet/pull/181)
- Previous base: [#180](https://github.com/anagrambuild/swig-wallet/pull/180)
- Base of stack: [#179](https://github.com/anagrambuild/swig-wallet/pull/179)

## Test plan
- [x] `cargo build-sbf --arch v1 && cargo test -- --nocapture` already passed on the unified source branch before split