### PR TITLE
Gate SignV2 token account closes by permission

### DIFF
--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -19,6 +19,7 @@ use swig_state::{
     action::{
         all::All,
         all_but_manage_authority::AllButManageAuthority,
+        close_swig_authority::CloseSwigAuthority,
         program::Program,
         program_all::ProgramAll,
         program_curated::ProgramCurated,
@@ -564,9 +565,25 @@ pub fn sign_v2(
             },
             AccountClassification::SwigTokenAccount { spent, .. } => {
                 let account_info = unsafe { all_accounts.get_unchecked(index) };
+                let data = unsafe { &account_info.borrow_data_unchecked() };
+
+                // The on-chain token program resizes closed accounts to zero bytes,
+                // while its native test processor retains zeroed data. Both forms
+                // drain the account's lamports and assign it to the system program.
+                if data.is_empty() || account_info.lamports() == 0 {
+                    let has_close_permission =
+                        RoleMut::get_action_mut::<CloseSwigAuthority>(actions, &[])?.is_some();
+                    if !has_close_permission {
+                        return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
+                    }
+                    if account_info.lamports() != 0 || account_info.owner() != &SYSTEM_PROGRAM_ID {
+                        return Err(SwigError::AccountDataModifiedUnexpectedly.into());
+                    }
+
+                    continue;
+                }
 
                 if account_info.is_writable() {
-                    let data = unsafe { &account_info.borrow_data_unchecked() };
                     let exclude_ranges = [TOKEN_BALANCE_EXCLUDE_RANGE];
                     let current_hash = hash_except(&data, account_info.owner(), &exclude_ranges);
                     let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
@@ -575,7 +592,6 @@ pub fn sign_v2(
                     }
                 }
 
-                let data = unsafe { &account_info.borrow_data_unchecked() };
                 let mint = unsafe { data.get_unchecked(TOKEN_MINT_RANGE) };
                 let state = unsafe { *data.get_unchecked(TOKEN_STATE_INDEX) };
                 let authority = unsafe { data.get_unchecked(TOKEN_AUTHORITY_RANGE) };

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -63,6 +63,7 @@ const TOKEN_BALANCE_EXCLUDE_RANGE: core::ops::Range<usize> = 64..72;
 const STAKE_BALANCE_EXCLUDE_RANGE: core::ops::Range<usize> = 184..192;
 
 /// Token account field ranges
+const TOKEN_ACCOUNT_BASE_DATA_LEN: usize = 165;
 const TOKEN_MINT_RANGE: core::ops::Range<usize> = 0..32;
 const TOKEN_AUTHORITY_RANGE: core::ops::Range<usize> = 32..64;
 const TOKEN_BALANCE_RANGE: core::ops::Range<usize> = 64..72;
@@ -581,6 +582,10 @@ pub fn sign_v2(
                     }
 
                     continue;
+                }
+
+                if data.len() < TOKEN_ACCOUNT_BASE_DATA_LEN {
+                    return Err(SwigError::AccountDataModifiedUnexpectedly.into());
                 }
 
                 if account_info.is_writable() {

--- a/program/tests/sign_v2_close_token_account.rs
+++ b/program/tests/sign_v2_close_token_account.rs
@@ -4,24 +4,26 @@
 mod common;
 
 use common::*;
-use litesvm_token::spl_token;
+use litesvm_token::{spl_token, CreateAccount};
 use solana_sdk::{
-    instruction::InstructionError,
+    instruction::{AccountMeta, Instruction, InstructionError},
     message::{v0, VersionedMessage},
     pubkey::Pubkey,
     signature::Keypair,
     signer::Signer,
     transaction::{TransactionError, VersionedTransaction},
 };
-use swig_interface::{AuthorityConfig, ClientAction, SignV2Instruction};
+use swig::actions::sign_v2::SignV2Args;
+use swig_interface::{compact_instructions, AuthorityConfig, ClientAction, SignV2Instruction};
 use swig_state::{
     action::{close_swig_authority::CloseSwigAuthority, program::Program, token_limit::TokenLimit},
     authority::AuthorityType,
     swig::{swig_wallet_address_seeds, SwigWithRoles},
-    SwigAuthenticateError,
+    IntoBytes, SwigAuthenticateError,
 };
 
 const TOKEN_LIMIT_AMOUNT: u64 = 100;
+const ACCOUNT_DATA_MODIFIED_UNEXPECTEDLY_ERROR: u32 = 43;
 
 fn token_limit_remaining(
     context: &Context,
@@ -224,6 +226,124 @@ fn sign_v2_rejects_token_account_close_without_permission_and_rolls_back_state()
             .map(|account| account.lamports)
             .unwrap_or(0),
         0
+    );
+    assert_eq!(
+        token_limit_remaining(&context, &swig_pubkey, 1, &mint),
+        TOKEN_LIMIT_AMOUNT
+    );
+}
+
+#[test_log::test]
+fn sign_v2_rejects_closed_token_account_reallocated_with_short_data() {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let close_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(swig_pubkey.as_ref()),
+        &program_id(),
+    );
+    let mint = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+
+    let token_account_keypair = Keypair::new();
+    let token_account = CreateAccount::new(&mut context.svm, &context.default_payer, &mint)
+        .owner(&swig_wallet_address)
+        .account_kp(token_account_keypair.insecure_clone())
+        .send()
+        .unwrap();
+    let token_account_before = context.svm.get_account(&token_account).unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: close_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::Program(Program {
+                program_id: spl_token::ID.to_bytes(),
+            }),
+            ClientAction::Program(Program {
+                program_id: solana_system_interface::program::ID.to_bytes(),
+            }),
+            ClientAction::CloseSwigAuthority(CloseSwigAuthority),
+            ClientAction::TokenLimit(TokenLimit {
+                token_mint: mint.to_bytes(),
+                current_amount: TOKEN_LIMIT_AMOUNT,
+            }),
+        ],
+    )
+    .unwrap();
+
+    let close_ix = spl_token::instruction::close_account(
+        &spl_token::ID,
+        &token_account,
+        &close_authority.pubkey(),
+        &swig_wallet_address,
+        &[],
+    )
+    .unwrap();
+    let refund_ix = solana_system_interface::instruction::transfer(
+        &close_authority.pubkey(),
+        &token_account,
+        1_000_000,
+    );
+    let allocate_ix = solana_system_interface::instruction::allocate(&token_account, 1);
+
+    let initial_accounts = vec![
+        AccountMeta::new(swig_pubkey, false),
+        AccountMeta::new(swig_wallet_address, false),
+        AccountMeta::new(close_authority.pubkey(), true),
+        AccountMeta::new(token_account, true),
+    ];
+    let (accounts, compact_ixs) = compact_instructions(
+        swig_pubkey,
+        initial_accounts,
+        vec![close_ix, refund_ix, allocate_ix],
+    );
+    let instruction_payload = compact_ixs.into_bytes();
+    let args = SignV2Args::new(1, instruction_payload.len() as u16);
+    let sign_ix = Instruction {
+        program_id: program_id(),
+        accounts,
+        data: [args.into_bytes().unwrap(), &instruction_payload, &[2]].concat(),
+    };
+
+    context
+        .svm
+        .airdrop(&close_authority.pubkey(), 2_000_000)
+        .unwrap();
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let transaction = VersionedTransaction::try_new(
+        VersionedMessage::V0(message),
+        &[
+            &context.default_payer,
+            &close_authority,
+            &token_account_keypair,
+        ],
+    )
+    .unwrap();
+
+    let error = context.svm.send_transaction(transaction).unwrap_err();
+    assert_eq!(
+        error.err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(ACCOUNT_DATA_MODIFIED_UNEXPECTEDLY_ERROR),
+        )
+    );
+    assert_eq!(
+        context.svm.get_account(&token_account).unwrap(),
+        token_account_before
     );
     assert_eq!(
         token_limit_remaining(&context, &swig_pubkey, 1, &mint),

--- a/program/tests/sign_v2_close_token_account.rs
+++ b/program/tests/sign_v2_close_token_account.rs
@@ -1,0 +1,232 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! Regression tests for closing pre-existing token accounts through SignV2.
+
+mod common;
+
+use common::*;
+use litesvm_token::spl_token;
+use solana_sdk::{
+    instruction::InstructionError,
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::{TransactionError, VersionedTransaction},
+};
+use swig_interface::{AuthorityConfig, ClientAction, SignV2Instruction};
+use swig_state::{
+    action::{close_swig_authority::CloseSwigAuthority, program::Program, token_limit::TokenLimit},
+    authority::AuthorityType,
+    swig::{swig_wallet_address_seeds, SwigWithRoles},
+    SwigAuthenticateError,
+};
+
+const TOKEN_LIMIT_AMOUNT: u64 = 100;
+
+fn token_limit_remaining(
+    context: &Context,
+    swig_pubkey: &Pubkey,
+    role_id: u32,
+    mint: &Pubkey,
+) -> u64 {
+    let swig_account = context.svm.get_account(swig_pubkey).unwrap();
+    let swig = SwigWithRoles::from_bytes(&swig_account.data).unwrap();
+    let role = swig.get_role(role_id).unwrap().unwrap();
+    role.get_action::<TokenLimit>(mint.as_ref())
+        .unwrap()
+        .unwrap()
+        .current_amount
+}
+
+#[test_log::test]
+fn sign_v2_closes_token_account_with_close_permission_without_consuming_token_limit() {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let close_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(swig_pubkey.as_ref()),
+        &program_id(),
+    );
+    let mint = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let token_account = setup_ata(
+        &mut context.svm,
+        &mint,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: close_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::Program(Program {
+                program_id: spl_token::ID.to_bytes(),
+            }),
+            ClientAction::CloseSwigAuthority(CloseSwigAuthority),
+            ClientAction::TokenLimit(TokenLimit {
+                token_mint: mint.to_bytes(),
+                current_amount: TOKEN_LIMIT_AMOUNT,
+            }),
+        ],
+    )
+    .unwrap();
+
+    let destination = Keypair::new();
+    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
+    let token_account_rent = context.svm.get_account(&token_account).unwrap().lamports;
+    let close_ix = spl_token::instruction::close_account(
+        &spl_token::ID,
+        &token_account,
+        &destination.pubkey(),
+        &swig_wallet_address,
+        &[],
+    )
+    .unwrap();
+    let sign_ix = SignV2Instruction::new_ed25519(
+        swig_pubkey,
+        swig_wallet_address,
+        close_authority.pubkey(),
+        close_ix,
+        1,
+    )
+    .unwrap();
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let transaction = VersionedTransaction::try_new(
+        VersionedMessage::V0(message),
+        &[&context.default_payer, &close_authority],
+    )
+    .unwrap();
+
+    context.svm.send_transaction(transaction).unwrap();
+
+    let closed_account = context.svm.get_account(&token_account);
+    assert!(
+        closed_account.is_none() || closed_account.unwrap().lamports == 0,
+        "token account should be closed"
+    );
+    assert_eq!(
+        context
+            .svm
+            .get_account(&destination.pubkey())
+            .map(|account| account.lamports)
+            .unwrap_or(0),
+        token_account_rent
+    );
+    assert_eq!(
+        token_limit_remaining(&context, &swig_pubkey, 1, &mint),
+        TOKEN_LIMIT_AMOUNT
+    );
+}
+
+#[test_log::test]
+fn sign_v2_rejects_token_account_close_without_permission_and_rolls_back_state() {
+    let mut context = setup_test_context().unwrap();
+    let root_authority = Keypair::new();
+    let restricted_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_pubkey, _) = create_swig_ed25519(&mut context, &root_authority, id).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_wallet_address_seeds(swig_pubkey.as_ref()),
+        &program_id(),
+    );
+    let mint = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let token_account = setup_ata(
+        &mut context.svm,
+        &mint,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_pubkey,
+        &root_authority,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: restricted_authority.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::Program(Program {
+                program_id: spl_token::ID.to_bytes(),
+            }),
+            ClientAction::TokenLimit(TokenLimit {
+                token_mint: mint.to_bytes(),
+                current_amount: TOKEN_LIMIT_AMOUNT,
+            }),
+        ],
+    )
+    .unwrap();
+
+    let destination = Keypair::new();
+    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
+    let token_account_before = context.svm.get_account(&token_account).unwrap();
+    let close_ix = spl_token::instruction::close_account(
+        &spl_token::ID,
+        &token_account,
+        &destination.pubkey(),
+        &swig_wallet_address,
+        &[],
+    )
+    .unwrap();
+    let sign_ix = SignV2Instruction::new_ed25519(
+        swig_pubkey,
+        swig_wallet_address,
+        restricted_authority.pubkey(),
+        close_ix,
+        1,
+    )
+    .unwrap();
+    let message = v0::Message::try_compile(
+        &context.default_payer.pubkey(),
+        &[sign_ix],
+        &[],
+        context.svm.latest_blockhash(),
+    )
+    .unwrap();
+    let transaction = VersionedTransaction::try_new(
+        VersionedMessage::V0(message),
+        &[&context.default_payer, &restricted_authority],
+    )
+    .unwrap();
+
+    let error = context.svm.send_transaction(transaction).unwrap_err();
+    assert_eq!(
+        error.err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(
+                SwigAuthenticateError::PermissionDeniedMissingPermission as u32
+            ),
+        )
+    );
+
+    let token_account_after = context.svm.get_account(&token_account).unwrap();
+    assert_eq!(token_account_after, token_account_before);
+    assert_eq!(
+        context
+            .svm
+            .get_account(&destination.pubkey())
+            .map(|account| account.lamports)
+            .unwrap_or(0),
+        0
+    );
+    assert_eq!(
+        token_limit_remaining(&context, &swig_pubkey, 1, &mint),
+        TOKEN_LIMIT_AMOUNT
+    );
+}


