### PR TITLE
SubAccount V2 (1/3): state-crate data model

### DIFF
--- a/state/src/action/mod.rs
+++ b/state/src/action/mod.rs
@@ -5,6 +5,8 @@
 //! actions such as limits on token operations, program interactions, and
 //! stake management.
 
+extern crate alloc;
+
 pub mod all;
 pub mod all_but_manage_authority;
 pub mod close_swig_authority;
@@ -310,6 +312,10 @@ impl ActionLoader {
     /// `actions_data` is walked sequentially by `[header][data]`, matching how
     /// `calculate_num_actions` reads the same buffer.
     pub fn reject_duplicate_v2_scoped(actions_data: &[u8]) -> Result<(), ProgramError> {
+        // Single forward pass collecting one packed `(type, subacc_id)` key per
+        // V2 action, then sort + adjacent-compare. Roles are capped at 255
+        // actions by `calculate_num_actions`, so this vector stays small.
+        let mut keys: alloc::vec::Vec<u64> = alloc::vec::Vec::new();
         let mut cursor = 0;
         while cursor + Action::LEN <= actions_data.len() {
             let header =
@@ -322,28 +328,20 @@ impl ActionLoader {
                 return Err(ProgramError::InvalidInstructionData);
             }
 
-            if let Some(key) =
+            if let Some((ty, id)) =
                 v2_dedup_key(header.permission()?, &actions_data[data_start..data_end])
             {
-                // Compare against every action before this one; a match means the
-                // key appears twice.
-                let mut prior = 0;
-                while prior < cursor {
-                    let ph = unsafe {
-                        Action::load_unchecked(&actions_data[prior..prior + Action::LEN])?
-                    };
-                    let pdata_start = prior + Action::LEN;
-                    let pdata_end = pdata_start + ph.length() as usize;
-                    if v2_dedup_key(ph.permission()?, &actions_data[pdata_start..pdata_end])
-                        == Some(key)
-                    {
-                        return Err(SwigStateError::DuplicateV2SubAccountAction.into());
-                    }
-                    prior = pdata_end;
-                }
+                keys.push(((ty as u64) << 32) | id as u64);
             }
 
             cursor = data_end;
+        }
+
+        keys.sort_unstable();
+        for pair in keys.windows(2) {
+            if pair[0] == pair[1] {
+                return Err(SwigStateError::DuplicateV2SubAccountAction.into());
+            }
         }
         Ok(())
     }

--- a/state/src/action/mod.rs
+++ b/state/src/action/mod.rs
@@ -22,6 +22,7 @@ pub mod stake_all;
 pub mod stake_limit;
 pub mod stake_recurring_limit;
 pub mod sub_account;
+pub mod sub_account_v2;
 pub mod token_destination_limit;
 pub mod token_limit;
 pub mod token_recurring_destination_limit;
@@ -45,6 +46,9 @@ use stake_all::StakeAll;
 use stake_limit::StakeLimit;
 use stake_recurring_limit::StakeRecurringLimit;
 use sub_account::SubAccount;
+use sub_account_v2::{
+    SubAccountV2All, SubAccountV2Create, SubAccountV2Sign, SubAccountV2Toggle, SubAccountV2Withdraw,
+};
 use token_destination_limit::TokenDestinationLimit;
 use token_limit::TokenLimit;
 use token_recurring_destination_limit::TokenRecurringDestinationLimit;
@@ -171,6 +175,18 @@ pub enum Permission {
     CloseSwigAuthority = 20,
     /// Permission to rotate passkey authority through the recovery path
     RecoveryAuthority = 21,
+    /// Permission to create V2 sub-accounts (non-repeatable marker)
+    SubAccountV2Create = 22,
+    /// Scoped umbrella permission for V2 sub-account runtime operations
+    /// (sign/withdraw/toggle) on a single `subacc_id`
+    SubAccountV2All = 23,
+    /// Scoped permission to sign as a V2 sub-account for a single `subacc_id`
+    SubAccountV2Sign = 24,
+    /// Scoped permission to withdraw from a V2 sub-account for a single
+    /// `subacc_id`
+    SubAccountV2Withdraw = 25,
+    /// Scoped permission to toggle a V2 sub-account for a single `subacc_id`
+    SubAccountV2Toggle = 26,
 }
 
 impl TryFrom<u16> for Permission {
@@ -180,7 +196,7 @@ impl TryFrom<u16> for Permission {
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
             // SAFETY: `value` is guaranteed to be in the range of the enum variants.
-            0..=21 => Ok(unsafe { core::mem::transmute::<u16, Permission>(value) }),
+            0..=26 => Ok(unsafe { core::mem::transmute::<u16, Permission>(value) }),
             _ => Err(SwigStateError::PermissionLoadError.into()),
         }
     }
@@ -218,6 +234,29 @@ pub trait Actionable<'a>: Transmutable + TransmutableMut {
     }
 }
 
