### PR TITLE
Rent Cliamer: PR comment fixes

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -3418,8 +3418,13 @@ impl SetRentClaimerV1Instruction {
             );
         }
 
-        let nonced_payload =
-            prepare_secp256k1_payload(current_slot, counter, args_bytes, &account_payload_bytes, &[]);
+        let nonced_payload = prepare_secp256k1_payload(
+            current_slot,
+            counter,
+            args_bytes,
+            &account_payload_bytes,
+            &[],
+        );
         let signature = authority_payload_fn(&nonced_payload);
         let mut authority_payload = Vec::new();
         authority_payload.extend_from_slice(&current_slot.to_le_bytes());
@@ -3471,7 +3476,13 @@ impl SetRentClaimerV1Instruction {
         let slot_bytes = current_slot.to_le_bytes();
         let counter_bytes = counter.to_le_bytes();
         let message_hash = keccak::hash(
-            &[args_bytes, &account_payload_bytes, &slot_bytes[..], &counter_bytes[..]].concat(),
+            &[
+                args_bytes,
+                &account_payload_bytes,
+                &slot_bytes[..],
+                &counter_bytes[..],
+            ]
+            .concat(),
         )
         .to_bytes();
 

--- a/program/src/actions/add_authority_v1.rs
+++ b/program/src/actions/add_authority_v1.rs
@@ -15,8 +15,8 @@ use swig_state::{
     action::{all::All, manage_authority::ManageAuthority},
     authority::{authority_type_to_length, AuthorityType},
     role::Position,
-    tail::SavedTail,
     swig::{Swig, SwigBuilder},
+    tail::SavedTail,
     Discriminator, IntoBytes, SwigAuthenticateError, Transmutable, TransmutableMut,
 };
 
@@ -253,7 +253,8 @@ pub fn add_authority_v1(
         }
     }
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
-    let (swig_header, roles_and_tail) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+    let (swig_header, roles_and_tail) =
+        unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
     let roles_capacity_len = roles_and_tail
         .len()
         .checked_sub(saved_tail.len())

