### PR TITLE
Support cross-key recovery rotation

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1598,6 +1598,38 @@ impl RecoverAuthorityInstruction {
         preceding_instruction: Instruction,
         acting_role_id: u32,
     ) -> anyhow::Result<Vec<Instruction>> {
+        Self::new_with_program_exec_inner(
+            swig_account,
+            swig_wallet_address,
+            preceding_instruction,
+            acting_role_id,
+            None,
+        )
+    }
+
+    pub fn new_with_program_exec_and_payer(
+        swig_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        preceding_instruction: Instruction,
+        acting_role_id: u32,
+        payer: Pubkey,
+    ) -> anyhow::Result<Vec<Instruction>> {
+        Self::new_with_program_exec_inner(
+            swig_account,
+            swig_wallet_address,
+            preceding_instruction,
+            acting_role_id,
+            Some(payer),
+        )
+    }
+
+    fn new_with_program_exec_inner(
+        swig_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        preceding_instruction: Instruction,
+        acting_role_id: u32,
+        payer: Option<Pubkey>,
+    ) -> anyhow::Result<Vec<Instruction>> {
         use solana_sdk::sysvar::instructions::ID as INSTRUCTIONS_ID;
 
         let pending_recovery = preceding_instruction
@@ -1605,12 +1637,19 @@ impl RecoverAuthorityInstruction {
             .get(2)
             .ok_or_else(|| anyhow::anyhow!("recovery execute instruction missing pending account"))?
             .pubkey;
-        let accounts = vec![
+        let mut accounts = vec![
             AccountMeta::new(swig_account, false),
             AccountMeta::new_readonly(swig_wallet_address, false),
             AccountMeta::new_readonly(INSTRUCTIONS_ID, false),
             AccountMeta::new_readonly(pending_recovery, false),
         ];
+        if let Some(payer) = payer {
+            accounts.push(AccountMeta::new(payer, true));
+            accounts.push(AccountMeta::new_readonly(
+                solana_system_interface::program::ID,
+                false,
+            ));
+        }
         let authority_payload = build_program_exec_authority_payload(2, None);
         let args = RecoverAuthorityV1Args::new(acting_role_id, authority_payload.len() as u16);
         let arg_bytes = args

--- a/program/src/actions/recover_authority_v1.rs
+++ b/program/src/actions/recover_authority_v1.rs
@@ -13,18 +13,21 @@ use pinocchio::{
     sysvars::{
         clock::Clock,
         instructions::{Instructions, INSTRUCTIONS_ID},
+        rent::Rent,
         Sysvar,
     },
     ProgramResult,
 };
-use swig_assertions::{check_self_owned, sol_assert_bytes_eq};
+use pinocchio_system::instructions::Transfer;
+use swig_assertions::{check_bytes_match, check_self_owned, sol_assert_bytes_eq};
 use swig_state::{
     action::recovery_authority::RecoveryAuthority,
     authority::{
+        authority_type_to_length,
         ed25519::{ED25519Authority, Ed25519SessionAuthority},
         secp256k1::{Secp256k1Authority, Secp256k1SessionAuthority},
         secp256r1::{Secp256r1Authority, Secp256r1SessionAuthority},
-        AuthorityType,
+        Authority, AuthorityType,
     },
     role::Position,
     swig::{swig_wallet_address_seeds, Swig},
@@ -43,16 +46,18 @@ const EXECUTE_RECOVERY_V1_DISCRIMINATOR: [u8; 8] = *b"execreV1";
 const PENDING_RECOVERY_SEED: &[u8] = b"pending-recovery";
 const PENDING_RECOVERY_V1_DISCRIMINATOR: [u8; 8] = *b"rpendV01";
 const PENDING_RECOVERY_STATUS_EXECUTED: u8 = 2;
-const PENDING_RECOVERY_V1_LEN: usize = 8 + 32 + 32 + 4 + 32 + 32 + 32 + 8 + 8 + 1 + 1 + 2 + 2 + 2;
+const PENDING_RECOVERY_V1_LEN: usize =
+    8 + 32 + 32 + 4 + 32 + 32 + 32 + 8 + 8 + 1 + 1 + 2 + 2 + 2 + 2;
 const PENDING_SWIG_WALLET_OFFSET: usize = 40;
 const PENDING_TARGET_ROLE_OFFSET: usize = 72;
 const PENDING_OLD_AUTHORITY_HASH_OFFSET: usize = 108;
 const PENDING_NEW_AUTHORITY_HASH_OFFSET: usize = 140;
 const PENDING_STATUS_OFFSET: usize = 188;
-const PENDING_AUTHORITY_TYPE_OFFSET: usize = 190;
-const PENDING_OLD_AUTHORITY_LEN_OFFSET: usize = 192;
-const PENDING_NEW_AUTHORITY_LEN_OFFSET: usize = 194;
-const RECOVERY_AUTHORITY_DATA_HEADER_LEN: usize = 2 + 2 + 2;
+const PENDING_OLD_AUTHORITY_TYPE_OFFSET: usize = 190;
+const PENDING_NEW_AUTHORITY_TYPE_OFFSET: usize = 192;
+const PENDING_OLD_AUTHORITY_LEN_OFFSET: usize = 194;
+const PENDING_NEW_AUTHORITY_LEN_OFFSET: usize = 196;
+const RECOVERY_AUTHORITY_DATA_HEADER_LEN: usize = 2 + 2 + 2 + 2;
 const MAX_RECOVERY_AUTHORITY_LEN: usize = 64;
 
 #[repr(C, align(8))]
@@ -118,15 +123,15 @@ pub fn recover_authority_v1(
     check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
 
     let recover = RecoverAuthorityV1::from_instruction_bytes(data)?;
-    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-    if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
-        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
-    }
-
-    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
-    let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
-
     {
+        let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+        if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+            return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+        }
+
+        let (swig_header, swig_roles) =
+            unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+        let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
         let acting_role = Swig::get_mut_role(recover.args.acting_role_id, swig_roles)?
             .ok_or(SwigError::InvalidAuthorityNotFoundByRoleId)?;
         let slot = Clock::get()?.slot;
@@ -159,12 +164,25 @@ pub fn recover_authority_v1(
         recover.authority_payload,
     )?;
 
+    let size_diff = recovery_authority_size_diff(ctx.accounts.swig, &binding)?;
+    if size_diff > 0 {
+        grow_swig_account_for_recovery(ctx.accounts.swig, all_accounts, size_diff)?;
+    }
+
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+    let (swig_header, swig_roles) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+    let swig = unsafe { Swig::load_mut_unchecked(swig_header)? };
+
     rotate_target_authority(swig, swig_roles, binding)
 }
 
 struct RecoveryBinding {
     target_role_id: u32,
-    authority_type: u16,
+    old_authority_type: u16,
+    new_authority_type: u16,
     old_authority: [u8; MAX_RECOVERY_AUTHORITY_LEN],
     old_authority_len: usize,
     new_authority: [u8; MAX_RECOVERY_AUTHORITY_LEN],
@@ -187,137 +205,305 @@ fn rotate_target_authority(
     swig_roles: &mut [u8],
     binding: RecoveryBinding,
 ) -> ProgramResult {
+    let replacement = recovery_authority_replacement(swig, swig_roles, &binding)?;
+    verify_old_authority_matches(swig_roles, &replacement, &binding)?;
+
+    let shift_start = replacement.actions_start;
+    let used_roles_end = replacement.used_roles_end;
+    let new_shift_start = offset_by_diff(shift_start, replacement.size_diff)?;
+    let new_used_roles_end = offset_by_diff(used_roles_end, replacement.size_diff)?;
+    if used_roles_end > shift_start {
+        swig_roles.copy_within(shift_start..used_roles_end, new_shift_start);
+    }
+    if replacement.size_diff < 0 {
+        swig_roles[new_used_roles_end..used_roles_end].fill(0);
+    }
+
+    write_new_authority(
+        replacement.new_authority_type,
+        binding.new_authority(),
+        &mut swig_roles[replacement.authority_start
+            ..replacement.authority_start + replacement.new_authority_len],
+    )?;
+    update_recovery_role_boundaries(swig, swig_roles, &replacement)?;
+    Ok(())
+}
+
+fn recovery_authority_size_diff(
+    swig_account: &AccountInfo,
+    binding: &RecoveryBinding,
+) -> Result<i64, ProgramError> {
+    let swig_account_data = unsafe { swig_account.borrow_data_unchecked() };
+    if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+    let (swig_header, swig_roles) = swig_account_data.split_at(Swig::LEN);
+    let swig = unsafe { Swig::load_unchecked(swig_header)? };
+    Ok(recovery_authority_replacement(swig, swig_roles, binding)?.size_diff)
+}
+
+fn grow_swig_account_for_recovery(
+    swig_account: &AccountInfo,
+    all_accounts: &[AccountInfo],
+    size_diff: i64,
+) -> ProgramResult {
+    let payer = all_accounts.get(4).ok_or(SwigError::StateError)?;
+    let system_program = all_accounts.get(5).ok_or(SwigError::StateError)?;
+    check_bytes_match(
+        system_program.key(),
+        &pinocchio_system::ID,
+        32,
+        SwigError::InvalidSystemProgram,
+    )?;
+
+    let current_size = unsafe { swig_account.borrow_data_unchecked() }.len();
+    let new_size = offset_by_diff(current_size, size_diff)?;
+    let aligned_size = core::alloc::Layout::from_size_align(new_size, core::mem::size_of::<u64>())
+        .map_err(|_| SwigError::InvalidAlignment)?
+        .pad_to_align()
+        .size();
+    swig_account.realloc(aligned_size, false)?;
+
+    let required_lamports = Rent::get()?.minimum_balance(aligned_size);
+    let current_lamports = swig_account.lamports();
+    let additional_lamports = required_lamports.saturating_sub(current_lamports);
+    if additional_lamports > 0 {
+        Transfer {
+            from: payer,
+            to: swig_account,
+            lamports: additional_lamports,
+        }
+        .invoke()?;
+    }
+
+    Ok(())
+}
+
+struct RecoveryAuthorityReplacement {
+    role_offset: usize,
+    authority_start: usize,
+    actions_start: usize,
+    role_boundary: usize,
+    used_roles_end: usize,
+    size_diff: i64,
+    old_authority_type: u16,
+    new_authority_type: u16,
+    new_authority_len: usize,
+}
+
+fn recovery_authority_replacement(
+    swig: &Swig,
+    swig_roles: &[u8],
+    binding: &RecoveryBinding,
+) -> Result<RecoveryAuthorityReplacement, ProgramError> {
     let mut cursor = 0;
+    let mut target = None;
+    let mut used_roles_end = 0;
     for _ in 0..swig.roles {
         let position =
             unsafe { Position::load_unchecked(&swig_roles[cursor..cursor + Position::LEN])? };
+        let boundary = position.boundary() as usize;
         if position.id() == binding.target_role_id {
-            let target_authority_type = position.authority_type()?;
-            if target_authority_type as u16 != binding.authority_type {
-                return Err(SwigError::RecoveryAuthorityTypeMismatch.into());
-            }
-
-            let authority_start = cursor + Position::LEN;
-            match target_authority_type {
-                AuthorityType::Ed25519 => {
-                    let (old_authority, new_authority) = fixed_authority_pair::<32>(&binding)?;
-                    let authority_end = authority_start + ED25519Authority::LEN;
-                    let authority = unsafe {
-                        ED25519Authority::load_mut_unchecked(
-                            &mut swig_roles[authority_start..authority_end],
-                        )?
-                    };
-                    if authority.public_key != old_authority {
-                        return Err(SwigError::RecoveryOldAuthorityMismatch.into());
-                    }
-                    authority.public_key = new_authority;
-                },
-                AuthorityType::Ed25519Session => {
-                    let (old_authority, new_authority) = fixed_authority_pair::<32>(&binding)?;
-                    let authority_end = authority_start + Ed25519SessionAuthority::LEN;
-                    let authority = unsafe {
-                        Ed25519SessionAuthority::load_mut_unchecked(
-                            &mut swig_roles[authority_start..authority_end],
-                        )?
-                    };
-                    if authority.public_key != old_authority {
-                        return Err(SwigError::RecoveryOldAuthorityMismatch.into());
-                    }
-                    authority.public_key = new_authority;
-                    authority.session_key = [0; 32];
-                    authority.current_session_expiration = 0;
-                },
-                AuthorityType::Secp256k1 => {
-                    let old_authority = normalize_secp256k1_authority(binding.old_authority())?;
-                    let new_authority = normalize_secp256k1_authority(binding.new_authority())?;
-                    let authority_end = authority_start + Secp256k1Authority::LEN;
-                    let authority = unsafe {
-                        Secp256k1Authority::load_mut_unchecked(
-                            &mut swig_roles[authority_start..authority_end],
-                        )?
-                    };
-                    if authority.public_key != old_authority {
-                        return Err(SwigError::RecoveryOldAuthorityMismatch.into());
-                    }
-                    authority.public_key = new_authority;
-                    authority.signature_odometer = 0;
-                },
-                AuthorityType::Secp256k1Session => {
-                    let old_authority = normalize_secp256k1_authority(binding.old_authority())?;
-                    let new_authority = normalize_secp256k1_authority(binding.new_authority())?;
-                    let authority_end = authority_start + Secp256k1SessionAuthority::LEN;
-                    let authority = unsafe {
-                        Secp256k1SessionAuthority::load_mut_unchecked(
-                            &mut swig_roles[authority_start..authority_end],
-                        )?
-                    };
-                    if authority.public_key != old_authority {
-                        return Err(SwigError::RecoveryOldAuthorityMismatch.into());
-                    }
-                    authority.public_key = new_authority;
-                    authority.signature_odometer = 0;
-                    authority.session_key = [0; 32];
-                    authority.current_session_expiration = 0;
-                },
-                AuthorityType::Secp256r1 => {
-                    let (old_authority, new_authority) = fixed_authority_pair::<33>(&binding)?;
-                    let authority_end = authority_start + Secp256r1Authority::LEN;
-                    let authority = unsafe {
-                        Secp256r1Authority::load_mut_unchecked(
-                            &mut swig_roles[authority_start..authority_end],
-                        )?
-                    };
-                    if authority.public_key != old_authority {
-                        return Err(SwigError::RecoveryOldAuthorityMismatch.into());
-                    }
-                    authority.public_key = new_authority;
-                    authority.signature_odometer = 0;
-                },
-                AuthorityType::Secp256r1Session => {
-                    let (old_authority, new_authority) = fixed_authority_pair::<33>(&binding)?;
-                    let authority_end = authority_start + Secp256r1SessionAuthority::LEN;
-                    let authority = unsafe {
-                        Secp256r1SessionAuthority::load_mut_unchecked(
-                            &mut swig_roles[authority_start..authority_end],
-                        )?
-                    };
-                    if authority.public_key != old_authority {
-                        return Err(SwigError::RecoveryOldAuthorityMismatch.into());
-                    }
-                    authority.public_key = new_authority;
-                    authority.signature_odometer = 0;
-                    authority.session_key = [0; 32];
-                    authority.current_session_expiration = 0;
-                },
-                _ => {
-                    return Err(SwigError::UnsupportedRecoveryAuthorityScheme.into());
-                },
-            }
-            return Ok(());
+            target = Some((
+                cursor,
+                boundary,
+                position.authority_type,
+                position.authority_length,
+            ));
         }
-
-        cursor = position.boundary() as usize;
+        used_roles_end = boundary;
+        cursor = boundary;
     }
 
-    Err(SwigError::InvalidAuthorityNotFoundByRoleId.into())
+    let Some((role_offset, role_boundary, old_authority_type_raw, old_authority_len_raw)) = target
+    else {
+        return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+    };
+    if old_authority_type_raw != binding.old_authority_type {
+        return Err(SwigError::RecoveryAuthorityTypeMismatch.into());
+    }
+    let old_authority_type = AuthorityType::try_from(old_authority_type_raw)?;
+    let new_authority_type = AuthorityType::try_from(binding.new_authority_type)?;
+    let expected_old_authority_len = authority_type_to_length(&old_authority_type)?;
+    if old_authority_len_raw as usize != expected_old_authority_len {
+        return Err(SwigError::RecoveryInvalidAuthorityLength.into());
+    }
+    let new_authority_len = replacement_authority_len(&new_authority_type)?;
+    let authority_start = role_offset + Position::LEN;
+    let actions_start = authority_start + expected_old_authority_len;
+    if role_boundary < actions_start || used_roles_end < role_boundary {
+        return Err(SwigError::StateError.into());
+    }
+
+    Ok(RecoveryAuthorityReplacement {
+        role_offset,
+        authority_start,
+        actions_start,
+        role_boundary,
+        used_roles_end,
+        size_diff: new_authority_len as i64 - expected_old_authority_len as i64,
+        old_authority_type: old_authority_type_raw,
+        new_authority_type: binding.new_authority_type,
+        new_authority_len,
+    })
 }
 
-fn fixed_authority_pair<const LEN: usize>(
+fn replacement_authority_len(authority_type: &AuthorityType) -> Result<usize, ProgramError> {
+    match authority_type {
+        AuthorityType::Ed25519 | AuthorityType::Secp256k1 | AuthorityType::Secp256r1 => {
+            authority_type_to_length(authority_type)
+        },
+        _ => Err(SwigError::UnsupportedRecoveryAuthorityScheme.into()),
+    }
+}
+
+fn verify_old_authority_matches(
+    swig_roles: &[u8],
+    replacement: &RecoveryAuthorityReplacement,
     binding: &RecoveryBinding,
-) -> Result<([u8; LEN], [u8; LEN]), ProgramError> {
-    if binding.old_authority_len != LEN || binding.new_authority_len != LEN {
+) -> Result<(), ProgramError> {
+    match AuthorityType::try_from(replacement.old_authority_type)? {
+        AuthorityType::Ed25519 => {
+            let old_authority = fixed_authority::<32>(binding.old_authority())?;
+            let authority_end = replacement.authority_start + ED25519Authority::LEN;
+            let authority = unsafe {
+                ED25519Authority::load_unchecked(
+                    &swig_roles[replacement.authority_start..authority_end],
+                )?
+            };
+            if authority.public_key != old_authority {
+                return Err(SwigError::RecoveryOldAuthorityMismatch.into());
+            }
+        },
+        AuthorityType::Ed25519Session => {
+            let old_authority = fixed_authority::<32>(binding.old_authority())?;
+            let authority_end = replacement.authority_start + Ed25519SessionAuthority::LEN;
+            let authority = unsafe {
+                Ed25519SessionAuthority::load_unchecked(
+                    &swig_roles[replacement.authority_start..authority_end],
+                )?
+            };
+            if authority.public_key != old_authority {
+                return Err(SwigError::RecoveryOldAuthorityMismatch.into());
+            }
+        },
+        AuthorityType::Secp256k1 => {
+            let old_authority = normalize_secp256k1_authority(binding.old_authority())?;
+            let authority_end = replacement.authority_start + Secp256k1Authority::LEN;
+            let authority = unsafe {
+                Secp256k1Authority::load_unchecked(
+                    &swig_roles[replacement.authority_start..authority_end],
+                )?
+            };
+            if authority.public_key != old_authority {
+                return Err(SwigError::RecoveryOldAuthorityMismatch.into());
+            }
+        },
+        AuthorityType::Secp256k1Session => {
+            let old_authority = normalize_secp256k1_authority(binding.old_authority())?;
+            let authority_end = replacement.authority_start + Secp256k1SessionAuthority::LEN;
+            let authority = unsafe {
+                Secp256k1SessionAuthority::load_unchecked(
+                    &swig_roles[replacement.authority_start..authority_end],
+                )?
+            };
+            if authority.public_key != old_authority {
+                return Err(SwigError::RecoveryOldAuthorityMismatch.into());
+            }
+        },
+        AuthorityType::Secp256r1 => {
+            let old_authority = fixed_authority::<33>(binding.old_authority())?;
+            let authority_end = replacement.authority_start + Secp256r1Authority::LEN;
+            let authority = unsafe {
+                Secp256r1Authority::load_unchecked(
+                    &swig_roles[replacement.authority_start..authority_end],
+                )?
+            };
+            if authority.public_key != old_authority {
+                return Err(SwigError::RecoveryOldAuthorityMismatch.into());
+            }
+        },
+        AuthorityType::Secp256r1Session => {
+            let old_authority = fixed_authority::<33>(binding.old_authority())?;
+            let authority_end = replacement.authority_start + Secp256r1SessionAuthority::LEN;
+            let authority = unsafe {
+                Secp256r1SessionAuthority::load_unchecked(
+                    &swig_roles[replacement.authority_start..authority_end],
+                )?
+            };
+            if authority.public_key != old_authority {
+                return Err(SwigError::RecoveryOldAuthorityMismatch.into());
+            }
+        },
+        _ => return Err(SwigError::UnsupportedRecoveryAuthorityScheme.into()),
+    }
+
+    Ok(())
+}
+
+fn write_new_authority(
+    authority_type: u16,
+    authority_data: &[u8],
+    target: &mut [u8],
+) -> Result<(), ProgramError> {
+    match AuthorityType::try_from(authority_type)? {
+        AuthorityType::Ed25519 => ED25519Authority::set_into_bytes(authority_data, target),
+        AuthorityType::Secp256k1 => Secp256k1Authority::set_into_bytes(authority_data, target),
+        AuthorityType::Secp256r1 => Secp256r1Authority::set_into_bytes(authority_data, target),
+        _ => Err(SwigError::UnsupportedRecoveryAuthorityScheme.into()),
+    }
+}
+
+fn update_recovery_role_boundaries(
+    swig: &Swig,
+    swig_roles: &mut [u8],
+    replacement: &RecoveryAuthorityReplacement,
+) -> Result<(), ProgramError> {
+    let new_boundary = offset_by_diff(replacement.role_boundary, replacement.size_diff)? as u32;
+    let mut cursor = 0;
+    for _ in 0..swig.roles {
+        let position = unsafe {
+            Position::load_mut_unchecked(&mut swig_roles[cursor..cursor + Position::LEN])?
+        };
+        let original_boundary = position.boundary() as usize;
+        if cursor == replacement.role_offset {
+            position.authority_type = replacement.new_authority_type;
+            position.authority_length = replacement.new_authority_len as u16;
+            position.boundary = new_boundary;
+            cursor = position.boundary() as usize;
+            continue;
+        }
+        if cursor > replacement.role_offset {
+            position.boundary =
+                offset_by_diff(position.boundary() as usize, replacement.size_diff)? as u32;
+            cursor = position.boundary() as usize;
+            continue;
+        }
+        cursor = original_boundary;
+    }
+    Ok(())
+}
+
+fn offset_by_diff(value: usize, diff: i64) -> Result<usize, ProgramError> {
+    if diff >= 0 {
+        value
+            .checked_add(diff as usize)
+            .ok_or(SwigError::StateError.into())
+    } else {
+        value
+            .checked_sub((-diff) as usize)
+            .ok_or(SwigError::StateError.into())
+    }
+}
+
+fn fixed_authority<const LEN: usize>(authority: &[u8]) -> Result<[u8; LEN], ProgramError> {
+    if authority.len() != LEN {
         return Err(SwigError::RecoveryInvalidAuthorityLength.into());
     }
 
-    let old_authority = binding
-        .old_authority()
+    authority
         .try_into()
-        .map_err(|_| SwigError::RecoveryInvalidAuthorityLength)?;
-    let new_authority = binding
-        .new_authority()
-        .try_into()
-        .map_err(|_| SwigError::RecoveryInvalidAuthorityLength)?;
-    Ok((old_authority, new_authority))
+        .map_err(|_| SwigError::RecoveryInvalidAuthorityLength.into())
 }
 
 fn normalize_secp256k1_authority(authority: &[u8]) -> Result<[u8; 33], ProgramError> {
@@ -404,8 +590,12 @@ fn load_verified_recovery_binding(
         return Err(SwigError::RecoveryPendingNotExecuted.into());
     }
 
-    let pending_authority_type = read_u16(pending_data, PENDING_AUTHORITY_TYPE_OFFSET)?;
-    if execute_ix.authority_type != pending_authority_type {
+    let pending_old_authority_type = read_u16(pending_data, PENDING_OLD_AUTHORITY_TYPE_OFFSET)?;
+    if execute_ix.old_authority_type != pending_old_authority_type {
+        return Err(SwigError::RecoveryInstructionMismatch.into());
+    }
+    let pending_new_authority_type = read_u16(pending_data, PENDING_NEW_AUTHORITY_TYPE_OFFSET)?;
+    if execute_ix.new_authority_type != pending_new_authority_type {
         return Err(SwigError::RecoveryInstructionMismatch.into());
     }
     let pending_old_authority_len = read_u16(pending_data, PENDING_OLD_AUTHORITY_LEN_OFFSET)?;
@@ -431,7 +621,8 @@ fn load_verified_recovery_binding(
 
     Ok(RecoveryBinding {
         target_role_id,
-        authority_type: execute_ix.authority_type,
+        old_authority_type: execute_ix.old_authority_type,
+        new_authority_type: execute_ix.new_authority_type,
         old_authority: execute_ix.old_authority,
         old_authority_len: execute_ix.old_authority_len,
         new_authority: execute_ix.new_authority,
@@ -442,7 +633,8 @@ fn load_verified_recovery_binding(
 struct RecoveryExecuteIx {
     program_id: [u8; 32],
     pending_recovery: [u8; 32],
-    authority_type: u16,
+    old_authority_type: u16,
+    new_authority_type: u16,
     old_authority: [u8; MAX_RECOVERY_AUTHORITY_LEN],
     old_authority_len: usize,
     new_authority: [u8; MAX_RECOVERY_AUTHORITY_LEN],
@@ -528,7 +720,8 @@ fn load_recovery_execute_ix(
     Ok(RecoveryExecuteIx {
         program_id: *recovery_ix.get_program_id(),
         pending_recovery: pending_meta.key,
-        authority_type: recovery_authorities.authority_type,
+        old_authority_type: recovery_authorities.old_authority_type,
+        new_authority_type: recovery_authorities.new_authority_type,
         old_authority: recovery_authorities.old_authority,
         old_authority_len: recovery_authorities.old_authority_len,
         new_authority: recovery_authorities.new_authority,
@@ -586,7 +779,8 @@ fn read_hash(data: &[u8], offset: usize) -> Result<[u8; 32], ProgramError> {
 }
 
 struct ParsedRecoveryAuthorityData {
-    authority_type: u16,
+    old_authority_type: u16,
+    new_authority_type: u16,
     old_authority: [u8; MAX_RECOVERY_AUTHORITY_LEN],
     old_authority_len: usize,
     new_authority: [u8; MAX_RECOVERY_AUTHORITY_LEN],
@@ -598,9 +792,10 @@ fn parse_recovery_authority_data(data: &[u8]) -> Result<ParsedRecoveryAuthorityD
         return Err(SwigError::RecoveryInstructionMismatch.into());
     }
 
-    let authority_type = read_u16(data, 0)?;
-    let old_authority_len = read_u16(data, 2)? as usize;
-    let new_authority_len = read_u16(data, 4)? as usize;
+    let old_authority_type = read_u16(data, 0)?;
+    let new_authority_type = read_u16(data, 2)?;
+    let old_authority_len = read_u16(data, 4)? as usize;
+    let new_authority_len = read_u16(data, 6)? as usize;
     if old_authority_len == 0
         || old_authority_len > MAX_RECOVERY_AUTHORITY_LEN
         || new_authority_len == 0
@@ -632,7 +827,8 @@ fn parse_recovery_authority_data(data: &[u8]) -> Result<ParsedRecoveryAuthorityD
     );
 
     Ok(ParsedRecoveryAuthorityData {
-        authority_type,
+        old_authority_type,
+        new_authority_type,
         old_authority,
         old_authority_len,
         new_authority,

--- a/program/tests/recover_authority_test.rs
+++ b/program/tests/recover_authority_test.rs
@@ -6,7 +6,6 @@ use alloy_signer_local::{LocalSigner, PrivateKeySigner};
 use common::*;
 use solana_sdk::{
     account::Account,
-    hash::hashv,
     instruction::{AccountMeta, Instruction},
     message::{v0, VersionedMessage},
     pubkey::Pubkey,
@@ -32,7 +31,8 @@ const EXECUTE_RECOVERY_V1_DISCRIMINATOR: [u8; 8] = *b"execreV1";
 const PENDING_RECOVERY_SEED: &[u8] = b"pending-recovery";
 const PENDING_RECOVERY_V1_DISCRIMINATOR: [u8; 8] = *b"rpendV01";
 const PENDING_RECOVERY_STATUS_EXECUTED: u8 = 2;
-const PENDING_RECOVERY_V1_LEN: usize = 8 + 32 + 32 + 4 + 32 + 32 + 32 + 8 + 8 + 1 + 1 + 2 + 2 + 2;
+const PENDING_RECOVERY_V1_LEN: usize =
+    8 + 32 + 32 + 4 + 32 + 32 + 32 + 8 + 8 + 1 + 1 + 2 + 2 + 2 + 2;
 
 fn deploy_recovery_test_program(context: &mut SwigTestContext) -> anyhow::Result<Pubkey> {
     let program_data = std::fs::read(TEST_RECOVERY_PROGRAM_PATH).map_err(|e| {
@@ -70,13 +70,19 @@ fn write_hash(data: &mut [u8], offset: usize, value: &[u8; 32]) {
     data[offset..offset + 32].copy_from_slice(value);
 }
 
+fn hash_recovery_authority(authority_type: AuthorityType, authority: &[u8]) -> [u8; 32] {
+    let _ = authority_type;
+    solana_sdk::hash::hashv(&[authority]).to_bytes()
+}
+
 fn create_executed_pending_recovery(
     context: &mut SwigTestContext,
     recovery_program_id: Pubkey,
     swig_wallet_address: Pubkey,
     target_role_id: u32,
     guardian: Pubkey,
-    authority_type: AuthorityType,
+    old_authority_type: AuthorityType,
+    new_authority_type: AuthorityType,
     old_authority: &[u8],
     new_authority: &[u8],
 ) -> Pubkey {
@@ -88,15 +94,24 @@ fn create_executed_pending_recovery(
     write_pubkey(&mut data, 40, &swig_wallet_address);
     data[72..76].copy_from_slice(&target_role_id.to_le_bytes());
     write_pubkey(&mut data, 76, &guardian);
-    write_hash(&mut data, 108, &hashv(&[old_authority]).to_bytes());
-    write_hash(&mut data, 140, &hashv(&[new_authority]).to_bytes());
+    write_hash(
+        &mut data,
+        108,
+        &hash_recovery_authority(old_authority_type, old_authority),
+    );
+    write_hash(
+        &mut data,
+        140,
+        &hash_recovery_authority(new_authority_type, new_authority),
+    );
     data[172..180].copy_from_slice(&1u64.to_le_bytes());
     data[180..188].copy_from_slice(&1u64.to_le_bytes());
     data[188] = PENDING_RECOVERY_STATUS_EXECUTED;
     data[189] = bump;
-    data[190..192].copy_from_slice(&(authority_type as u16).to_le_bytes());
-    data[192..194].copy_from_slice(&(old_authority.len() as u16).to_le_bytes());
-    data[194..196].copy_from_slice(&(new_authority.len() as u16).to_le_bytes());
+    data[190..192].copy_from_slice(&(old_authority_type as u16).to_le_bytes());
+    data[192..194].copy_from_slice(&(new_authority_type as u16).to_le_bytes());
+    data[194..196].copy_from_slice(&(old_authority.len() as u16).to_le_bytes());
+    data[196..198].copy_from_slice(&(new_authority.len() as u16).to_le_bytes());
 
     context
         .svm
@@ -120,15 +135,18 @@ fn execute_recovery_v1_instruction(
     swig: Pubkey,
     swig_wallet_address: Pubkey,
     target_role_id: u32,
-    authority_type: u16,
+    old_authority_type: u16,
+    new_authority_type: u16,
     old_authority: &[u8],
     new_authority: &[u8],
 ) -> Instruction {
     let (pending, _) =
         find_pending_recovery_address(&recovery_program_id, &swig_wallet_address, target_role_id);
-    let mut data = Vec::with_capacity(8 + 2 + 2 + 2 + old_authority.len() + new_authority.len());
+    let mut data =
+        Vec::with_capacity(8 + 2 + 2 + 2 + 2 + old_authority.len() + new_authority.len());
     data.extend_from_slice(&EXECUTE_RECOVERY_V1_DISCRIMINATOR);
-    data.extend_from_slice(&authority_type.to_le_bytes());
+    data.extend_from_slice(&old_authority_type.to_le_bytes());
+    data.extend_from_slice(&new_authority_type.to_le_bytes());
     data.extend_from_slice(&(old_authority.len() as u16).to_le_bytes());
     data.extend_from_slice(&(new_authority.len() as u16).to_le_bytes());
     data.extend_from_slice(old_authority);
@@ -214,7 +232,8 @@ fn start_recovery(
     guardian: &Keypair,
     swig_wallet_address: Pubkey,
     target_role_id: u32,
-    authority_type: AuthorityType,
+    old_authority_type: AuthorityType,
+    new_authority_type: AuthorityType,
     old_authority: &[u8],
     new_authority: &[u8],
 ) {
@@ -224,7 +243,8 @@ fn start_recovery(
         swig_wallet_address,
         target_role_id,
         guardian.pubkey(),
-        authority_type,
+        old_authority_type,
+        new_authority_type,
         old_authority,
         new_authority,
     );
@@ -308,6 +328,7 @@ fn test_program_exec_recovery_rotates_passkey_authority() {
         swig_wallet_address,
         1,
         AuthorityType::Secp256r1,
+        AuthorityType::Secp256r1,
         &old_passkey,
         &new_passkey,
     );
@@ -321,6 +342,7 @@ fn test_program_exec_recovery_rotates_passkey_authority() {
         swig,
         swig_wallet_address,
         1,
+        AuthorityType::Secp256r1 as u16,
         AuthorityType::Secp256r1 as u16,
         &old_passkey,
         &new_passkey,
@@ -346,6 +368,132 @@ fn test_program_exec_recovery_rotates_passkey_authority() {
 
     assert_eq!(recovered_authority.public_key, new_passkey);
     assert_eq!(recovered_authority.signature_odometer, 0);
+    assert!(recovered_role
+        .get_action::<ManageAuthority>(&[])
+        .unwrap()
+        .is_some());
+}
+
+#[test_log::test]
+fn test_program_exec_recovery_rotates_passkey_to_ed25519_authority() {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let new_authority = Keypair::new();
+    let admin = Keypair::new();
+    let operator = Keypair::new();
+    let guardian = Keypair::new();
+    let recovery_program_id = deploy_recovery_test_program(&mut context).unwrap();
+
+    install_operator(&mut context, recovery_program_id, &admin, operator.pubkey());
+    context
+        .svm
+        .airdrop(&operator.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&guardian.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let old_passkey = create_test_secp256r1_public_key();
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet_address =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+
+    create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Secp256r1,
+            authority: &old_passkey,
+        },
+        vec![ClientAction::ManageAuthority(ManageAuthority {})],
+    )
+    .unwrap();
+
+    let recovery_program_id_bytes = recovery_program_id.to_bytes();
+    let program_exec_data = ProgramExecAuthority::create_authority_data(
+        &recovery_program_id_bytes,
+        &EXECUTE_RECOVERY_V1_DISCRIMINATOR,
+    );
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::ProgramExec,
+            authority: &program_exec_data,
+        },
+        vec![ClientAction::RecoveryAuthority(RecoveryAuthority {})],
+    )
+    .unwrap();
+
+    let delay_slots = 10;
+    configure_recovery(
+        &mut context,
+        recovery_program_id,
+        &operator,
+        swig_wallet_address,
+        1,
+        guardian.pubkey(),
+        delay_slots,
+    );
+    start_recovery(
+        &mut context,
+        recovery_program_id,
+        &guardian,
+        swig_wallet_address,
+        1,
+        AuthorityType::Secp256r1,
+        AuthorityType::Ed25519,
+        &old_passkey,
+        new_authority.pubkey().as_ref(),
+    );
+    context
+        .svm
+        .warp_to_slot(context.svm.get_sysvar::<Clock>().slot + delay_slots + 1);
+    context.svm.expire_blockhash();
+
+    let execute_ix = execute_recovery_v1_instruction(
+        recovery_program_id,
+        swig,
+        swig_wallet_address,
+        1,
+        AuthorityType::Secp256r1 as u16,
+        AuthorityType::Ed25519 as u16,
+        &old_passkey,
+        new_authority.pubkey().as_ref(),
+    );
+    let instructions = RecoverAuthorityInstruction::new_with_program_exec(
+        swig,
+        swig_wallet_address,
+        execute_ix,
+        2,
+    )
+    .unwrap();
+
+    send_recovery_transaction(&mut context, &instructions).unwrap();
+
+    let swig_account = context.svm.get_account(&swig).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    let recovered_role = swig_state.get_role(1).unwrap().unwrap();
+    let recovered_authority = recovered_role
+        .authority
+        .as_any()
+        .downcast_ref::<ED25519Authority>()
+        .unwrap();
+
+    assert_eq!(
+        recovered_authority.public_key,
+        new_authority.pubkey().to_bytes()
+    );
     assert!(recovered_role
         .get_action::<ManageAuthority>(&[])
         .unwrap()
@@ -417,6 +565,7 @@ fn test_program_exec_recovery_rotates_ed25519_authority() {
         swig_wallet_address,
         0,
         AuthorityType::Ed25519,
+        AuthorityType::Ed25519,
         root_authority.pubkey().as_ref(),
         new_root_authority.pubkey().as_ref(),
     );
@@ -430,6 +579,7 @@ fn test_program_exec_recovery_rotates_ed25519_authority() {
         swig,
         swig_wallet_address,
         0,
+        AuthorityType::Ed25519 as u16,
         AuthorityType::Ed25519 as u16,
         root_authority.pubkey().as_ref(),
         new_root_authority.pubkey().as_ref(),
@@ -457,6 +607,114 @@ fn test_program_exec_recovery_rotates_ed25519_authority() {
         recovered_authority.public_key,
         new_root_authority.pubkey().to_bytes()
     );
+}
+
+#[test_log::test]
+fn test_program_exec_recovery_rotates_ed25519_to_passkey_authority() {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let admin = Keypair::new();
+    let operator = Keypair::new();
+    let guardian = Keypair::new();
+    let recovery_program_id = deploy_recovery_test_program(&mut context).unwrap();
+
+    install_operator(&mut context, recovery_program_id, &admin, operator.pubkey());
+    context
+        .svm
+        .airdrop(&operator.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&guardian.pubkey(), 1_000_000_000)
+        .unwrap();
+    context
+        .svm
+        .airdrop(&root_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let new_passkey = create_test_secp256r1_public_key();
+    let id = rand::random::<[u8; 32]>();
+    let swig = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id()).0;
+    let swig_wallet_address =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+
+    create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+
+    let recovery_program_id_bytes = recovery_program_id.to_bytes();
+    let program_exec_data = ProgramExecAuthority::create_authority_data(
+        &recovery_program_id_bytes,
+        &EXECUTE_RECOVERY_V1_DISCRIMINATOR,
+    );
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::ProgramExec,
+            authority: &program_exec_data,
+        },
+        vec![ClientAction::RecoveryAuthority(RecoveryAuthority {})],
+    )
+    .unwrap();
+
+    let delay_slots = 10;
+    configure_recovery(
+        &mut context,
+        recovery_program_id,
+        &operator,
+        swig_wallet_address,
+        0,
+        guardian.pubkey(),
+        delay_slots,
+    );
+    start_recovery(
+        &mut context,
+        recovery_program_id,
+        &guardian,
+        swig_wallet_address,
+        0,
+        AuthorityType::Ed25519,
+        AuthorityType::Secp256r1,
+        root_authority.pubkey().as_ref(),
+        &new_passkey,
+    );
+    context
+        .svm
+        .warp_to_slot(context.svm.get_sysvar::<Clock>().slot + delay_slots + 1);
+    context.svm.expire_blockhash();
+
+    let execute_ix = execute_recovery_v1_instruction(
+        recovery_program_id,
+        swig,
+        swig_wallet_address,
+        0,
+        AuthorityType::Ed25519 as u16,
+        AuthorityType::Secp256r1 as u16,
+        root_authority.pubkey().as_ref(),
+        &new_passkey,
+    );
+    let instructions = RecoverAuthorityInstruction::new_with_program_exec_and_payer(
+        swig,
+        swig_wallet_address,
+        execute_ix,
+        1,
+        context.default_payer.pubkey(),
+    )
+    .unwrap();
+
+    send_recovery_transaction(&mut context, &instructions).unwrap();
+
+    let swig_account = context.svm.get_account(&swig).unwrap();
+    let swig_state = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    let recovered_role = swig_state.get_role(0).unwrap().unwrap();
+    let recovered_authority = recovered_role
+        .authority
+        .as_any()
+        .downcast_ref::<Secp256r1Authority>()
+        .unwrap();
+
+    assert_eq!(recovered_authority.public_key, new_passkey);
+    assert_eq!(recovered_authority.signature_odometer, 0);
 }
 
 #[test_log::test]
@@ -538,6 +796,7 @@ fn test_program_exec_recovery_rotates_secp256k1_authority() {
         swig_wallet_address,
         1,
         AuthorityType::Secp256k1,
+        AuthorityType::Secp256k1,
         &old_authority,
         &new_authority,
     );
@@ -551,6 +810,7 @@ fn test_program_exec_recovery_rotates_secp256k1_authority() {
         swig,
         swig_wallet_address,
         1,
+        AuthorityType::Secp256k1 as u16,
         AuthorityType::Secp256k1 as u16,
         &old_authority,
         &new_authority,
@@ -658,6 +918,7 @@ fn test_program_exec_recovery_requires_recovery_authority_permission() {
         swig_wallet_address,
         1,
         AuthorityType::Secp256r1,
+        AuthorityType::Secp256r1,
         &old_passkey,
         &new_passkey,
     );
@@ -671,6 +932,7 @@ fn test_program_exec_recovery_requires_recovery_authority_permission() {
         swig,
         swig_wallet_address,
         1,
+        AuthorityType::Secp256r1 as u16,
         AuthorityType::Secp256r1 as u16,
         &old_passkey,
         &new_passkey,
@@ -786,6 +1048,7 @@ fn test_recovery_binding_rejects_pending_account_mismatch() {
         swig_wallet_address,
         1,
         AuthorityType::Secp256r1,
+        AuthorityType::Secp256r1,
         &primary_passkey,
         &new_legit_passkey,
     );
@@ -799,6 +1062,7 @@ fn test_recovery_binding_rejects_pending_account_mismatch() {
         swig,
         swig_wallet_address,
         1,
+        AuthorityType::Secp256r1 as u16,
         AuthorityType::Secp256r1 as u16,
         &primary_passkey,
         &new_legit_passkey,
@@ -912,6 +1176,7 @@ fn test_recovery_rejects_authority_type_mismatch() {
         swig_wallet_address,
         1,
         AuthorityType::Ed25519,
+        AuthorityType::Ed25519,
         root_authority.pubkey().as_ref(),
         new_ed25519_authority.pubkey().as_ref(),
     );
@@ -925,6 +1190,7 @@ fn test_recovery_rejects_authority_type_mismatch() {
         swig,
         swig_wallet_address,
         1,
+        AuthorityType::Ed25519 as u16,
         AuthorityType::Ed25519 as u16,
         root_authority.pubkey().as_ref(),
         new_ed25519_authority.pubkey().as_ref(),


### PR DESCRIPTION
## Summary
- lets recover_authority_v1 rotate recovered roles across Ed25519, Secp256k1, and Secp256r1 authority types
- rewrites role authority bytes and shifts action/role data for shrink and grow cases
- funds rent when recovery grows the Swig account and adds interface support for payer/system accounts
- covers same-type and cross-type ProgramExec recovery paths in LiteSVM tests

## Tests
- cargo check -p swig
- cargo build-sbf (passes; existing SignV2/iterator stack-frame warnings remain)
- cargo test -p swig --test recover_authority_test

This is stacked on codex/sign-v2-cu-comparison because the recovery tests and implementation depend on that branch state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anagrambuild/codesmith/swig-wallet/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785507598&installation_id=138016541&pr_number=183&repository=anagrambuild%2Fswig-wallet&return_to=https%3A%2F%2Fgithub.com%2Fanagrambuild%2Fswig-wallet%2Fpull%2F183&signature=e68f6ae1b52df8d2399204e97913f05936bdb0252ae3d7bcfa3cc9c57d7b5ffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->