+/// Returns a deduplication key for a V2 sub-account action, or `None` for any
+/// non-V2 permission (which is intentionally not deduplicated).
+///
+/// The scoped permissions key on `(type, subacc_id)`; the create marker keys on
+/// its type with a fixed id so a second marker collides.
+fn v2_dedup_key(permission: Permission, data: &[u8]) -> Option<(u16, u32)> {
+    match permission {
+        Permission::SubAccountV2Create => Some((permission as u16, 0)),
+        Permission::SubAccountV2All
+        | Permission::SubAccountV2Sign
+        | Permission::SubAccountV2Withdraw
+        | Permission::SubAccountV2Toggle => {
+            if data.len() >= 4 {
+                let id = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+                Some((permission as u16, id))
+            } else {
+                None
+            }
+        },
+        _ => None,
+    }
+}
+
 /// Helper struct for loading and validating actions.
 pub struct ActionLoader;
 
@@ -250,8 +289,63 @@ impl ActionLoader {
             Permission::TokenRecurringDestinationLimit => {
                 TokenRecurringDestinationLimit::valid_layout(data)
             },
+            Permission::SubAccountV2Create => SubAccountV2Create::valid_layout(data),
+            Permission::SubAccountV2All => SubAccountV2All::valid_layout(data),
+            Permission::SubAccountV2Sign => SubAccountV2Sign::valid_layout(data),
+            Permission::SubAccountV2Withdraw => SubAccountV2Withdraw::valid_layout(data),
+            Permission::SubAccountV2Toggle => SubAccountV2Toggle::valid_layout(data),
             _ => Ok(false),
         }