--- a/program/src/actions/mod.rs
+++ b/program/src/actions/mod.rs
@@ -29,9 +29,8 @@ use self::{
     add_authority_v1::*, close_swig_v1::*, close_token_account_v1::*, create_session_v1::*,
     create_sub_account_v1::*, create_v1::*, migrate_to_wallet_address_v1::*,
     recover_authority_v1::*, remove_authority_v1::*, set_rent_claimer_v1::*, sign_v2::*,
-    sub_account_sign_v1::*,
-    toggle_sub_account_v1::*, transfer_assets_v1::*, update_authority_v1::*,
-    withdraw_from_sub_account_v1::*,
+    sub_account_sign_v1::*, toggle_sub_account_v1::*, transfer_assets_v1::*,
+    update_authority_v1::*, withdraw_from_sub_account_v1::*,
 };
 use crate::{
     instruction::{
@@ -39,9 +38,9 @@ use crate::{
             AddAuthorityV1Accounts, CloseSwigV1Accounts, CloseTokenAccountV1Accounts,
             CreateSessionV1Accounts, CreateSubAccountV1Accounts, CreateV1Accounts,
             MigrateToWalletAddressV1Accounts, RecoverAuthorityV1Accounts,
-            RemoveAuthorityV1Accounts, SetRentClaimerV1Accounts, SignV2Accounts, SubAccountSignV1Accounts,
-            ToggleSubAccountV1Accounts, TransferAssetsV1Accounts, UpdateAuthorityV1Accounts,
-            WithdrawFromSubAccountV1Accounts,
+            RemoveAuthorityV1Accounts, SetRentClaimerV1Accounts, SignV2Accounts,
+            SubAccountSignV1Accounts, ToggleSubAccountV1Accounts, TransferAssetsV1Accounts,
+            UpdateAuthorityV1Accounts, WithdrawFromSubAccountV1Accounts,
         },
         SwigInstruction,
     },

--- a/program/src/actions/remove_authority_v1.rs
+++ b/program/src/actions/remove_authority_v1.rs
@@ -12,8 +12,8 @@ use pinocchio::{
 use swig_assertions::{check_bytes_match, check_self_owned};
 use swig_state::{
     action::{all::All, manage_authority::ManageAuthority},
-    tail::SavedTail,
     swig::{Swig, SwigBuilder},
+    tail::SavedTail,
     Discriminator, IntoBytes, SwigAuthenticateError, Transmutable, TransmutableMut,
 };
 

--- a/program/src/actions/set_rent_claimer_v1.rs
+++ b/program/src/actions/set_rent_claimer_v1.rs
@@ -9,7 +9,7 @@ use pinocchio_system::instructions::Transfer;
 use swig_assertions::{check_bytes_match, check_self_owned};
 use swig_state::{
     action::{all::All, close_swig_authority::CloseSwigAuthority},
-    swig::Swig,
+    swig::{swig_wallet_address_seeds_with_bump, Swig},
     tail::rent_claimer,
     Discriminator, IntoBytes, SwigAuthenticateError, Transmutable,
 };
@@ -102,7 +102,17 @@ pub fn set_rent_claimer_v1(
 
     {
         let parts = Swig::split_parts_mut(swig_account_data)?;
-        let _swig = parts.state;
+        let swig = parts.state;
+
+        let wallet_bump = [swig.wallet_bump];
+        let wallet_address = pinocchio::pubkey::create_program_address(
+            &swig_wallet_address_seeds_with_bump(ctx.accounts.swig.key().as_ref(), &wallet_bump),
+            &crate::ID,
+        )?;
+        if set_ix.args.rent_claimer == wallet_address {
+            return Err(SwigError::InvalidRentClaimerValue.into());
+        }
+
         let acting_role = Swig::get_mut_role(set_ix.args.role_id, parts.roles)?
             .ok_or(SwigError::InvalidAuthorityNotFoundByRoleId)?;
 

--- a/program/src/actions/set_rent_claimer_v1.rs
+++ b/program/src/actions/set_rent_claimer_v1.rs
@@ -90,6 +90,9 @@ pub fn set_rent_claimer_v1(
     if set_ix.args.rent_claimer == [0u8; 32] {
         return Err(SwigError::InvalidRentClaimerValue.into());
     }
+    if &set_ix.args.rent_claimer == ctx.accounts.swig.key() {
+        return Err(SwigError::InvalidRentClaimerValue.into());
+    }
 
     let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
     if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {

--- a/program/src/actions/update_authority_v1.rs
+++ b/program/src/actions/update_authority_v1.rs
@@ -15,8 +15,8 @@ use swig_state::{
     action::{all::All, manage_authority::ManageAuthority, Action, ActionLoader},
     authority::{authority_type_to_length, AuthorityType},
     role::Position,
-    tail::SavedTail,
     swig::Swig,
+    tail::SavedTail,
     Discriminator, IntoBytes, SwigAuthenticateError, SwigStateError, Transmutable, TransmutableMut,
 };
 
@@ -647,8 +647,9 @@ pub fn update_authority_v1(
                 if cursor + Position::LEN > roles_len {
                     return Err(ProgramError::InvalidAccountData);
                 }
-                let position =
-                    unsafe { Position::load_unchecked(&swig_roles[cursor..cursor + Position::LEN])? };
+                let position = unsafe {
+                    Position::load_unchecked(&swig_roles[cursor..cursor + Position::LEN])?
+                };
                 let boundary = position.boundary() as usize;
                 if boundary < cursor + Position::LEN || boundary > roles_len {
                     return Err(ProgramError::InvalidAccountData);
@@ -671,24 +672,24 @@ pub fn update_authority_v1(
         };
 
         let prealloc_size_diff = match operation {
-        AuthorityUpdateOperation::ReplaceAll => {
-            let new_actions = update_authority_v1.get_actions_data()?;
-            new_actions.len() as i64 - current_actions_size as i64
-        },
-        AuthorityUpdateOperation::AddActions => {
-            let new_actions = update_authority_v1.get_actions_data()?;
-            new_actions.len() as i64 // Adding to existing, so just the new size
-        },
-        AuthorityUpdateOperation::RemoveActionsByType => {
-            // For remove operations, we need to calculate how much will be removed
-            // This is complex, so for now we'll calculate it in the operation function
-            0 // Will be calculated in the operation
-        },
-        AuthorityUpdateOperation::RemoveActionsByIndex => {
-            // For remove operations, we need to calculate how much will be removed
-            // This is complex, so for now we'll calculate it in the operation function
-            0 // Will be calculated in the operation
-        },
+            AuthorityUpdateOperation::ReplaceAll => {
+                let new_actions = update_authority_v1.get_actions_data()?;
+                new_actions.len() as i64 - current_actions_size as i64
+            },
+            AuthorityUpdateOperation::AddActions => {
+                let new_actions = update_authority_v1.get_actions_data()?;
+                new_actions.len() as i64 // Adding to existing, so just the new size
+            },
+            AuthorityUpdateOperation::RemoveActionsByType => {
+                // For remove operations, we need to calculate how much will be removed
+                // This is complex, so for now we'll calculate it in the operation function
+                0 // Will be calculated in the operation
+            },
+            AuthorityUpdateOperation::RemoveActionsByIndex => {
+                // For remove operations, we need to calculate how much will be removed
+                // This is complex, so for now we'll calculate it in the operation function
+                0 // Will be calculated in the operation
+            },
         };
 
         (
@@ -736,8 +737,7 @@ pub fn update_authority_v1(
         .len()
         .checked_sub(saved_tail.len())
         .ok_or(ProgramError::InvalidAccountData)?;
-    let (swig_roles, _) =
-        unsafe { swig_roles_and_tail.split_at_mut_unchecked(roles_capacity_len) };
+    let (swig_roles, _) = unsafe { swig_roles_and_tail.split_at_mut_unchecked(roles_capacity_len) };
 
     // Now perform the operation with the reallocated account
     let size_diff = match operation {
@@ -863,7 +863,11 @@ mod tests {
             Action::LEN as u32 + all_data.len() as u32,
         );
         let all_actions = [all_header.into_bytes()?, all_data].concat();
-        builder.add_role(AuthorityType::Ed25519, authority.into_bytes()?, &all_actions)?;
+        builder.add_role(
+            AuthorityType::Ed25519,
+            authority.into_bytes()?,
+            &all_actions,
+        )?;
         drop(builder);
 
         let roles_end = Swig::roles_end_offset(&account_buffer)?;
@@ -895,7 +899,12 @@ mod tests {
             let authority_offset = 0usize;
             let actions_offset = Position::LEN + position.authority_length() as usize;
             let current_actions_size = position.boundary() as usize - actions_offset;
-            (roles.len(), authority_offset, actions_offset, current_actions_size)
+            (
+                roles.len(),
+                authority_offset,
+                actions_offset,
+                current_actions_size,
+            )
         };
 
         {

--- a/program/tests/close_swig_test.rs
+++ b/program/tests/close_swig_test.rs
@@ -120,7 +120,10 @@ fn test_close_swig_with_configured_rent_claimer_destination_mismatch_fails() {
     let message = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
@@ -171,7 +174,10 @@ fn test_close_swig_with_configured_rent_claimer_destination_match_succeeds() {
     let message = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
@@ -179,7 +185,10 @@ fn test_close_swig_with_configured_rent_claimer_destination_match_succeeds() {
     );
     let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
     let result = context.svm.send_transaction(tx);
-    assert!(result.is_ok(), "close should succeed with pinned destination");
+    assert!(
+        result.is_ok(),
+        "close should succeed with pinned destination"
+    );
 
     let claimer_lamports_after = context
         .svm
@@ -187,8 +196,8 @@ fn test_close_swig_with_configured_rent_claimer_destination_match_succeeds() {
         .map(|a| a.lamports)
         .unwrap_or(0);
     let expected_closed_account_rent = context.svm.minimum_balance_for_rent_exemption(1);
-    let expected_reclaimed = wallet_lamports_before
-        + swig_lamports_before.saturating_sub(expected_closed_account_rent);
+    let expected_reclaimed =
+        wallet_lamports_before + swig_lamports_before.saturating_sub(expected_closed_account_rent);
 
     let swig_lamports_after = context.svm.get_account(&swig_pubkey).unwrap().lamports;
     let wallet_lamports_after = context
@@ -196,10 +205,22 @@ fn test_close_swig_with_configured_rent_claimer_destination_match_succeeds() {
         .get_account(&swig_wallet_address)
         .map(|a| a.lamports)
         .unwrap_or(0);
-    println!("claimer_lamports_before: {} after: {}", claimer_lamports_before, claimer_lamports_after);
-    println!("swig_wallet_lamports_before: {} after: {}", wallet_lamports_before, wallet_lamports_after);
-    println!("swig_lamports_before: {} after: {}", swig_lamports_before, swig_lamports_after);
-    println!("expected_closed_account_rent: {}", expected_closed_account_rent);
+    println!(
+        "claimer_lamports_before: {} after: {}",
+        claimer_lamports_before, claimer_lamports_after
+    );
+    println!(
+        "swig_wallet_lamports_before: {} after: {}",
+        wallet_lamports_before, wallet_lamports_after
+    );
+    println!(
+        "swig_lamports_before: {} after: {}",
+        swig_lamports_before, swig_lamports_after
+    );
+    println!(
+        "expected_closed_account_rent: {}",
+        expected_closed_account_rent
+    );
     println!("expected_reclaimed: {}", expected_reclaimed);
     assert_eq!(
         claimer_lamports_after.saturating_sub(claimer_lamports_before),
@@ -257,7 +278,10 @@ fn test_rent_claimer_receives_rent_from_close_token_then_close_swig() {
     let close_token_msg = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_token_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_token_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
@@ -283,7 +307,10 @@ fn test_rent_claimer_receives_rent_from_close_token_then_close_swig() {
     let close_swig_msg = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_swig_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_swig_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )

--- a/program/tests/close_token_account_test.rs
+++ b/program/tests/close_token_account_test.rs
@@ -145,7 +145,10 @@ fn test_close_token_account_with_configured_rent_claimer_destination_mismatch_fa
     let message = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
@@ -202,7 +205,10 @@ fn test_close_token_account_with_configured_rent_claimer_destination_match_succe
     let message = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
@@ -210,7 +216,10 @@ fn test_close_token_account_with_configured_rent_claimer_destination_match_succe
     );
     let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
     let result = context.svm.send_transaction(tx);
-    assert!(result.is_ok(), "close token should succeed with pinned destination");
+    assert!(
+        result.is_ok(),
+        "close token should succeed with pinned destination"
+    );
 
     let claimer_after = context
         .svm

--- a/program/tests/common/mod.rs
+++ b/program/tests/common/mod.rs
@@ -121,7 +121,10 @@ pub fn set_rent_claimer_with_ed25519(
     )?;
     let msg = v0::Message::try_compile(
         &context.default_payer.pubkey(),
-        &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), set_ix],
+        &[
+            ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+            set_ix,
+        ],
         &[],
         context.svm.latest_blockhash(),
     )?;

--- a/program/tests/rent_claimer_matrix_test.rs
+++ b/program/tests/rent_claimer_matrix_test.rs
@@ -153,20 +153,19 @@ fn create_test_secp256r1_keypair() -> (openssl::ec::EcKey<openssl::pkey::Private
 // A. SetRentClaimerV1 — core set semantics
 // ===========================================================================
 
-/// A5: setting the claimer to the swig account's own pubkey is allowed (no
-/// special-casing) — first-write-wins still applies.
+/// A5: setting the claimer to the swig account's own pubkey is rejected —
+/// the swig cannot be its own rent claimer.
 #[test_log::test]
-fn a5_set_claimer_to_swig_itself_succeeds() {
+fn a5_set_claimer_to_swig_itself_fails() {
     let mut context = setup_test_context().unwrap();
     let authority = Keypair::new();
     let id = rand::random::<[u8; 32]>();
     let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
 
-    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, swig_pubkey).unwrap();
-    assert_eq!(
-        configured_claimer(&context, &swig_pubkey),
-        Some(swig_pubkey.to_bytes())
-    );
+    let result =
+        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, swig_pubkey);
+    assert!(result.is_err(), "swig as its own rent claimer must fail");
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
 }
 
 /// A6: setting the claimer to the acting authority's own pubkey is allowed.

--- a/program/tests/rent_claimer_matrix_test.rs
+++ b/program/tests/rent_claimer_matrix_test.rs
@@ -168,6 +168,29 @@ fn a5_set_claimer_to_swig_itself_fails() {
     assert_eq!(configured_claimer(&context, &swig_pubkey), None);
 }
 
+/// A5b: setting the claimer to the swig wallet address PDA is rejected —
+/// close proceeds must not be routed back into the wallet's own accounts.
+#[test_log::test]
+fn a5b_set_claimer_to_wallet_address_fails() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    let result = set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        0,
+        wallet_address(&swig_pubkey),
+    );
+    assert!(
+        result.is_err(),
+        "swig wallet address as rent claimer must fail"
+    );
+    assert_eq!(configured_claimer(&context, &swig_pubkey), None);
+}
+
 /// A6: setting the claimer to the acting authority's own pubkey is allowed.
 /// (The §3 attack is only relevant to *mutation*, which v1 forbids.)
 #[test_log::test]

--- a/program/tests/rent_claimer_matrix_test.rs
+++ b/program/tests/rent_claimer_matrix_test.rs
@@ -54,7 +54,10 @@ fn configured_claimer(context: &SwigTestContext, swig_pubkey: &Pubkey) -> Option
 /// Number of roles currently stored on the swig.
 fn role_count(context: &SwigTestContext, swig_pubkey: &Pubkey) -> u16 {
     let account = context.svm.get_account(swig_pubkey).unwrap();
-    SwigWithRoles::from_bytes(&account.data).unwrap().state.roles
+    SwigWithRoles::from_bytes(&account.data)
+        .unwrap()
+        .state
+        .roles
 }
 
 fn account_len(context: &SwigTestContext, swig_pubkey: &Pubkey) -> usize {
@@ -62,7 +65,11 @@ fn account_len(context: &SwigTestContext, swig_pubkey: &Pubkey) -> usize {
 }
 
 fn lamports_of(context: &SwigTestContext, key: &Pubkey) -> u64 {
-    context.svm.get_account(key).map(|a| a.lamports).unwrap_or(0)
+    context
+        .svm
+        .get_account(key)
+        .map(|a| a.lamports)
+        .unwrap_or(0)
 }
 
 fn wallet_address(swig_pubkey: &Pubkey) -> Pubkey {
@@ -156,7 +163,10 @@ fn a5_set_claimer_to_swig_itself_succeeds() {
     let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
 
     set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, swig_pubkey).unwrap();
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(swig_pubkey.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(swig_pubkey.to_bytes())
+    );
 }
 
 /// A6: setting the claimer to the acting authority's own pubkey is allowed.
@@ -168,8 +178,14 @@ fn a6_set_claimer_to_acting_authority_succeeds() {
     let id = rand::random::<[u8; 32]>();
     let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
 
-    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 0, authority.pubkey())
-        .unwrap();
+    set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        0,
+        authority.pubkey(),
+    )
+    .unwrap();
     assert_eq!(
         configured_claimer(&context, &swig_pubkey),
         Some(authority.pubkey().to_bytes())
@@ -185,8 +201,13 @@ fn a8_set_with_unknown_role_id_fails() {
     let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
 
     // Role 7 does not exist; signing key is the real root.
-    let result =
-        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &authority, 7, Keypair::new().pubkey());
+    let result = set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &authority,
+        7,
+        Keypair::new().pubkey(),
+    );
     assert!(result.is_err(), "unknown role_id must fail");
     assert_eq!(configured_claimer(&context, &swig_pubkey), None);
 }
@@ -218,7 +239,10 @@ fn b2_close_swig_authority_can_set() {
 
     let claimer = Keypair::new().pubkey();
     set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &closer, 1, claimer).unwrap();
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
 }
 
 /// B3: `ManageAuthority` alone is explicitly insufficient to set.
@@ -242,9 +266,17 @@ fn b3_manage_authority_cannot_set() {
     )
     .unwrap();
 
-    let result =
-        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &manager, 1, Keypair::new().pubkey());
-    assert!(result.is_err(), "ManageAuthority must not be able to set the rent claimer");
+    let result = set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &manager,
+        1,
+        Keypair::new().pubkey(),
+    );
+    assert!(
+        result.is_err(),
+        "ManageAuthority must not be able to set the rent claimer"
+    );
     assert_eq!(configured_claimer(&context, &swig_pubkey), None);
 }
 
@@ -267,12 +299,19 @@ fn b4_all_but_manage_authority_cannot_set() {
             authority_type: AuthorityType::Ed25519,
             authority: broad.pubkey().as_ref(),
         },
-        vec![ClientAction::AllButManageAuthority(AllButManageAuthority {})],
+        vec![ClientAction::AllButManageAuthority(
+            AllButManageAuthority {},
+        )],
     )
     .unwrap();
 
-    let result =
-        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &broad, 1, Keypair::new().pubkey());
+    let result = set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &broad,
+        1,
+        Keypair::new().pubkey(),
+    );
     assert!(
         result.is_err(),
         "AllButManageAuthority is not one of the two authorized set permissions"
@@ -313,7 +352,10 @@ fn c3_secp256k1_authority_can_set() {
     let message = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), set_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                set_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
@@ -322,7 +364,10 @@ fn c3_secp256k1_authority_can_set() {
     let tx = VersionedTransaction::try_new(message, &[&context.default_payer]).unwrap();
     let result = context.svm.send_transaction(tx);
     assert!(result.is_ok(), "secp256k1 set failed: {:?}", result.err());
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
 }
 
 /// C6: a Secp256r1 root authority can set the rent claimer.
@@ -366,7 +411,10 @@ fn c6_secp256r1_authority_can_set() {
     let tx = VersionedTransaction::try_new(message, &[&context.default_payer]).unwrap();
     let result = context.svm.send_transaction(tx);
     assert!(result.is_ok(), "secp256r1 set failed: {:?}", result.err());
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
 }
 
 // ===========================================================================
@@ -397,9 +445,15 @@ fn d1_add_authority_preserves_tail() {
     )
     .unwrap();
 
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
     assert_eq!(role_count(&context, &swig_pubkey), 2);
-    assert!(account_len(&context, &swig_pubkey) > len_before, "account should have grown");
+    assert!(
+        account_len(&context, &swig_pubkey) > len_before,
+        "account should have grown"
+    );
     // Tail must remain a clean single entry — read_strict would error otherwise.
 }
 
@@ -450,7 +504,10 @@ fn d3_add_mixed_authority_types_preserves_tail() {
         vec![ClientAction::ManageAuthority(ManageAuthority {})],
     )
     .unwrap();
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
 
     // Secp256k1 authority (64-byte authority) — a different role size.
     let secp = LocalSigner::random();
@@ -471,7 +528,10 @@ fn d3_add_mixed_authority_types_preserves_tail() {
     )
     .unwrap();
 
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
     assert_eq!(role_count(&context, &swig_pubkey), 3);
 }
 
@@ -589,7 +649,10 @@ fn d7_remove_middle_role_preserves_tail() {
         "tail corrupted by middle-role removal"
     );
     assert_eq!(role_count(&context, &swig_pubkey), 2);
-    assert!(account_len(&context, &swig_pubkey) < len_before, "account should have shrunk");
+    assert!(
+        account_len(&context, &swig_pubkey) < len_before,
+        "account should have shrunk"
+    );
 }
 
 /// D8: removing the last role preserves the tail.
@@ -616,7 +679,10 @@ fn d8_remove_last_role_preserves_tail() {
     set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
     remove_authority_with_ed25519_root(&mut context, &swig_pubkey, &root, 1).unwrap();
 
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
     assert_eq!(role_count(&context, &swig_pubkey), 1);
 }
 
@@ -688,7 +754,10 @@ fn d12_update_authority_grow_then_shrink_preserves_tail() {
         Some(claimer.to_bytes()),
         "tail corrupted by update-grow"
     );
-    assert!(account_len(&context, &swig_pubkey) > len_one_action, "update should have grown");
+    assert!(
+        account_len(&context, &swig_pubkey) > len_one_action,
+        "update should have grown"
+    );
 
     // Shrink: drop back to a single action.
     update_authority_replace_with_ed25519_root(
@@ -747,7 +816,10 @@ fn d18_claimer_survives_full_role_churn() {
     // shrink (remove)
     remove_authority_with_ed25519_root(&mut context, &swig_pubkey, &root, 1).unwrap();
 
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
 
     // D19: still immutable after all the reallocs.
     let second = set_rent_claimer_with_ed25519(
@@ -757,7 +829,10 @@ fn d18_claimer_survives_full_role_churn() {
         0,
         Keypair::new().pubkey(),
     );
-    assert!(second.is_err(), "claimer must stay immutable through role churn");
+    assert!(
+        second.is_err(),
+        "claimer must stay immutable through role churn"
+    );
 }
 
 /// D17: setting the claimer AFTER growing the roles writes the tail at the
@@ -783,7 +858,10 @@ fn d17_add_then_set_writes_tail_at_correct_offset() {
 
     let claimer = Keypair::new().pubkey();
     set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, claimer).unwrap();
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
     assert_eq!(role_count(&context, &swig_pubkey), 2);
 }
 
@@ -801,7 +879,11 @@ fn f1_unset_close_allows_any_destination() {
 
     let destination = Keypair::new().pubkey();
     let result = close_swig_ed25519(&mut context, &swig_pubkey, &root, 0, &destination);
-    assert!(result.is_ok(), "unset wallet should close to any destination: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "unset wallet should close to any destination: {:?}",
+        result.err()
+    );
 }
 
 /// F4: a delegated `CloseSwigAuthority` role can wind the wallet down, but only
@@ -857,7 +939,13 @@ fn g3_unset_token_close_allows_any_destination() {
     let swig_wallet_address = wallet_address(&swig_pubkey);
 
     let mint = setup_mint(&mut context.svm, &context.default_payer).unwrap();
-    let ata = setup_ata(&mut context.svm, &mint, &swig_wallet_address, &context.default_payer).unwrap();
+    let ata = setup_ata(
+        &mut context.svm,
+        &mint,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
 
     let destination = Keypair::new().pubkey();
     let close_ix = CloseTokenAccountV1Instruction::new_with_ed25519_authority(
@@ -873,14 +961,20 @@ fn g3_unset_token_close_allows_any_destination() {
     let message = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
         .unwrap(),
     );
     let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &root]).unwrap();
-    assert!(context.svm.send_transaction(tx).is_ok(), "unset token close to any dest should succeed");
+    assert!(
+        context.svm.send_transaction(tx).is_ok(),
+        "unset token close to any dest should succeed"
+    );
 }
 
 /// G4 + G5: closing multiple token accounts in one ix routes to the pinned
@@ -898,8 +992,20 @@ fn g4_g5_multiple_token_accounts_respect_pin() {
 
     let mint1 = setup_mint(&mut context.svm, &context.default_payer).unwrap();
     let mint2 = setup_mint(&mut context.svm, &context.default_payer).unwrap();
-    let ata1 = setup_ata(&mut context.svm, &mint1, &swig_wallet_address, &context.default_payer).unwrap();
-    let ata2 = setup_ata(&mut context.svm, &mint2, &swig_wallet_address, &context.default_payer).unwrap();
+    let ata1 = setup_ata(
+        &mut context.svm,
+        &mint1,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    let ata2 = setup_ata(
+        &mut context.svm,
+        &mint2,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
     let total_rent = lamports_of(&context, &ata1) + lamports_of(&context, &ata2);
 
     // G5: wrong destination rejects all.
@@ -917,16 +1023,29 @@ fn g4_g5_multiple_token_accounts_respect_pin() {
     let msg = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_wrong],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_wrong,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
         .unwrap(),
     );
     let tx = VersionedTransaction::try_new(msg, &[&context.default_payer, &root]).unwrap();
-    assert!(context.svm.send_transaction(tx).is_err(), "wrong dest must reject all token closes");
+    assert!(
+        context.svm.send_transaction(tx).is_err(),
+        "wrong dest must reject all token closes"
+    );
     // Nothing should have moved.
-    assert!(context.svm.get_account(&ata1).map(|a| a.lamports).unwrap_or(0) > 0);
+    assert!(
+        context
+            .svm
+            .get_account(&ata1)
+            .map(|a| a.lamports)
+            .unwrap_or(0)
+            > 0
+    );
 
     // G4: correct destination routes all rent to the claimer.
     let claimer_before = lamports_of(&context, &claimer.pubkey());
@@ -943,14 +1062,20 @@ fn g4_g5_multiple_token_accounts_respect_pin() {
     let msg = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), close_ok],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                close_ok,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
         .unwrap(),
     );
     let tx = VersionedTransaction::try_new(msg, &[&context.default_payer, &root]).unwrap();
-    assert!(context.svm.send_transaction(tx).is_ok(), "pinned dest should close all token accounts");
+    assert!(
+        context.svm.send_transaction(tx).is_ok(),
+        "pinned dest should close all token accounts"
+    );
     assert_eq!(
         lamports_of(&context, &claimer.pubkey()).saturating_sub(claimer_before),
         total_rent,
@@ -972,11 +1097,21 @@ fn h1_set_grows_by_entry_len_and_stays_rent_exempt() {
     let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
     let len_before = account_len(&context, &swig_pubkey);
 
-    set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, Keypair::new().pubkey())
-        .unwrap();
+    set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        0,
+        Keypair::new().pubkey(),
+    )
+    .unwrap();
 
     let len_after = account_len(&context, &swig_pubkey);
-    assert_eq!(len_after - len_before, rent_claimer::ENTRY_LEN, "should grow by exactly 40 bytes");
+    assert_eq!(
+        len_after - len_before,
+        rent_claimer::ENTRY_LEN,
+        "should grow by exactly 40 bytes"
+    );
     assert_eq!(
         lamports_of(&context, &swig_pubkey),
         context.svm.minimum_balance_for_rent_exemption(len_after),
@@ -1008,14 +1143,20 @@ fn h2_insufficient_payer_fails_cleanly() {
     let message = VersionedMessage::V0(
         v0::Message::try_compile(
             &poor_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), set_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                set_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )
         .unwrap(),
     );
     let tx = VersionedTransaction::try_new(message, &[&poor_payer, &root]).unwrap();
-    assert!(context.svm.send_transaction(tx).is_err(), "underfunded payer must fail the set");
+    assert!(
+        context.svm.send_transaction(tx).is_err(),
+        "underfunded payer must fail the set"
+    );
     assert_eq!(configured_claimer(&context, &swig_pubkey), None);
 }
 
@@ -1097,9 +1238,12 @@ fn k1_bundled_create_and_set_is_atomic() {
     let id = rand::random::<[u8; 32]>();
     let payer = context.default_payer.pubkey();
 
-    let (swig_pubkey, swig_bump) = Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
-    let (swig_wallet_address, wallet_bump) =
-        Pubkey::find_program_address(&swig_wallet_address_seeds(swig_pubkey.as_ref()), &program_id());
+    let (swig_pubkey, swig_bump) =
+        Pubkey::find_program_address(&swig_account_seeds(&id), &program_id());
+    let (swig_wallet_address, wallet_bump) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(swig_pubkey.as_ref()),
+        &program_id(),
+    );
 
     let create_ix = CreateInstruction::new(
         swig_pubkey,
@@ -1141,8 +1285,15 @@ fn k1_bundled_create_and_set_is_atomic() {
     );
     let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
     let result = context.svm.send_transaction(tx);
-    assert!(result.is_ok(), "bundled create+set failed: {:?}", result.err());
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(claimer.to_bytes()));
+    assert!(
+        result.is_ok(),
+        "bundled create+set failed: {:?}",
+        result.err()
+    );
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(claimer.to_bytes())
+    );
 }
 
 /// K2: with `CreateV1` alone, a different authority can win the first-write
@@ -1171,13 +1322,27 @@ fn k2_first_write_wins() {
     // `other` wins the race.
     let other_claimer = Keypair::new().pubkey();
     set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &other, 1, other_claimer).unwrap();
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(other_claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(other_claimer.to_bytes())
+    );
 
     // root loses — the value is immutable.
-    let root_attempt =
-        set_rent_claimer_with_ed25519(&mut context, &swig_pubkey, &root, 0, Keypair::new().pubkey());
-    assert!(root_attempt.is_err(), "first write wins; later set must fail");
-    assert_eq!(configured_claimer(&context, &swig_pubkey), Some(other_claimer.to_bytes()));
+    let root_attempt = set_rent_claimer_with_ed25519(
+        &mut context,
+        &swig_pubkey,
+        &root,
+        0,
+        Keypair::new().pubkey(),
+    );
+    assert!(
+        root_attempt.is_err(),
+        "first write wins; later set must fail"
+    );
+    assert_eq!(
+        configured_claimer(&context, &swig_pubkey),
+        Some(other_claimer.to_bytes())
+    );
 }
 
 /// K3: two `SetRentClaimerV1` in a single transaction — the second fails, so the
@@ -1221,6 +1386,9 @@ fn k3_two_sets_in_one_tx_fails() {
         .unwrap(),
     );
     let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &root]).unwrap();