### PR DESCRIPTION
## Summary

- detect a closed pre-existing Swig token account before post-CPI hashing or token-field reads
- require `CloseSwigAuthority` for restricted SignV2 roles before accepting the close
- validate the terminal account state as zero lamports and system-program-owned
- reject non-closed token accounts shorter than the 165-byte base layout before hashing or unchecked field access
- leave token limits unchanged for close-only operations and rely on transaction rollback when the permission check fails
- add regressions for permitted close, missing-permission rollback, and close-refund-short-reallocate rejection

Fixes #185.

## Root cause

SignV2 classified and snapshotted a token account before CPI, then hashed it again after CPI using the token balance exclusion range. SPL Token closes resize the account data to zero bytes on-chain, so `hash_except` attempted to slice beyond the empty account and panicked. Native test execution retains a zeroed data buffer, but still drains the account and assigns it to the system program.

The new terminal-state branch runs before hashing and unchecked token-field access. Restricted roles without `CloseSwigAuthority` now receive `PermissionDeniedMissingPermission`. Any remaining token account must retain at least the 165-byte base layout; shorter post-CPI data returns `AccountDataModifiedUnexpectedly` instead of reaching `hash_except` or unchecked field reads.

Existing unrestricted `All` and `AllButManageAuthority` SignV2 behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo build-sbf --arch v1`
- `cargo test -p swig --test sign_v2_close_token_account -- --nocapture`
- `cargo test -p swig --test sign_v2 -- --nocapture`
- `cargo nextest run --config-file nextest.toml --profile ci --all --workspace --no-fail-fast` — 277 passed
- `cargo build-sbf --arch v1 --features=program_scope_test`
- `cargo nextest run --config-file nextest.toml --profile ci --all --workspace --no-fail-fast --exclude test-program-authority --features=program_scope_test` — 57 passed
- `cargo nextest run --config-file nextest.toml --profile ci --all --workspace --no-fail-fast --exclude test-program-authority --features=rust_sdk_test,program_scope_test` — 174 passed
- `git diff --check`

## Self-review

| Area | Checked | Evidence |
| --- | --- | --- |
| Stored and wire layout | yes | no layout or instruction changes |
| Account validation and ordering | yes | terminal state requires zero lamports and system owner; non-closed token data requires the 165-byte base layout |
| Auth and replay binding | yes | unchanged |
| Permission semantics | yes | explicit `CloseSwigAuthority` lookup for restricted roles |
| Grow and shrink reallocations | N/A | no Swig account reallocations |
| CPI and SignV2 enforcement | yes | permitted close, denied close, and close-refund-short-reallocate regressions |
| IDL and SDK compatibility | yes | no public surface changes |
| Compute units | N/A | close-only terminal branch; standard CU suite passes |
| Design conflicts resolved | yes | bounded SignV2 close requires the existing close permission |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anagrambuild/codesmith/swig-wallet/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786640192&installation_id=138016541&pr_number=186&repository=anagrambuild%2Fswig-wallet&return_to=https%3A%2F%2Fgithub.com%2Fanagrambuild%2Fswig-wallet%2Fpull%2F186&signature=35eb9c69967167ff5b5eda77ab3fa403f0d7fb16f7c0698063457bceb3daa571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->