+    }
+
+    /// Rejects duplicate V2 sub-account scoped actions within a role's full
+    /// action buffer.
+    ///
+    /// A role may hold at most one scoped V2 action per `(permission type,
+    /// subacc_id)` and at most one `SubAccountV2Create` marker. Only the five V2
+    /// permission types are deduplicated here; all other actions (including V1
+    /// `SubAccount` and repeatable destination limits) are left untouched to
+    /// preserve existing behavior.
+    ///
+    /// `actions_data` is walked sequentially by `[header][data]`, matching how
+    /// `calculate_num_actions` reads the same buffer.
+    pub fn reject_duplicate_v2_scoped(actions_data: &[u8]) -> Result<(), ProgramError> {
+        let mut cursor = 0;
+        while cursor + Action::LEN <= actions_data.len() {
+            let header =
+                unsafe { Action::load_unchecked(&actions_data[cursor..cursor + Action::LEN])? };
+            let data_start = cursor + Action::LEN;
+            let data_end = data_start
+                .checked_add(header.length() as usize)
+                .ok_or(ProgramError::InvalidInstructionData)?;
+            if data_end > actions_data.len() {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+
+            if let Some(key) =
+                v2_dedup_key(header.permission()?, &actions_data[data_start..data_end])
+            {
+                // Compare against every action before this one; a match means the
+                // key appears twice.
+                let mut prior = 0;
+                while prior < cursor {
+                    let ph = unsafe {
+                        Action::load_unchecked(&actions_data[prior..prior + Action::LEN])?
+                    };
+                    let pdata_start = prior + Action::LEN;
+                    let pdata_end = pdata_start + ph.length() as usize;
+                    if v2_dedup_key(ph.permission()?, &actions_data[pdata_start..pdata_end])
+                        == Some(key)
+                    {
+                        return Err(SwigStateError::DuplicateV2SubAccountAction.into());
+                    }
+                    prior = pdata_end;
+                }
+            }
+
+            cursor = data_end;
+        }
+        Ok(())
     }
 
     /// Finds an action of a specific type in the provided bytes.

--- a/state/src/action/sub_account_v2.rs
+++ b/state/src/action/sub_account_v2.rs
@@ -1,0 +1,183 @@
+//! V2 sub-account action types.
+//!
+//! These are the flattened, scoped permissions a role can hold for V2
+//! sub-accounts. Unlike V1's single `SubAccount` action, access is expressed as
+//! separate permission types so presence grants and absence denies — there is
+//! no bundled grant object and no per-action enabled flag.
+//!
+//! - [`SubAccountV2Create`] — a zero-length, non-repeatable marker granting the
+//!   ability to create V2 sub-accounts.
+//! - [`SubAccountV2All`] / [`SubAccountV2Sign`] / [`SubAccountV2Withdraw`] /
+//!   [`SubAccountV2Toggle`] — repeatable, each scoped to a single `subacc_id`.
+//!
+//! The scoped types share an identical 8-byte body and match on `subacc_id`,
+//! reusing the same repeatable-action mechanism as V1's `SubAccount`.
+
+use no_padding::NoPadding;
+use pinocchio::program_error::ProgramError;
+
+use super::{Actionable, Permission};
+use crate::{IntoBytes, Transmutable, TransmutableMut};
+
+/// Zero-length marker granting permission to create V2 sub-accounts.
+pub struct SubAccountV2Create;
+
+impl Transmutable for SubAccountV2Create {
+    const LEN: usize = 0;
+}
+
+impl TransmutableMut for SubAccountV2Create {}
+
+impl IntoBytes for SubAccountV2Create {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(&[])
+    }
+}
+
+impl<'a> Actionable<'a> for SubAccountV2Create {
+    const TYPE: Permission = Permission::SubAccountV2Create;
+    /// A role needs at most one create marker.
+    const REPEATABLE: bool = false;
+
+    fn match_data(&self, _data: &[u8]) -> bool {
+        true
+    }
+}
+
+/// Defines a scoped V2 sub-account permission: an 8-byte body carrying a
+/// `subacc_id`, repeatable, matched on that id.
+macro_rules! scoped_v2_permission {
+    ($name:ident, $permission:expr, $doc:literal) => {
+        #[doc = $doc]
+        #[repr(C, align(8))]
+        #[derive(Debug, NoPadding)]
+        pub struct $name {
+            /// The sub-account this permission is scoped to.
+            pub subacc_id: u32,
+            pub _padding: [u8; 4],
+        }
+
+        impl $name {
+            /// Creates a new scoped permission for `subacc_id`.
+            pub fn new(subacc_id: u32) -> Self {
+                Self {
+                    subacc_id,
+                    _padding: [0; 4],
+                }
+            }
+        }
+
+        impl Transmutable for $name {
+            /// 4 (subacc_id) + 4 (padding) = 8
+            const LEN: usize = 8;
+        }
+
+        impl TransmutableMut for $name {}
+
+        impl IntoBytes for $name {
+            fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+                Ok(unsafe {
+                    core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN)
+                })
+            }
+        }
+
+        impl<'a> Actionable<'a> for $name {
+            const TYPE: Permission = $permission;
+            const REPEATABLE: bool = true;
+
+            /// Matches when `data` is the little-endian `subacc_id` this
+            /// permission is scoped to.
+            fn match_data(&self, data: &[u8]) -> bool {
+                data.len() == 4 && self.subacc_id.to_le_bytes() == data
+            }
+        }
+    };
+}
+
+scoped_v2_permission!(
+    SubAccountV2All,
+    Permission::SubAccountV2All,
+    "Scoped umbrella permission for sign/withdraw/toggle on one `subacc_id`."
+);
+scoped_v2_permission!(
+    SubAccountV2Sign,
+    Permission::SubAccountV2Sign,
+    "Scoped permission to sign as one V2 sub-account."
+);
+scoped_v2_permission!(
+    SubAccountV2Withdraw,
+    Permission::SubAccountV2Withdraw,
+    "Scoped permission to withdraw from one V2 sub-account."
+);
+scoped_v2_permission!(
+    SubAccountV2Toggle,
+    Permission::SubAccountV2Toggle,
+    "Scoped permission to toggle one V2 sub-account."
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scoped_layout() {
+        assert_eq!(SubAccountV2All::LEN, 8);
+        assert_eq!(core::mem::size_of::<SubAccountV2Sign>(), 8);
+        assert_eq!(core::mem::align_of::<SubAccountV2Withdraw>(), 8);
+        assert_eq!(SubAccountV2Create::LEN, 0);
+    }
+
+    #[test]
+    fn test_match_data_on_subacc_id() {
+        let action = SubAccountV2Sign::new(5);
+        assert!(action.match_data(&5u32.to_le_bytes()));
+        assert!(!action.match_data(&6u32.to_le_bytes()));
+        assert!(!action.match_data(&[])); // empty never matches a scoped id
+        assert!(!action.match_data(&5u64.to_le_bytes())); // wrong length
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let action = SubAccountV2All::new(42);
+        let bytes = action.into_bytes().unwrap();
+        assert_eq!(bytes.len(), 8);
+        let loaded = unsafe { SubAccountV2All::load_unchecked(bytes).unwrap() };
+        assert_eq!(loaded.subacc_id, 42);
+    }
+
+    /// Builds an `[Action header][data]` byte buffer for a scoped V2 action.
+    fn scoped_action_bytes(permission: super::Permission, subacc_id: u32) -> Vec<u8> {
+        use crate::action::Action;
+        let mut buf = Vec::new();
+        // header: type(u16), length(u16)=8, boundary(u32) — boundary unused by the
+        // sequential dedup walk.
+        buf.extend_from_slice(&(permission as u16).to_le_bytes());
+        buf.extend_from_slice(&8u16.to_le_bytes());
+        buf.extend_from_slice(&0u32.to_le_bytes());
+        assert_eq!(buf.len(), Action::LEN);
+        buf.extend_from_slice(&subacc_id.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 4]);
+        buf
+    }
+
+    #[test]
+    fn test_reject_duplicate_v2_scoped() {
+        use crate::action::{ActionLoader, Permission};
+
+        // Same type + same id twice → rejected.
+        let mut dup = scoped_action_bytes(Permission::SubAccountV2Sign, 3);
+        dup.extend(scoped_action_bytes(Permission::SubAccountV2Sign, 3));
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&dup).is_err());
+
+        // Same type, different id → allowed (one role, many sub-accounts).
+        let mut diff_id = scoped_action_bytes(Permission::SubAccountV2Sign, 3);
+        diff_id.extend(scoped_action_bytes(Permission::SubAccountV2Sign, 4));
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&diff_id).is_ok());
+
+        // Same id, different type → allowed (Sign and Withdraw for one sub-account).
+        let mut diff_type = scoped_action_bytes(Permission::SubAccountV2Sign, 3);
+        diff_type.extend(scoped_action_bytes(Permission::SubAccountV2Withdraw, 3));
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&diff_type).is_ok());
+    }
+}