-    assert!(context.svm.send_transaction(tx).is_err(), "two sets in one tx must fail");
+    assert!(
+        context.svm.send_transaction(tx).is_err(),
+        "two sets in one tx must fail"
+    );
     assert_eq!(configured_claimer(&context, &swig_pubkey), None);
 }

--- a/program/tests/rent_claimer_roles_invariant_test.rs
+++ b/program/tests/rent_claimer_roles_invariant_test.rs
@@ -101,7 +101,10 @@ fn roles_identical_after_add_regardless_of_tail() {
     let (plain, tailed) = create_pair(&mut context, &root, &claimer);
 
     // Baseline: role 0 only — already identical.
-    assert_eq!(roles_bytes(&context, &plain), roles_bytes(&context, &tailed));
+    assert_eq!(
+        roles_bytes(&context, &plain),
+        roles_bytes(&context, &tailed)
+    );
 
     // Same authority keypairs + same actions applied to BOTH wallets.
     // (`ClientAction` isn't `Clone`, so build a fresh vec per call.)
@@ -111,8 +114,14 @@ fn roles_identical_after_add_regardless_of_tail() {
         let mk = || vec![ClientAction::SolLimit(SolLimit { amount })];
         add_authority_with_ed25519_root(&mut context, &plain, &root, ed_config(&kp.pubkey()), mk())
             .unwrap();
-        add_authority_with_ed25519_root(&mut context, &tailed, &root, ed_config(&kp.pubkey()), mk())
-            .unwrap();
+        add_authority_with_ed25519_root(
+            &mut context,
+            &tailed,
+            &root,
+            ed_config(&kp.pubkey()),
+            mk(),
+        )
+        .unwrap();
 
         assert_eq!(
             roles_bytes(&context, &plain),
@@ -122,7 +131,10 @@ fn roles_identical_after_add_regardless_of_tail() {
     }
 
     // The tail is unaffected the whole time; the plain wallet never grew one.
-    assert_eq!(configured_claimer(&context, &tailed), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &tailed),
+        Some(claimer.to_bytes())
+    );
     assert_eq!(configured_claimer(&context, &plain), None);
 }
 
@@ -142,10 +154,19 @@ fn roles_identical_after_remove_middle_regardless_of_tail() {
         let mk = || vec![ClientAction::SolLimit(SolLimit { amount: 7 })];
         add_authority_with_ed25519_root(&mut context, &plain, &root, ed_config(&kp.pubkey()), mk())
             .unwrap();
-        add_authority_with_ed25519_root(&mut context, &tailed, &root, ed_config(&kp.pubkey()), mk())
-            .unwrap();
+        add_authority_with_ed25519_root(
+            &mut context,
+            &tailed,
+            &root,
+            ed_config(&kp.pubkey()),
+            mk(),
+        )
+        .unwrap();
     }
-    assert_eq!(roles_bytes(&context, &plain), roles_bytes(&context, &tailed));
+    assert_eq!(
+        roles_bytes(&context, &plain),
+        roles_bytes(&context, &tailed)
+    );
 
     // Remove the middle role (id 2 = `b`) on both.
     remove_authority_with_ed25519_root(&mut context, &plain, &root, 2).unwrap();
@@ -156,7 +177,10 @@ fn roles_identical_after_remove_middle_regardless_of_tail() {
         roles_bytes(&context, &tailed),
         "roles diverged after middle-role removal"
     );
-    assert_eq!(configured_claimer(&context, &tailed), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &tailed),
+        Some(claimer.to_bytes())
+    );
     // `b` is gone, `a` and `c` remain — on both wallets identically.
     assert!(!has_role_for(&context, &tailed, &b.pubkey()));
     assert!(has_role_for(&context, &tailed, &a.pubkey()));