--- a/state/src/action/sub_account_v2.rs
+++ b/state/src/action/sub_account_v2.rs
@@ -161,6 +161,17 @@ mod tests {
         buf
     }
 
+    /// Builds an `[Action header]` byte buffer for a zero-length marker action.
+    fn marker_action_bytes(permission: super::Permission) -> Vec<u8> {
+        use crate::action::Action;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(permission as u16).to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes());
+        buf.extend_from_slice(&0u32.to_le_bytes());
+        assert_eq!(buf.len(), Action::LEN);
+        buf
+    }
+
     #[test]
     fn test_reject_duplicate_v2_scoped() {
         use crate::action::{ActionLoader, Permission};
@@ -179,5 +190,65 @@ mod tests {
         let mut diff_type = scoped_action_bytes(Permission::SubAccountV2Sign, 3);
         diff_type.extend(scoped_action_bytes(Permission::SubAccountV2Withdraw, 3));
         assert!(ActionLoader::reject_duplicate_v2_scoped(&diff_type).is_ok());
+    }
+
+    /// The sort-based pass must catch duplicates that are not adjacent in the
+    /// buffer, which is the case a plain adjacent-compare would miss.
+    #[test]
+    fn test_reject_duplicate_v2_scoped_detects_non_adjacent() {
+        use crate::action::{ActionLoader, Permission};
+
+        let mut buf = scoped_action_bytes(Permission::SubAccountV2Sign, 3);
+        buf.extend(scoped_action_bytes(Permission::SubAccountV2Withdraw, 9));
+        buf.extend(scoped_action_bytes(Permission::SubAccountV2Toggle, 1));
+        buf.extend(scoped_action_bytes(Permission::SubAccountV2Sign, 3));
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&buf).is_err());
+    }
+
+    /// `SubAccountV2Create` is a zero-length, non-repeatable marker: a role
+    /// needs at most one.
+    #[test]
+    fn test_reject_duplicate_v2_scoped_rejects_two_create_markers() {
+        use crate::action::{ActionLoader, Permission};
+
+        let mut dup = marker_action_bytes(Permission::SubAccountV2Create);
+        dup.extend(marker_action_bytes(Permission::SubAccountV2Create));
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&dup).is_err());
+
+        // A single marker alongside scoped actions is fine.
+        let mut single = marker_action_bytes(Permission::SubAccountV2Create);
+        single.extend(scoped_action_bytes(Permission::SubAccountV2All, 0));
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&single).is_ok());
+    }
+
+    /// Only the five V2 types are deduplicated; everything else keeps its
+    /// existing behavior, including being repeatable.
+    #[test]
+    fn test_reject_duplicate_v2_scoped_ignores_non_v2_actions() {
+        use crate::action::{ActionLoader, Permission};
+
+        let mut buf = marker_action_bytes(Permission::All);
+        buf.extend(marker_action_bytes(Permission::All));
+        buf.extend(marker_action_bytes(Permission::ManageAuthority));
+        buf.extend(marker_action_bytes(Permission::ManageAuthority));
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&buf).is_ok());
+    }
+
+    /// A role holding the maximum number of distinct scoped actions must be
+    /// accepted — this is the buffer size the single forward pass has to stay
+    /// linear over.
+    #[test]
+    fn test_reject_duplicate_v2_scoped_accepts_max_distinct_scopes() {
+        use crate::action::{ActionLoader, Permission};
+
+        let mut buf = Vec::new();
+        for subacc_id in 0..255u32 {
+            buf.extend(scoped_action_bytes(Permission::SubAccountV2Sign, subacc_id));
+        }
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&buf).is_ok());
+
+        // One repeat anywhere in a full buffer is still caught.
+        buf.extend(scoped_action_bytes(Permission::SubAccountV2Sign, 128));
+        assert!(ActionLoader::reject_duplicate_v2_scoped(&buf).is_err());
     }
 }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -9,6 +9,7 @@ pub mod action;
 pub mod authority;
 pub mod constants;
 pub mod role;
+pub mod sub_account_v2;
 pub mod swig;
 pub mod tail;
 pub mod transmute;
@@ -17,17 +18,22 @@ pub use transmute::{IntoBytes, Transmutable, TransmutableMut};
 
 /// Represents the type discriminator for different account types in the system.
 #[repr(u8)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub enum Discriminator {
     SwigConfigAccount = 1,
+    SwigSubAccountV2 = 2,
     ClosedSwigAccount = 255,
 }
 
-impl From<u8> for Discriminator {
-    fn from(discriminator: u8) -> Self {
+impl TryFrom<u8> for Discriminator {
+    type Error = ProgramError;
+
+    fn try_from(discriminator: u8) -> Result<Self, Self::Error> {
         match discriminator {
-            1 => Discriminator::SwigConfigAccount,
-            255 => Discriminator::ClosedSwigAccount,
-            _ => panic!("Invalid discriminator"),
+            1 => Ok(Discriminator::SwigConfigAccount),
+            2 => Ok(Discriminator::SwigSubAccountV2),
+            255 => Ok(Discriminator::ClosedSwigAccount),
+            _ => Err(ProgramError::InvalidAccountData),
         }
     }
 }
@@ -115,6 +121,9 @@ pub enum SwigStateError {
     /// Trailing region after the roles is neither empty nor a well-formed
     /// rent-claimer tail entry.
     InvalidRentClaimerLayout,
+    /// A role may not hold two scoped V2 sub-account actions for the same
+    /// `(permission type, subacc_id)`, nor two create markers.
+    DuplicateV2SubAccountAction,
 }
 
 /// Error types related to authentication operations.

--- a/state/src/sub_account_v2.rs
+++ b/state/src/sub_account_v2.rs
@@ -1,0 +1,109 @@
+// V2 sub-account state account.
+use no_padding::NoPadding;
+use pinocchio::program_error::ProgramError;
+
+use crate::{Discriminator, IntoBytes, Transmutable, TransmutableMut};
+
+/// On-chain state for a V2 sub-account.
+#[repr(C, align(8))]
+#[derive(Debug, NoPadding)]
+pub struct SubAccountV2 {
+    /// Account type discriminator (`Discriminator::SwigSubAccountV2`)
+    pub discriminator: u8,
+    /// State PDA bump seed
+    pub bump: u8,
+    /// Asset PDA bump seed
+    pub asset_bump: u8,
+    /// Kill-switch for the whole sub-account
+    pub enabled: bool,
+    /// Sub-account identifier, drawn from the Swig header counter
+    pub subacc_id: u32,
+    /// ID of the parent Swig account
+    pub swig_id: [u8; 32],
+    /// Asset PDA pubkey (cached so it need not be re-derived on each op)
+    pub sub_account: [u8; 32],
+}
+
+impl Transmutable for SubAccountV2 {
+    /// 1 (discriminator) + 1 (bump) + 1 (asset_bump) + 1 (enabled) + 4
+    /// (subacc_id) + 32 (swig_id) + 32 (sub_account) = 72
+    const LEN: usize = 72;
+}
+
+impl TransmutableMut for SubAccountV2 {}
+
+impl IntoBytes for SubAccountV2 {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+impl SubAccountV2 {
+    /// Creates a new, enabled V2 sub-account state.
+    pub fn new(
+        bump: u8,
+        asset_bump: u8,
+        subacc_id: u32,
+        swig_id: [u8; 32],
+        sub_account: [u8; 32],
+    ) -> Self {
+        Self {
+            discriminator: Discriminator::SwigSubAccountV2 as u8,
+            bump,
+            asset_bump,
+            enabled: true,
+            subacc_id,
+            swig_id,
+            sub_account,
+        }
+    }
+
+    /// Validates the account discriminator, failing closed on anything that is
+    /// not a V2 sub-account state account.
+    pub fn check_discriminator(&self) -> Result<(), ProgramError> {
+        match Discriminator::try_from(self.discriminator)? {
+            Discriminator::SwigSubAccountV2 => Ok(()),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sub_account_v2_size() {
+        assert_eq!(SubAccountV2::LEN, 72);
+        assert_eq!(core::mem::size_of::<SubAccountV2>(), 72);
+        assert_eq!(core::mem::align_of::<SubAccountV2>(), 8);
+    }
+
+    #[test]
+    fn test_sub_account_v2_roundtrip() {
+        let state = SubAccountV2::new(254, 253, 7, [3u8; 32], [4u8; 32]);
+        assert_eq!(state.discriminator, Discriminator::SwigSubAccountV2 as u8);
+        assert_eq!(state.enabled, true);
+        assert_eq!(state.subacc_id, 7);
+
+        let bytes = state.into_bytes().unwrap();
+        assert_eq!(bytes.len(), 72);
+
+        let loaded = unsafe { SubAccountV2::load_unchecked(bytes).unwrap() };
+        assert_eq!(loaded.bump, 254);
+        assert_eq!(loaded.asset_bump, 253);
+        assert_eq!(loaded.subacc_id, 7);
+        assert_eq!(loaded.swig_id, [3u8; 32]);
+        assert_eq!(loaded.sub_account, [4u8; 32]);
+        loaded.check_discriminator().unwrap();
+    }
+
+    #[test]
+    fn test_check_discriminator_rejects_foreign() {
+        let mut state = SubAccountV2::new(1, 1, 0, [0u8; 32], [0u8; 32]);
+        state.discriminator = Discriminator::SwigConfigAccount as u8;
+        assert!(state.check_discriminator().is_err());
+        state.discriminator = 9; // not a valid discriminator at all
+        assert!(state.check_discriminator().is_err());
+    }
+}

--- a/state/src/sub_account_v2.rs
+++ b/state/src/sub_account_v2.rs
@@ -14,8 +14,8 @@ pub struct SubAccountV2 {
     pub bump: u8,
     /// Asset PDA bump seed
     pub asset_bump: u8,
-    /// Kill-switch for the whole sub-account
-    pub enabled: bool,
+    /// Kill-switch for the whole sub-account (`0` = disabled, `1` = enabled)
+    pub enabled: u8,
     /// Sub-account identifier, drawn from the Swig header counter
     pub subacc_id: u32,
     /// ID of the parent Swig account
@@ -51,7 +51,7 @@ impl SubAccountV2 {
             discriminator: Discriminator::SwigSubAccountV2 as u8,
             bump,
             asset_bump,
-            enabled: true,
+            enabled: 1,
             subacc_id,
             swig_id,
             sub_account,
@@ -65,6 +65,21 @@ impl SubAccountV2 {
             Discriminator::SwigSubAccountV2 => Ok(()),
             _ => Err(ProgramError::InvalidAccountData),
         }
+    }
+
+    /// Returns whether the sub-account is enabled, rejecting invalid wire
+    /// values instead of interpreting arbitrary non-zero bytes as `true`.
+    pub fn is_enabled(&self) -> Result<bool, ProgramError> {
+        match self.enabled {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    /// Stores the canonical wire value for the enabled flag.
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = u8::from(enabled);
     }
 }
 
@@ -83,7 +98,8 @@ mod tests {
     fn test_sub_account_v2_roundtrip() {
         let state = SubAccountV2::new(254, 253, 7, [3u8; 32], [4u8; 32]);
         assert_eq!(state.discriminator, Discriminator::SwigSubAccountV2 as u8);
-        assert_eq!(state.enabled, true);
+        assert_eq!(state.enabled, 1);
+        assert!(state.is_enabled().unwrap());
         assert_eq!(state.subacc_id, 7);
 
         let bytes = state.into_bytes().unwrap();
@@ -105,5 +121,27 @@ mod tests {
         assert!(state.check_discriminator().is_err());
         state.discriminator = 9; // not a valid discriminator at all
         assert!(state.check_discriminator().is_err());
+    }
+
+    #[test]
+    fn test_enabled_rejects_invalid_wire_value() {
+        let mut state = SubAccountV2::new(1, 1, 0, [0u8; 32], [0u8; 32]);
+        state.enabled = 2;
+
+        let bytes = state.into_bytes().unwrap();
+        let loaded = unsafe { SubAccountV2::load_unchecked(bytes).unwrap() };
+        assert!(loaded.is_enabled().is_err());
+    }
+
+    #[test]
+    fn test_set_enabled_uses_canonical_wire_values() {
+        let mut state = SubAccountV2::new(1, 1, 0, [0u8; 32], [0u8; 32]);
+        state.set_enabled(false);
+        assert_eq!(state.enabled, 0);
+        assert!(!state.is_enabled().unwrap());
+
+        state.set_enabled(true);
+        assert_eq!(state.enabled, 1);
+        assert!(state.is_enabled().unwrap());
     }
 }

--- a/state/src/swig.rs
+++ b/state/src/swig.rs
@@ -99,8 +99,12 @@ pub fn sub_account_signer<'a>(
 }
 
 /// Generates the seeds for a V2 sub-account state account.
+///
+/// `id_le` is the little-endian `subacc_id`. It is typed as a fixed 4-byte
+/// array so a wrong-length seed is a compile error rather than a silently
+/// different PDA.
 #[inline(always)]
-pub fn sub_account_v2_state_seeds<'a>(swig_id: &'a [u8], id_le: &'a [u8]) -> [&'a [u8]; 3] {
+pub fn sub_account_v2_state_seeds<'a>(swig_id: &'a [u8], id_le: &'a [u8; 4]) -> [&'a [u8]; 3] {
     [b"sub-account-v2-state".as_ref(), swig_id, id_le]
 }
 
@@ -108,8 +112,8 @@ pub fn sub_account_v2_state_seeds<'a>(swig_id: &'a [u8], id_le: &'a [u8]) -> [&'
 #[inline(always)]
 pub fn sub_account_v2_state_seeds_with_bump<'a>(
     swig_id: &'a [u8],
-    id_le: &'a [u8],
-    bump: &'a [u8],
+    id_le: &'a [u8; 4],
+    bump: &'a [u8; 1],
 ) -> [&'a [u8]; 4] {
     [b"sub-account-v2-state".as_ref(), swig_id, id_le, bump]
 }
@@ -117,20 +121,23 @@ pub fn sub_account_v2_state_seeds_with_bump<'a>(
 /// Creates a signer seeds array for a V2 sub-account state account.
 pub fn sub_account_v2_state_signer<'a>(
     swig_id: &'a [u8],
-    id_le: &'a [u8],
+    id_le: &'a [u8; 4],
     bump: &'a [u8; 1],
 ) -> [Seed<'a>; 4] {
     [
         b"sub-account-v2-state".as_ref().into(),
         swig_id.into(),
-        id_le.into(),
+        id_le.as_ref().into(),
         bump.as_ref().into(),
     ]
 }
 
 /// Generates the seeds for a V2 sub-account asset account.
+///
+/// `id_le` is the little-endian `subacc_id`, typed as a fixed 4-byte array for
+/// the same reason as [`sub_account_v2_state_seeds`].
 #[inline(always)]
-pub fn sub_account_v2_asset_seeds<'a>(swig_id: &'a [u8], id_le: &'a [u8]) -> [&'a [u8]; 3] {
+pub fn sub_account_v2_asset_seeds<'a>(swig_id: &'a [u8], id_le: &'a [u8; 4]) -> [&'a [u8]; 3] {
     [b"sub-account-v2".as_ref(), swig_id, id_le]
 }
 
@@ -138,8 +145,8 @@ pub fn sub_account_v2_asset_seeds<'a>(swig_id: &'a [u8], id_le: &'a [u8]) -> [&'
 #[inline(always)]
 pub fn sub_account_v2_asset_seeds_with_bump<'a>(
     swig_id: &'a [u8],
-    id_le: &'a [u8],
-    bump: &'a [u8],
+    id_le: &'a [u8; 4],
+    bump: &'a [u8; 1],
 ) -> [&'a [u8]; 4] {
     [b"sub-account-v2".as_ref(), swig_id, id_le, bump]
 }
@@ -147,13 +154,13 @@ pub fn sub_account_v2_asset_seeds_with_bump<'a>(
 /// Creates a signer seeds array for a V2 sub-account asset account.
 pub fn sub_account_v2_asset_signer<'a>(
     swig_id: &'a [u8],
-    id_le: &'a [u8],
+    id_le: &'a [u8; 4],
     bump: &'a [u8; 1],
 ) -> [Seed<'a>; 4] {
     [
         b"sub-account-v2".as_ref().into(),
         swig_id.into(),
-        id_le.into(),
+        id_le.as_ref().into(),
         bump.as_ref().into(),
     ]
 }