@@ -174,10 +198,22 @@ fn roles_identical_after_update_regardless_of_tail() {
 
     let target = Keypair::new();
     let mk_init = || vec![ClientAction::ManageAuthority(ManageAuthority {})];
-    add_authority_with_ed25519_root(&mut context, &plain, &root, ed_config(&target.pubkey()), mk_init())
-        .unwrap();
-    add_authority_with_ed25519_root(&mut context, &tailed, &root, ed_config(&target.pubkey()), mk_init())
-        .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &plain,
+        &root,
+        ed_config(&target.pubkey()),
+        mk_init(),
+    )
+    .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &tailed,
+        &root,
+        ed_config(&target.pubkey()),
+        mk_init(),
+    )
+    .unwrap();
 
     // Grow.
     let mk_grown = || {
@@ -187,7 +223,8 @@ fn roles_identical_after_update_regardless_of_tail() {
         ]
     };
     update_authority_replace_with_ed25519_root(&mut context, &plain, &root, 1, mk_grown()).unwrap();
-    update_authority_replace_with_ed25519_root(&mut context, &tailed, &root, 1, mk_grown()).unwrap();
+    update_authority_replace_with_ed25519_root(&mut context, &tailed, &root, 1, mk_grown())
+        .unwrap();
     assert_eq!(
         roles_bytes(&context, &plain),
         roles_bytes(&context, &tailed),
@@ -196,14 +233,19 @@ fn roles_identical_after_update_regardless_of_tail() {
 
     // Shrink.
     let mk_shrunk = || vec![ClientAction::SolLimit(SolLimit { amount: 42 })];
-    update_authority_replace_with_ed25519_root(&mut context, &plain, &root, 1, mk_shrunk()).unwrap();
-    update_authority_replace_with_ed25519_root(&mut context, &tailed, &root, 1, mk_shrunk()).unwrap();
+    update_authority_replace_with_ed25519_root(&mut context, &plain, &root, 1, mk_shrunk())
+        .unwrap();
+    update_authority_replace_with_ed25519_root(&mut context, &tailed, &root, 1, mk_shrunk())
+        .unwrap();
     assert_eq!(
         roles_bytes(&context, &plain),
         roles_bytes(&context, &tailed),
         "roles diverged after update-shrink"
     );
-    assert_eq!(configured_claimer(&context, &tailed), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &tailed),
+        Some(claimer.to_bytes())
+    );
 }
 
 // ===========================================================================