--- a/state/src/swig.rs
+++ b/state/src/swig.rs
@@ -98,6 +98,66 @@ pub fn sub_account_signer<'a>(
     ]
 }
 
+/// Generates the seeds for a V2 sub-account state account.
+#[inline(always)]
+pub fn sub_account_v2_state_seeds<'a>(swig_id: &'a [u8], id_le: &'a [u8]) -> [&'a [u8]; 3] {
+    [b"sub-account-v2-state".as_ref(), swig_id, id_le]
+}
+
+/// Generates the seeds for a V2 sub-account state account with bump seed.
+#[inline(always)]
+pub fn sub_account_v2_state_seeds_with_bump<'a>(
+    swig_id: &'a [u8],
+    id_le: &'a [u8],
+    bump: &'a [u8],
+) -> [&'a [u8]; 4] {
+    [b"sub-account-v2-state".as_ref(), swig_id, id_le, bump]
+}
+
+/// Creates a signer seeds array for a V2 sub-account state account.
+pub fn sub_account_v2_state_signer<'a>(
+    swig_id: &'a [u8],
+    id_le: &'a [u8],
+    bump: &'a [u8; 1],
+) -> [Seed<'a>; 4] {
+    [
+        b"sub-account-v2-state".as_ref().into(),
+        swig_id.into(),
+        id_le.into(),
+        bump.as_ref().into(),
+    ]
+}
+
+/// Generates the seeds for a V2 sub-account asset account.
+#[inline(always)]
+pub fn sub_account_v2_asset_seeds<'a>(swig_id: &'a [u8], id_le: &'a [u8]) -> [&'a [u8]; 3] {
+    [b"sub-account-v2".as_ref(), swig_id, id_le]
+}
+
+/// Generates the seeds for a V2 sub-account asset account with bump seed.
+#[inline(always)]
+pub fn sub_account_v2_asset_seeds_with_bump<'a>(
+    swig_id: &'a [u8],
+    id_le: &'a [u8],
+    bump: &'a [u8],
+) -> [&'a [u8]; 4] {
+    [b"sub-account-v2".as_ref(), swig_id, id_le, bump]
+}
+
+/// Creates a signer seeds array for a V2 sub-account asset account.
+pub fn sub_account_v2_asset_signer<'a>(
+    swig_id: &'a [u8],
+    id_le: &'a [u8],
+    bump: &'a [u8; 1],
+) -> [Seed<'a>; 4] {
+    [
+        b"sub-account-v2".as_ref().into(),
+        swig_id.into(),
+        id_le.into(),
+        bump.as_ref().into(),
+    ]
+}
+
 /// Builder for constructing and modifying Swig accounts.
 pub struct SwigBuilder<'a> {
     /// Buffer for role data
@@ -285,6 +345,8 @@ impl<'a> SwigBuilder<'a> {
     ) -> Result<(), ProgramError> {
         // Calculate the actual number of actions from the actions data
         let num_actions = Self::calculate_num_actions(actions_data)?;
+        // Reject duplicate V2 sub-account scoped actions within this role.
+        ActionLoader::reject_duplicate_v2_scoped(actions_data)?;
 
         // check number of roles and iterate to last boundary
         let mut cursor = 0;
@@ -373,7 +435,8 @@ impl<'a> SwigBuilder<'a> {
         position.id = self.swig.role_counter;
         cursor += Position::LEN;
         cursor += authority_length;
-        // todo check actions for duplicates
+        // V2 scoped duplicates are rejected above; general action dedup (SWI-450)
+        // is still TODO.
         let mut action_cursor = 0;
         let actions_start_cursor_pos = cursor;
         for _i in 0..num_actions {
@@ -424,7 +487,12 @@ pub struct Swig {
     pub role_counter: u32,
     /// Wallet address bump seed
     pub wallet_bump: u8,
-    pub _padding: [u8; 7],
+    pub _padding: [u8; 3],
+    /// Counter for generating unique V2 sub-account IDs.
+    ///
+    /// Occupies former padding, so the header stays 48 bytes and existing
+    /// accounts (whose padding is zeroed) read a counter of 0 with no migration.
+    pub sub_account_counter: u32,
 }
 
 /// Immutable split view of a Swig account buffer.
@@ -451,7 +519,8 @@ impl Swig {
             roles: 0,
             role_counter: 0,
             wallet_bump,
-            _padding: [0; 7],
+            _padding: [0; 3],
+            sub_account_counter: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

State-crate foundations for **SubAccount V2** — a sub-account family whose identity is a `u32` counter (not a role id), so one sub-account can be shared across roles and one role can own many. V1 is untouched.

- **Swig header**: `sub_account_counter: u32` reuses former padding (still 48 bytes; existing accounts read 0, no migration).
- **New state struct**: 72-byte program-owned `SubAccountV2` (discriminator, state+asset bumps, `enabled` kill-switch, `subacc_id`, `swig_id`, cached asset pubkey).
- **Discriminator**: `SwigSubAccountV2 = 2`; panicking `From<u8>` replaced by a fallible `TryFrom` so foreign account data fails closed.
- **Seeds**: `sub_account_v2_state_seeds` (`"sub-account-v2-state"`) and `sub_account_v2_asset_seeds` (`"sub-account-v2"`) — distinct prefixes/lengths, collision-free vs V1's `"sub-account"`.
- **Permissions (22–26)**: non-repeatable `SubAccountV2Create` marker + repeatable scoped All/Sign/Withdraw/Toggle (8-byte body matched on `subacc_id`).
- **Duplicate rejection**: `ActionLoader::reject_duplicate_v2_scoped` (V2 scoped types only), wired into `SwigBuilder::add_role`.

## Test
```
cargo test -p swig-state   # 75 unit tests (layout, discriminator, match_data, dup-rejection)
```

## Stack
1. **swig-state V2 data model** ← this PR (base `main`)
2. swig program: V2 instructions + handlers (base this branch)
3. rust-sdk + interface: builders, SDK, tests (base #2)