@@ -246,7 +288,10 @@ fn added_role_is_functional_with_tail_present() {
 
     assert_eq!(role_count(&context, &swig), 3);
     assert!(has_role_for(&context, &swig, &downstream.pubkey()));
-    assert_eq!(configured_claimer(&context, &swig), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig),
+        Some(claimer.to_bytes())
+    );
 }
 
 /// After removing a middle role on a tailed wallet, the surviving roles keep
@@ -264,8 +309,22 @@ fn surviving_roles_functional_after_remove_with_tail() {
     set_rent_claimer_with_ed25519(&mut context, &swig, &root, 0, claimer).unwrap();
 
     // role 1 = mid (All), role 2 = survivor (All)
-    add_authority_with_ed25519_root(&mut context, &swig, &root, ed_config(&mid.pubkey()), vec![ClientAction::All(All {})]).unwrap();
-    add_authority_with_ed25519_root(&mut context, &swig, &root, ed_config(&survivor.pubkey()), vec![ClientAction::All(All {})]).unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed_config(&mid.pubkey()),
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed_config(&survivor.pubkey()),
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
 
     // Remove the middle role.
     remove_authority_with_ed25519_root(&mut context, &swig, &root, 1).unwrap();
@@ -283,7 +342,10 @@ fn surviving_roles_functional_after_remove_with_tail() {
     .unwrap();
 
     assert!(has_role_for(&context, &swig, &downstream.pubkey()));
-    assert_eq!(configured_claimer(&context, &swig), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig),
+        Some(claimer.to_bytes())
+    );
 }
 
 /// An `update` to a role's permissions takes real effect even with a tail set:
@@ -317,7 +379,10 @@ fn update_changes_effective_permissions_with_tail() {
         ed_config(&Keypair::new().pubkey()),
         vec![ClientAction::SolLimit(SolLimit { amount: 1 })],
     );
-    assert!(before.is_err(), "SolLimit-only role must not manage authorities");
+    assert!(
+        before.is_err(),
+        "SolLimit-only role must not manage authorities"
+    );
 
     // Grant ManageAuthority via update (root acting).
     update_authority_replace_with_ed25519_root(
@@ -343,7 +408,10 @@ fn update_changes_effective_permissions_with_tail() {
     )
     .unwrap();
     assert!(has_role_for(&context, &swig, &added.pubkey()));
-    assert_eq!(configured_claimer(&context, &swig), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig),
+        Some(claimer.to_bytes())
+    );
 }
 
 /// A role can actually SPEND from the wallet (SignV2 SOL transfer) with the tail
@@ -378,47 +446,81 @@ fn roles_can_sign_v2_spend_with_tail_present() {
         &swig_wallet_address,
         2_000_000_000,
     );
-    let fund_msg = v0::Message::try_compile(&root.pubkey(), &[fund_ix], &[], context.svm.latest_blockhash()).unwrap();
+    let fund_msg = v0::Message::try_compile(
+        &root.pubkey(),
+        &[fund_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
     context
         .svm
-        .send_transaction(VersionedTransaction::try_new(VersionedMessage::V0(fund_msg), &[&root]).unwrap())
+        .send_transaction(
+            VersionedTransaction::try_new(VersionedMessage::V0(fund_msg), &[&root]).unwrap(),
+        )
         .unwrap();
 
     // Helper closure: spend `amount` via SignV2 using `(authority, role_id)`.
-    let mut spend = |context: &mut SwigTestContext, authority: &Keypair, role_id: u32, amount: u64| {
-        let recipient = Keypair::new().pubkey();
-        let transfer_ix =
-            solana_system_interface::instruction::transfer(&swig_wallet_address, &recipient, amount);
-        let sign_ix =
-            SignV2Instruction::new_ed25519(swig, swig_wallet_address, authority.pubkey(), transfer_ix, role_id)
-                .unwrap();
-        let msg = v0::Message::try_compile(
-            &context.default_payer.pubkey(),
-            &[sign_ix],
-            &[],
-            context.svm.latest_blockhash(),
-        )
-        .unwrap();
-        let tx = VersionedTransaction::try_new(
-            VersionedMessage::V0(msg),
-            &[&context.default_payer, authority],
-        )
-        .unwrap();
-        let result = context.svm.send_transaction(tx);
-        assert!(result.is_ok(), "SignV2 spend failed: {:?}", result.err());
-        (recipient, amount)
-    };
+    let mut spend =
+        |context: &mut SwigTestContext, authority: &Keypair, role_id: u32, amount: u64| {
+            let recipient = Keypair::new().pubkey();
+            let transfer_ix = solana_system_interface::instruction::transfer(
+                &swig_wallet_address,
+                &recipient,
+                amount,
+            );
+            let sign_ix = SignV2Instruction::new_ed25519(
+                swig,
+                swig_wallet_address,
+                authority.pubkey(),
+                transfer_ix,
+                role_id,
+            )
+            .unwrap();
+            let msg = v0::Message::try_compile(
+                &context.default_payer.pubkey(),
+                &[sign_ix],
+                &[],
+                context.svm.latest_blockhash(),
+            )
+            .unwrap();
+            let tx = VersionedTransaction::try_new(
+                VersionedMessage::V0(msg),
+                &[&context.default_payer, authority],
+            )
+            .unwrap();
+            let result = context.svm.send_transaction(tx);
+            assert!(result.is_ok(), "SignV2 spend failed: {:?}", result.err());
+            (recipient, amount)
+        };
 
     // Root (role 0) spends.
     let (r1, a1) = spend(&mut context, &root, 0, 100_000_000);
-    assert_eq!(context.svm.get_account(&r1).map(|a| a.lamports).unwrap_or(0), a1);
+    assert_eq!(
+        context
+            .svm
+            .get_account(&r1)
+            .map(|a| a.lamports)
+            .unwrap_or(0),
+        a1
+    );
 
     // Added authority (role 1) spends.
     let (r2, a2) = spend(&mut context, &spender, 1, 150_000_000);
-    assert_eq!(context.svm.get_account(&r2).map(|a| a.lamports).unwrap_or(0), a2);
+    assert_eq!(
+        context
+            .svm
+            .get_account(&r2)
+            .map(|a| a.lamports)
+            .unwrap_or(0),
+        a2
+    );
 
     // The tail survived all of the signing activity.
-    assert_eq!(configured_claimer(&context, &swig), Some(claimer.to_bytes()));
+    assert_eq!(
+        configured_claimer(&context, &swig),
+        Some(claimer.to_bytes())
+    );
 }
 
 // ===========================================================================

--- a/program/tests/set_rent_claimer_test.rs
+++ b/program/tests/set_rent_claimer_test.rs
@@ -12,10 +12,7 @@ use solana_sdk::{
 };
 use swig_interface::{AuthorityConfig, ClientAction, SetRentClaimerV1Instruction};
 use swig_state::{
-    action::sol_limit::SolLimit,
-    authority::AuthorityType,
-    swig::Swig,
-    tail::rent_claimer,
+    action::sol_limit::SolLimit, authority::AuthorityType, swig::Swig, tail::rent_claimer,
 };
 
 #[test_log::test]
@@ -53,7 +50,10 @@ fn test_set_rent_claimer_rejects_zero_pubkey() {
     let message = VersionedMessage::V0(
         v0::Message::try_compile(
             &context.default_payer.pubkey(),
-            &[ComputeBudgetInstruction::set_compute_unit_limit(400_000), set_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                set_ix,
+            ],
             &[],
             context.svm.latest_blockhash(),
         )

--- a/program/tests/set_rent_claimer_test.rs
+++ b/program/tests/set_rent_claimer_test.rs
@@ -12,7 +12,10 @@ use solana_sdk::{
 };
 use swig_interface::{AuthorityConfig, ClientAction, SetRentClaimerV1Instruction};
 use swig_state::{
-    action::sol_limit::SolLimit, authority::AuthorityType, swig::Swig, tail::rent_claimer,
+    action::sol_limit::SolLimit,
+    authority::AuthorityType,
+    swig::{swig_wallet_address_seeds, Swig},
+    tail::rent_claimer,
 };
 
 #[test_log::test]
@@ -94,6 +97,45 @@ fn test_set_rent_claimer_rejects_swig_self() {
     let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
     let result = context.svm.send_transaction(tx);
     assert!(result.is_err(), "swig as its own rent claimer must fail");
+}
+
+#[test_log::test]
+fn test_set_rent_claimer_rejects_swig_wallet_address() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+    let (swig_wallet_address, _) = solana_sdk::pubkey::Pubkey::find_program_address(
+        &swig_wallet_address_seeds(swig_pubkey.as_ref()),
+        &program_id(),
+    );
+
+    let set_ix = SetRentClaimerV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        context.default_payer.pubkey(),
+        authority.pubkey(),
+        0,
+        swig_wallet_address.to_bytes(),
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                set_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(
+        result.is_err(),
+        "swig wallet address as rent claimer must fail"
+    );
 }
 
 #[test_log::test]

--- a/program/tests/set_rent_claimer_test.rs
+++ b/program/tests/set_rent_claimer_test.rs
@@ -65,6 +65,38 @@ fn test_set_rent_claimer_rejects_zero_pubkey() {
 }
 
 #[test_log::test]
+fn test_set_rent_claimer_rejects_swig_self() {
+    let mut context = setup_test_context().unwrap();
+    let authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &authority, id).unwrap();
+
+    let set_ix = SetRentClaimerV1Instruction::new_with_ed25519_authority(
+        swig_pubkey,
+        context.default_payer.pubkey(),
+        authority.pubkey(),
+        0,
+        swig_pubkey.to_bytes(),
+    )
+    .unwrap();
+    let message = VersionedMessage::V0(
+        v0::Message::try_compile(
+            &context.default_payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+                set_ix,
+            ],
+            &[],
+            context.svm.latest_blockhash(),
+        )
+        .unwrap(),
+    );
+    let tx = VersionedTransaction::try_new(message, &[&context.default_payer, &authority]).unwrap();
+    let result = context.svm.send_transaction(tx);
+    assert!(result.is_err(), "swig as its own rent claimer must fail");
+}
+
+#[test_log::test]
 fn test_set_rent_claimer_is_one_shot() {
     let mut context = setup_test_context().unwrap();
     let authority = Keypair::new();

--- a/rust-sdk/src/client_role.rs
+++ b/rust-sdk/src/client_role.rs
@@ -2,8 +2,7 @@ use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use swig_interface::{
     AddAuthorityInstruction, AuthorityConfig, ClientAction, CreateSessionInstruction,
     CreateSubAccountInstruction, RemoveAuthorityInstruction, SetRentClaimerV1Instruction,
-    SignV2Instruction,
-    SubAccountSignInstruction, ToggleSubAccountInstruction, UpdateAuthorityData,
+    SignV2Instruction, SubAccountSignInstruction, ToggleSubAccountInstruction, UpdateAuthorityData,
     UpdateAuthorityInstruction, WithdrawFromSubAccountInstruction,
 };
 use swig_state::{

--- a/rust-sdk/src/tests/wallet/mod.rs
+++ b/rust-sdk/src/tests/wallet/mod.rs
@@ -4,6 +4,7 @@ pub mod destination_tests;
 pub mod helper_tests;
 pub mod program_all_tests;
 pub mod program_scope_test;
+pub mod rent_claimer_tests;
 pub mod secp256r1_test;
 pub mod secp_tests;
 pub mod session_tests;

--- a/rust-sdk/src/tests/wallet/rent_claimer_tests.rs
+++ b/rust-sdk/src/tests/wallet/rent_claimer_tests.rs
@@ -1,0 +1,50 @@
+use solana_sdk::signature::{Keypair, Signer};
+use swig_state::{swig::Swig, tail::rent_claimer};
+
+use super::*;
+use crate::client_role::Ed25519ClientRole;
+
+#[test_log::test]
+fn should_set_rent_claimer_through_wallet() {
+    let (litesvm, main_authority) = setup_test_environment();
+
+    let mut swig_wallet = SwigWallet::new(
+        [7; 32],
+        Box::new(Ed25519ClientRole::new(main_authority.pubkey())),
+        &main_authority,
+        "http://localhost:8899".to_string(),
+        Some(&main_authority),
+        litesvm,
+    )
+    .unwrap();
+
+    let claimer = Keypair::new().pubkey();
+    swig_wallet.set_rent_claimer(claimer).unwrap();
+
+    let swig_pubkey = swig_wallet.get_swig_account().unwrap();
+    let swig_account = swig_wallet.litesvm().get_account(&swig_pubkey).unwrap();
+    let parts = Swig::split_parts(&swig_account.data).unwrap();
+    let parsed = rent_claimer::read_strict(parts.tail).unwrap();
+    assert_eq!(parsed, Some(&claimer.to_bytes()));
+}
+
+#[test_log::test]
+fn should_reject_second_rent_claimer_through_wallet() {
+    let (litesvm, main_authority) = setup_test_environment();
+
+    let mut swig_wallet = SwigWallet::new(
+        [8; 32],
+        Box::new(Ed25519ClientRole::new(main_authority.pubkey())),
+        &main_authority,
+        "http://localhost:8899".to_string(),
+        Some(&main_authority),
+        litesvm,
+    )
+    .unwrap();
+
+    swig_wallet
+        .set_rent_claimer(Keypair::new().pubkey())
+        .unwrap();
+    let second = swig_wallet.set_rent_claimer(Keypair::new().pubkey());
+    assert!(second.is_err(), "rent claimer should be immutable");
+}

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -1250,6 +1250,40 @@ impl<'c> SwigWallet<'c> {
         Ok(())
     }
 
+    /// Sets the immutable rent claimer on the wallet
+    ///
+    /// # Arguments
+    ///
+    /// * `rent_claimer` - The public key that will receive rent when the wallet
+    ///   or its token accounts are closed
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the transaction signature or a `SwigError`
+    pub fn set_rent_claimer(&mut self, rent_claimer: Pubkey) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let instructions = self
+            .instruction_builder
+            .set_rent_claimer(rent_claimer, Some(current_slot))?;
+
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &instructions,
+            &[],
+            self.get_current_blockhash()?,
+        )?;
+        let tx = VersionedTransaction::try_new(
+            VersionedMessage::V0(msg),
+            &[self.fee_payer.insecure_clone()],
+        )?;
+
+        let tx_result = self.send_and_confirm_transaction(tx);
+        if tx_result.is_ok() {
+            self.instruction_builder.increment_odometer()?;
+        }
+        tx_result
+    }
+
     /// Get the sub account if it exists
     ///
     /// # Returns


### PR DESCRIPTION
- aa15edf Reject swig account as its own rent claimer — the PR #180 fix (program check + test)
- 60bee93 Expose set_rent_claimer through SwigWallet — the PR #182 fix (wallet method + tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anagrambuild/codesmith/swig-wallet/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786568031&installation_id=138016541&pr_number=184&repository=anagrambuild%2Fswig-wallet&return_to=https%3A%2F%2Fgithub.com%2Fanagrambuild%2Fswig-wallet%2Fpull%2F184&signature=758307b3d313a5bf6647e748d35699e4775f1611f543a398f9a2eb9dff18fdbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->