### PR TITLE
SubAccount V2 (2/3): program + interface builders + program tests

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -4078,7 +4078,7 @@ impl ToggleSubAccountV2Instruction {
     {
         let accounts = vec![
             AccountMeta::new(swig_account, false),
-            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(payer, true),
             AccountMeta::new(sub_account_state, false),
         ];
         let args = ToggleSubAccountV2Args::new(auth_role_id, subacc_id, enabled);
@@ -4117,7 +4117,7 @@ impl ToggleSubAccountV2Instruction {
     {
         let accounts = vec![
             AccountMeta::new(swig_account, false),
-            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(payer, true),
             AccountMeta::new(sub_account_state, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
             AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
@@ -4200,9 +4200,10 @@ impl SubAccountSignV2Instruction {
         let args_bytes = args
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        let data_payload = [args_bytes, &ix_bytes].concat();
         let account_payload_bytes = secp_account_payload(&accounts)?;
         let authority_payload = secp256k1_v2_authority_payload(
-            &ix_bytes,
+            &data_payload,
             &account_payload_bytes,
             current_slot,
             counter,
@@ -4245,12 +4246,11 @@ impl SubAccountSignV2Instruction {
             .into_bytes()
             .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
         // Instructions sysvar is the last base account (index 4); CPI accounts
-        // are appended after it by the compaction step. The signed data is the
-        // ix bytes; the instruction data is args ++ ix bytes ++ authority payload.
+        // are appended after it by the compaction step.
         let data_prefix = [args_bytes, &ix_bytes].concat();
         secp256r1_v2_instructions(
             &accounts,
-            &ix_bytes,
+            &data_prefix,
             &data_prefix,
             current_slot,
             counter,
@@ -4532,8 +4532,8 @@ impl WithdrawFromSubAccountV2Instruction {
 
 /// Builds the Secp256k1 authority payload (`slot ++ counter ++ signature`) for
 /// a V2 instruction. `counter` must be the authority's next odometer value
-/// (on-chain odometer + 1); `signed_data` is what gets signed (args for
-/// create/toggle/withdraw, ix bytes for sign).
+/// (on-chain odometer + 1); `signed_data` is the instruction data prefix the
+/// program authenticates.
 fn secp256k1_v2_authority_payload<F>(
     signed_data: &[u8],
     account_payload: &[u8],
@@ -4570,8 +4570,7 @@ fn secp_account_payload(accounts: &[AccountMeta]) -> anyhow::Result<Vec<u8>> {
 /// Builds the `[verify_ix, main_ix]` pair for a Secp256r1-authenticated V2
 /// instruction.
 ///
-/// - `signed_data` is the byte string the program authenticates over: the args
-///   for create/toggle/withdraw, or the compact-instruction bytes for sign.
+/// - `signed_data` is the byte string the program authenticates over.
 /// - `data_prefix` is what precedes the authority payload in the instruction
 ///   data: the args, or `args ++ ix_bytes` for sign.
 /// - `sysvar_index` is the position of the instructions sysvar in `accounts`.
@@ -4617,4 +4616,133 @@ where
         data: [data_prefix, &authority_payload].concat(),
     };
     Ok(vec![verify_ix, main_ix])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_inner_instruction() -> Instruction {
+        Instruction {
+            program_id: Pubkey::new_unique(),
+            accounts: Vec::new(),
+            data: vec![1, 2, 3],
+        }
+    }
+
+    #[test]
+    fn sub_account_sign_v2_secp_payloads_bind_role_id() {
+        let swig = Pubkey::new_unique();
+        let state = Pubkey::new_unique();
+        let asset = Pubkey::new_unique();
+
+        let mut k1_role_1 = [0u8; 32];
+        SubAccountSignV2Instruction::new_with_secp256k1_authority(
+            swig,
+            state,
+            asset,
+            |payload| {
+                k1_role_1.copy_from_slice(payload);
+                [0u8; 65]
+            },
+            10,
+            1,
+            1,
+            0,
+            vec![test_inner_instruction()],
+        )
+        .unwrap();
+
+        let mut k1_role_2 = [0u8; 32];
+        SubAccountSignV2Instruction::new_with_secp256k1_authority(
+            swig,
+            state,
+            asset,
+            |payload| {
+                k1_role_2.copy_from_slice(payload);
+                [0u8; 65]
+            },
+            10,
+            1,
+            2,
+            0,
+            vec![test_inner_instruction()],
+        )
+        .unwrap();
+        assert_ne!(k1_role_1, k1_role_2);
+
+        let public_key = [2u8; 33];
+        let mut r1_role_1 = [0u8; 32];
+        SubAccountSignV2Instruction::new_with_secp256r1_authority(
+            swig,
+            state,
+            asset,
+            |payload| {
+                r1_role_1.copy_from_slice(payload);
+                [0u8; 64]
+            },
+            10,
+            1,
+            1,
+            0,
+            vec![test_inner_instruction()],
+            &public_key,
+        )
+        .unwrap();
+
+        let mut r1_role_2 = [0u8; 32];
+        SubAccountSignV2Instruction::new_with_secp256r1_authority(
+            swig,
+            state,
+            asset,
+            |payload| {
+                r1_role_2.copy_from_slice(payload);
+                [0u8; 64]
+            },
+            10,
+            1,
+            2,
+            0,
+            vec![test_inner_instruction()],
+            &public_key,
+        )
+        .unwrap();
+        assert_ne!(r1_role_1, r1_role_2);
+    }
+
+    #[test]
+    fn toggle_sub_account_v2_secp_payer_is_writable() {
+        let swig = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let state = Pubkey::new_unique();
+
+        let k1 = ToggleSubAccountV2Instruction::new_with_secp256k1_authority(
+            swig,
+            payer,
+            |_| [0u8; 65],
+            10,
+            1,
+            state,
+            1,
+            0,
+            false,
+        )
+        .unwrap();
+        assert!(k1.accounts[1].is_writable);
+
+        let r1 = ToggleSubAccountV2Instruction::new_with_secp256r1_authority(
+            swig,
+            payer,
+            |_| [0u8; 64],
+            10,
+            1,
+            state,
+            1,
+            0,
+            false,
+            &[2u8; 33],
+        )
+        .unwrap();
+        assert!(r1[1].accounts[1].is_writable);
+    }
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -4264,9 +4264,7 @@ impl SubAccountSignV2Instruction {
 pub struct WithdrawFromSubAccountV2Instruction;
 
 impl WithdrawFromSubAccountV2Instruction {
-    /// Builds a SOL withdrawal. For token withdrawals, append
-    /// `[source_token, destination_token, token_program]` to the returned
-    /// instruction's account list.
+    /// Builds a SOL withdrawal.
     pub fn new_with_ed25519_authority(
         swig_account: Pubkey,
         authority: Pubkey,
@@ -4299,6 +4297,46 @@ impl WithdrawFromSubAccountV2Instruction {
         })
     }
 
+    /// Builds a token withdrawal with all token accounts included before the
+    /// instruction is signed.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_token_with_ed25519_authority(
+        swig_account: Pubkey,
+        authority: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+    ) -> anyhow::Result<Instruction> {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new(source_token, false),
+            AccountMeta::new(destination_token, false),
+            AccountMeta::new_readonly(token_program, false),
+        ];
+        let args = WithdrawFromSubAccountV2Args::new(role_id, subacc_id, amount);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &[5]].concat(),
+        })
+    }
+
     pub fn new_with_secp256k1_authority<F>(
         swig_account: Pubkey,
         payer: Pubkey,
@@ -4317,13 +4355,66 @@ impl WithdrawFromSubAccountV2Instruction {
     {
         let accounts = vec![
             AccountMeta::new(swig_account, false),
-            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(payer, true),
             AccountMeta::new_readonly(sub_account_state, false),
             AccountMeta::new(sub_account, false),
             AccountMeta::new(swig_wallet_address, false),
             // authority_context placeholder for Secp256k1
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+        let args = WithdrawFromSubAccountV2Args::new(role_id, subacc_id, amount);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        let account_payload_bytes = secp_account_payload(&accounts)?;
+        let authority_payload = secp256k1_v2_authority_payload(
+            args_bytes,
+            &account_payload_bytes,
+            current_slot,
+            counter,
+            &mut authority_payload_fn,
+        );
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        })
+    }
+
+    /// Builds a Secp256k1 token withdrawal. Token accounts are part of the
+    /// authenticated account payload and cannot be appended after signing.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_token_with_secp256k1_authority<F>(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+    ) -> anyhow::Result<Instruction>
+    where
+        F: FnMut(&[u8]) -> [u8; 65],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new(source_token, false),
+            AccountMeta::new(destination_token, false),
+            AccountMeta::new_readonly(token_program, false),
         ];
         let args = WithdrawFromSubAccountV2Args::new(role_id, subacc_id, amount);
         let args_bytes = args
@@ -4363,13 +4454,64 @@ impl WithdrawFromSubAccountV2Instruction {
     {
         let accounts = vec![
             AccountMeta::new(swig_account, false),
-            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(payer, true),
             AccountMeta::new_readonly(sub_account_state, false),
             AccountMeta::new(sub_account, false),
             AccountMeta::new(swig_wallet_address, false),
             // authority_context is the instructions sysvar for Secp256r1 (index 5)
             AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+        let args = WithdrawFromSubAccountV2Args::new(role_id, subacc_id, amount);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        secp256r1_v2_instructions(
+            &accounts,
+            args_bytes,
+            args_bytes,
+            current_slot,
+            counter,
+            5,
+            &mut authority_payload_fn,
+            public_key,
+        )
+    }
+
+    /// Builds a Secp256r1 token withdrawal. Token accounts are part of the
+    /// authenticated account payload and cannot be appended after signing.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_token_with_secp256r1_authority<F>(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        public_key: &[u8; 33],
+    ) -> anyhow::Result<Vec<Instruction>>
+    where
+        F: FnMut(&[u8]) -> [u8; 64],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new(source_token, false),
+            AccountMeta::new(destination_token, false),
+            AccountMeta::new_readonly(token_program, false),
         ];
         let args = WithdrawFromSubAccountV2Args::new(role_id, subacc_id, amount);
         let args_bytes = args

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -12,30 +12,49 @@ use swig::actions::{
     close_token_account_v1::CloseTokenAccountV1Args,
     create_session_v1::CreateSessionV1Args,
     create_sub_account_v1::CreateSubAccountV1Args,
+    create_sub_account_v2::CreateSubAccountV2Args,
     create_v1::CreateV1Args,
     recover_authority_v1::RecoverAuthorityV1Args,
     remove_authority_v1::RemoveAuthorityV1Args,
     set_rent_claimer_v1::SetRentClaimerV1Args,
     sub_account_sign_v1::SubAccountSignV1Args,
+    sub_account_sign_v2::SubAccountSignV2Args,
     toggle_sub_account_v1::ToggleSubAccountV1Args,
+    toggle_sub_account_v2::ToggleSubAccountV2Args,
     transfer_assets_v1::TransferAssetsV1Args,
     update_authority_v1::{AuthorityUpdateOperation, UpdateAuthorityV1Args},
     withdraw_from_sub_account_v1::WithdrawFromSubAccountV1Args,
+    withdraw_from_sub_account_v2::WithdrawFromSubAccountV2Args,
 };
 pub use swig_compact_instructions::*;
 use swig_state::{
     action::{
-        all::All, all_but_manage_authority::AllButManageAuthority,
-        close_swig_authority::CloseSwigAuthority, manage_authority::ManageAuthority,
-        program::Program, program_all::ProgramAll, program_curated::ProgramCurated,
-        program_scope::ProgramScope, recovery_authority::RecoveryAuthority,
-        sol_destination_limit::SolDestinationLimit, sol_limit::SolLimit,
+        all::All,
+        all_but_manage_authority::AllButManageAuthority,
+        close_swig_authority::CloseSwigAuthority,
+        manage_authority::ManageAuthority,
+        program::Program,
+        program_all::ProgramAll,
+        program_curated::ProgramCurated,
+        program_scope::ProgramScope,
+        recovery_authority::RecoveryAuthority,
+        sol_destination_limit::SolDestinationLimit,
+        sol_limit::SolLimit,
         sol_recurring_destination_limit::SolRecurringDestinationLimit,
-        sol_recurring_limit::SolRecurringLimit, stake_all::StakeAll, stake_limit::StakeLimit,
-        stake_recurring_limit::StakeRecurringLimit, sub_account::SubAccount,
-        token_destination_limit::TokenDestinationLimit, token_limit::TokenLimit,
+        sol_recurring_limit::SolRecurringLimit,
+        stake_all::StakeAll,
+        stake_limit::StakeLimit,
+        stake_recurring_limit::StakeRecurringLimit,
+        sub_account::SubAccount,
+        sub_account_v2::{
+            SubAccountV2All, SubAccountV2Create, SubAccountV2Sign, SubAccountV2Toggle,
+            SubAccountV2Withdraw,
+        },
+        token_destination_limit::TokenDestinationLimit,
+        token_limit::TokenLimit,
         token_recurring_destination_limit::TokenRecurringDestinationLimit,
-        token_recurring_limit::TokenRecurringLimit, Action, Permission,
+        token_recurring_limit::TokenRecurringLimit,
+        Action, Permission,
     },
     authority::{
         secp256k1::{hex_encode, AccountsPayload},
@@ -64,6 +83,11 @@ pub enum ClientAction {
     RecoveryAuthority(RecoveryAuthority),
     CloseSwigAuthority(CloseSwigAuthority),
     SubAccount(SubAccount),
+    SubAccountV2Create(SubAccountV2Create),
+    SubAccountV2All(SubAccountV2All),
+    SubAccountV2Sign(SubAccountV2Sign),
+    SubAccountV2Withdraw(SubAccountV2Withdraw),
+    SubAccountV2Toggle(SubAccountV2Toggle),
     StakeLimit(StakeLimit),
     StakeRecurringLimit(StakeRecurringLimit),
     StakeAll(StakeAll),
@@ -112,6 +136,19 @@ impl ClientAction {
                 (Permission::CloseSwigAuthority, CloseSwigAuthority::LEN)
             },
             ClientAction::SubAccount(_) => (Permission::SubAccount, SubAccount::LEN),
+            ClientAction::SubAccountV2Create(_) => {
+                (Permission::SubAccountV2Create, SubAccountV2Create::LEN)
+            },
+            ClientAction::SubAccountV2All(_) => (Permission::SubAccountV2All, SubAccountV2All::LEN),
+            ClientAction::SubAccountV2Sign(_) => {
+                (Permission::SubAccountV2Sign, SubAccountV2Sign::LEN)
+            },
+            ClientAction::SubAccountV2Withdraw(_) => {
+                (Permission::SubAccountV2Withdraw, SubAccountV2Withdraw::LEN)
+            },
+            ClientAction::SubAccountV2Toggle(_) => {
+                (Permission::SubAccountV2Toggle, SubAccountV2Toggle::LEN)
+            },
             ClientAction::StakeLimit(_) => (Permission::StakeLimit, StakeLimit::LEN),
             ClientAction::StakeRecurringLimit(_) => {
                 (Permission::StakeRecurringLimit, StakeRecurringLimit::LEN)
@@ -147,6 +184,11 @@ impl ClientAction {
             ClientAction::RecoveryAuthority(action) => action.into_bytes(),
             ClientAction::CloseSwigAuthority(action) => action.into_bytes(),
             ClientAction::SubAccount(action) => action.into_bytes(),
+            ClientAction::SubAccountV2Create(action) => action.into_bytes(),
+            ClientAction::SubAccountV2All(action) => action.into_bytes(),
+            ClientAction::SubAccountV2Sign(action) => action.into_bytes(),
+            ClientAction::SubAccountV2Withdraw(action) => action.into_bytes(),
+            ClientAction::SubAccountV2Toggle(action) => action.into_bytes(),
             ClientAction::StakeLimit(action) => action.into_bytes(),
             ClientAction::StakeRecurringLimit(action) => action.into_bytes(),
             ClientAction::StakeAll(action) => action.into_bytes(),
@@ -3867,4 +3909,570 @@ impl CloseSwigV1Instruction {
 
         Ok(vec![secp256r1_verify_ix, main_ix])
     }
+}
+
+/// Instruction builders for V2 sub-accounts (Ed25519, Secp256k1, Secp256r1).
+///
+/// The authority-payload construction mirrors the V1 builders: Ed25519 appends
+/// the signer account index; Secp256k1 appends `slot ++ signature`; Secp256r1
+/// emits a precompile verify instruction plus a `slot ++ counter ++
+/// sysvar_index` payload.
+pub struct CreateSubAccountV2Instruction;
+
+impl CreateSubAccountV2Instruction {
+    pub fn new_with_ed25519_authority(
+        swig_account: Pubkey,
+        authority: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        state_bump: u8,
+        asset_bump: u8,
+    ) -> anyhow::Result<Instruction> {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new_readonly(authority, true),
+        ];
+        let args = CreateSubAccountV2Args::new(role_id, state_bump, asset_bump);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        // Ed25519 authority payload is the index of the authority signer account.
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &[5]].concat(),
+        })
+    }
+
+    pub fn new_with_secp256k1_authority<F>(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        state_bump: u8,
+        asset_bump: u8,
+    ) -> anyhow::Result<Instruction>
+    where
+        F: FnMut(&[u8]) -> [u8; 65],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+        let args = CreateSubAccountV2Args::new(role_id, state_bump, asset_bump);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        let account_payload_bytes = secp_account_payload(&accounts)?;
+        let authority_payload = secp256k1_v2_authority_payload(
+            args_bytes,
+            &account_payload_bytes,
+            current_slot,
+            counter,
+            &mut authority_payload_fn,
+        );
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        })
+    }
+
+    pub fn new_with_secp256r1_authority<F>(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        state_bump: u8,
+        asset_bump: u8,
+        public_key: &[u8; 33],
+    ) -> anyhow::Result<Vec<Instruction>>
+    where
+        F: FnMut(&[u8]) -> [u8; 64],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
+        ];
+        let args = CreateSubAccountV2Args::new(role_id, state_bump, asset_bump);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        // Instructions sysvar is the last account (index 5).
+        secp256r1_v2_instructions(
+            &accounts,
+            args_bytes,
+            args_bytes,
+            current_slot,
+            counter,
+            5,
+            &mut authority_payload_fn,
+            public_key,
+        )
+    }
+}
+
+pub struct ToggleSubAccountV2Instruction;
+
+impl ToggleSubAccountV2Instruction {
+    pub fn new_with_ed25519_authority(
+        swig_account: Pubkey,
+        authority: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+    ) -> anyhow::Result<Instruction> {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(sub_account_state, false),
+            AccountMeta::new_readonly(authority, true),
+        ];
+        let args = ToggleSubAccountV2Args::new(auth_role_id, subacc_id, enabled);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &[3]].concat(),
+        })
+    }
+
+    pub fn new_with_secp256k1_authority<F>(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+    ) -> anyhow::Result<Instruction>
+    where
+        F: FnMut(&[u8]) -> [u8; 65],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(sub_account_state, false),
+        ];
+        let args = ToggleSubAccountV2Args::new(auth_role_id, subacc_id, enabled);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        let account_payload_bytes = secp_account_payload(&accounts)?;
+        let authority_payload = secp256k1_v2_authority_payload(
+            args_bytes,
+            &account_payload_bytes,
+            current_slot,
+            counter,
+            &mut authority_payload_fn,
+        );
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        })
+    }
+
+    pub fn new_with_secp256r1_authority<F>(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+        public_key: &[u8; 33],
+    ) -> anyhow::Result<Vec<Instruction>>
+    where
+        F: FnMut(&[u8]) -> [u8; 64],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(sub_account_state, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
+        ];
+        let args = ToggleSubAccountV2Args::new(auth_role_id, subacc_id, enabled);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        // Instructions sysvar is the last account (index 4).
+        secp256r1_v2_instructions(
+            &accounts,
+            args_bytes,
+            args_bytes,
+            current_slot,
+            counter,
+            4,
+            &mut authority_payload_fn,
+            public_key,
+        )
+    }
+}
+
+pub struct SubAccountSignV2Instruction;
+
+impl SubAccountSignV2Instruction {
+    pub fn new_with_ed25519_authority(
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        authority: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+    ) -> anyhow::Result<Instruction> {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new_readonly(authority, true),
+        ];
+        let (accounts, ixs) =
+            compact_instructions_sub_account(swig_account, sub_account, accounts, instructions);
+        let ix_bytes = ixs.into_bytes();
+        let args = SubAccountSignV2Args::new(role_id, subacc_id, ix_bytes.len() as u16);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &ix_bytes, &[4]].concat(),
+        })
+    }
+
+    pub fn new_with_secp256k1_authority<F>(
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+    ) -> anyhow::Result<Instruction>
+    where
+        F: FnMut(&[u8]) -> [u8; 65],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+        let (accounts, ixs) =
+            compact_instructions_sub_account(swig_account, sub_account, accounts, instructions);
+        let ix_bytes = ixs.into_bytes();
+        let args = SubAccountSignV2Args::new(role_id, subacc_id, ix_bytes.len() as u16);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        let account_payload_bytes = secp_account_payload(&accounts)?;
+        let authority_payload = secp256k1_v2_authority_payload(
+            &ix_bytes,
+            &account_payload_bytes,
+            current_slot,
+            counter,
+            &mut authority_payload_fn,
+        );
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &ix_bytes, &authority_payload].concat(),
+        })
+    }
+
+    pub fn new_with_secp256r1_authority<F>(
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        public_key: &[u8; 33],
+    ) -> anyhow::Result<Vec<Instruction>>
+    where
+        F: FnMut(&[u8]) -> [u8; 64],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
+        ];
+        let (accounts, ixs) =
+            compact_instructions_sub_account(swig_account, sub_account, accounts, instructions);
+        let ix_bytes = ixs.into_bytes();
+        let args = SubAccountSignV2Args::new(role_id, subacc_id, ix_bytes.len() as u16);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        // Instructions sysvar is the last base account (index 4); CPI accounts
+        // are appended after it by the compaction step. The signed data is the
+        // ix bytes; the instruction data is args ++ ix bytes ++ authority payload.
+        let data_prefix = [args_bytes, &ix_bytes].concat();
+        secp256r1_v2_instructions(
+            &accounts,
+            &ix_bytes,
+            &data_prefix,
+            current_slot,
+            counter,
+            4,
+            &mut authority_payload_fn,
+            public_key,
+        )
+    }
+}
+
+pub struct WithdrawFromSubAccountV2Instruction;
+
+impl WithdrawFromSubAccountV2Instruction {
+    /// Builds a SOL withdrawal. For token withdrawals, append
+    /// `[source_token, destination_token, token_program]` to the returned
+    /// instruction's account list.
+    pub fn new_with_ed25519_authority(
+        swig_account: Pubkey,
+        authority: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+    ) -> anyhow::Result<Instruction> {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+        let args = WithdrawFromSubAccountV2Args::new(role_id, subacc_id, amount);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        // Authority context (the Ed25519 signer) is at index 5.
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &[5]].concat(),
+        })
+    }
+
+    pub fn new_with_secp256k1_authority<F>(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+    ) -> anyhow::Result<Instruction>
+    where
+        F: FnMut(&[u8]) -> [u8; 65],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            // authority_context placeholder for Secp256k1
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+        let args = WithdrawFromSubAccountV2Args::new(role_id, subacc_id, amount);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        let account_payload_bytes = secp_account_payload(&accounts)?;
+        let authority_payload = secp256k1_v2_authority_payload(
+            args_bytes,
+            &account_payload_bytes,
+            current_slot,
+            counter,
+            &mut authority_payload_fn,
+        );
+        Ok(Instruction {
+            program_id: program_id(),
+            accounts,
+            data: [args_bytes, &authority_payload].concat(),
+        })
+    }
+
+    pub fn new_with_secp256r1_authority<F>(
+        swig_account: Pubkey,
+        payer: Pubkey,
+        mut authority_payload_fn: F,
+        current_slot: u64,
+        counter: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        swig_wallet_address: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        public_key: &[u8; 33],
+    ) -> anyhow::Result<Vec<Instruction>>
+    where
+        F: FnMut(&[u8]) -> [u8; 64],
+    {
+        let accounts = vec![
+            AccountMeta::new(swig_account, false),
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new_readonly(sub_account_state, false),
+            AccountMeta::new(sub_account, false),
+            AccountMeta::new(swig_wallet_address, false),
+            // authority_context is the instructions sysvar for Secp256r1 (index 5)
+            AccountMeta::new_readonly(solana_sdk::sysvar::instructions::ID, false),
+            AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+        ];
+        let args = WithdrawFromSubAccountV2Args::new(role_id, subacc_id, amount);
+        let args_bytes = args
+            .into_bytes()
+            .map_err(|e| anyhow::anyhow!("Failed to serialize args {:?}", e))?;
+        secp256r1_v2_instructions(
+            &accounts,
+            args_bytes,
+            args_bytes,
+            current_slot,
+            counter,
+            5,
+            &mut authority_payload_fn,
+            public_key,
+        )
+    }
+}
+
+/// Builds the Secp256k1 authority payload (`slot ++ counter ++ signature`) for
+/// a V2 instruction. `counter` must be the authority's next odometer value
+/// (on-chain odometer + 1); `signed_data` is what gets signed (args for
+/// create/toggle/withdraw, ix bytes for sign).
+fn secp256k1_v2_authority_payload<F>(
+    signed_data: &[u8],
+    account_payload: &[u8],
+    current_slot: u64,
+    counter: u32,
+    authority_payload_fn: &mut F,
+) -> Vec<u8>
+where
+    F: FnMut(&[u8]) -> [u8; 65],
+{
+    let nonced =
+        prepare_secp256k1_payload(current_slot, counter, signed_data, account_payload, &[]);
+    let signature = authority_payload_fn(&nonced);
+    let mut authority_payload = Vec::new();
+    authority_payload.extend_from_slice(&current_slot.to_le_bytes());
+    authority_payload.extend_from_slice(&counter.to_le_bytes());
+    authority_payload.extend_from_slice(&signature);
+    authority_payload
+}
+
+/// Concatenates the signed account-meta payload for a Secp instruction.
+fn secp_account_payload(accounts: &[AccountMeta]) -> anyhow::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    for account in accounts {
+        bytes.extend_from_slice(
+            accounts_payload_from_meta(account)
+                .into_bytes()
+                .map_err(|e| anyhow::anyhow!("Failed to serialize account meta {:?}", e))?,
+        );
+    }
+    Ok(bytes)
+}
+
+/// Builds the `[verify_ix, main_ix]` pair for a Secp256r1-authenticated V2
+/// instruction.
+///
+/// - `signed_data` is the byte string the program authenticates over: the args
+///   for create/toggle/withdraw, or the compact-instruction bytes for sign.
+/// - `data_prefix` is what precedes the authority payload in the instruction
+///   data: the args, or `args ++ ix_bytes` for sign.
+/// - `sysvar_index` is the position of the instructions sysvar in `accounts`.
+#[allow(clippy::too_many_arguments)]
+fn secp256r1_v2_instructions<F>(
+    accounts: &[AccountMeta],
+    signed_data: &[u8],
+    data_prefix: &[u8],
+    current_slot: u64,
+    counter: u32,
+    sysvar_index: u8,
+    authority_payload_fn: &mut F,
+    public_key: &[u8; 33],
+) -> anyhow::Result<Vec<Instruction>>
+where
+    F: FnMut(&[u8]) -> [u8; 64],
+{
+    let account_payload_bytes = secp_account_payload(accounts)?;
+    let slot_bytes = current_slot.to_le_bytes();
+    let counter_bytes = counter.to_le_bytes();
+    let message_hash = keccak::hash(
+        &[
+            signed_data,
+            &account_payload_bytes[..],
+            &slot_bytes[..],
+            &counter_bytes[..],
+        ]
+        .concat(),
+    )
+    .to_bytes();
+    let signature = authority_payload_fn(&message_hash);
+    let verify_ix = new_secp256r1_instruction_with_signature(&message_hash, &signature, public_key);
+
+    let mut authority_payload = Vec::new();
+    authority_payload.extend_from_slice(&current_slot.to_le_bytes()); // 8
+    authority_payload.extend_from_slice(&counter.to_le_bytes()); // 4
+    authority_payload.push(sysvar_index); // 1
+    authority_payload.extend_from_slice(&[0u8; 4]); // padding to 17 bytes
+
+    let main_ix = Instruction {
+        program_id: program_id(),
+        accounts: accounts.to_vec(),
+        data: [data_prefix, &authority_payload].concat(),
+    };
+    Ok(vec![verify_ix, main_ix])
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -4045,9 +4045,14 @@ impl ToggleSubAccountV2Instruction {
         subacc_id: u32,
         enabled: bool,
     ) -> anyhow::Result<Instruction> {
+        // The payer is writable to match the instruction's declared accounts and
+        // the Secp variants below. Those cannot use `new_readonly`: the signed
+        // account payload is built from these metas client-side but rebuilt from
+        // the runtime `AccountInfo` on-chain, and a fee-paying account is always
+        // writable at runtime, so the two would disagree.
         let accounts = vec![
             AccountMeta::new(swig_account, false),
-            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(payer, true),
             AccountMeta::new(sub_account_state, false),
             AccountMeta::new_readonly(authority, true),
         ];

--- a/program/idl.json
+++ b/program/idl.json
@@ -715,7 +715,7 @@
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true,
           "docs": [
             "the payer"

--- a/program/idl.json
+++ b/program/idl.json
@@ -651,6 +651,198 @@
         "type": "u8",
         "value": 17
       }
+    },
+    {
+      "name": "CreateSubAccountV2",
+      "accounts": [
+        {
+          "name": "swig",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the swig smart wallet"
+          ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "the payer"
+          ]
+        },
+        {
+          "name": "subAccountState",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the v2 sub account state account to create"
+          ]
+        },
+        {
+          "name": "subAccount",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the v2 sub account asset account to create"
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "the system program"
+          ]
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 18
+      }
+    },
+    {
+      "name": "ToggleSubAccountV2",
+      "accounts": [
+        {
+          "name": "swig",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the swig smart wallet"
+          ]
+        },
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "the payer"
+          ]
+        },
+        {
+          "name": "subAccountState",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the v2 sub account state account to toggle"
+          ]
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 19
+      }
+    },
+    {
+      "name": "SubAccountSignV2",
+      "accounts": [
+        {
+          "name": "swig",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the swig smart wallet"
+          ]
+        },
+        {
+          "name": "subAccountState",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "the v2 sub account state account"
+          ]
+        },
+        {
+          "name": "subAccount",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the v2 sub account asset account"
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "the system program"
+          ]
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 20
+      }
+    },
+    {
+      "name": "WithdrawFromSubAccountV2",
+      "accounts": [
+        {
+          "name": "swig",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the swig smart wallet"
+          ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "the payer"
+          ]
+        },
+        {
+          "name": "subAccountState",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "the v2 sub account state account"
+          ]
+        },
+        {
+          "name": "subAccount",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the v2 sub account asset account to withdraw from"
+          ]
+        },
+        {
+          "name": "swigWalletAddress",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the swig wallet address (destination)"
+          ]
+        },
+        {
+          "name": "authorityContext",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "authority context: signer for Ed25519, sysvar for Secp256r1, or placeholder for Secp256k1"
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "the system program"
+          ]
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 21
+      }
     }
   ],
   "metadata": {

--- a/program/src/actions/close_swig_v1.rs
+++ b/program/src/actions/close_swig_v1.rs
@@ -150,11 +150,6 @@ pub fn close_swig_v1(
     if !has_all && !has_manage && !has_close {
         return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
     }
-    // There is no V2 sub-account close lifecycle yet. Closing the parent would
-    // remove the authorization root needed to access its state and asset PDAs.
-    if swig.sub_account_counter != 0 {
-        return Err(SwigError::SwigHasSubAccountV2.into());
-    }
     if let Some(claimer) = configured_rent_claimer {
         if ctx.accounts.destination.key().as_ref() != claimer.as_ref() {
             return Err(SwigError::InvalidRentClaimerDestination.into());

--- a/program/src/actions/close_swig_v1.rs
+++ b/program/src/actions/close_swig_v1.rs
@@ -150,6 +150,11 @@ pub fn close_swig_v1(
     if !has_all && !has_manage && !has_close {
         return Err(SwigAuthenticateError::PermissionDeniedMissingPermission.into());
     }
+    // There is no V2 sub-account close lifecycle yet. Closing the parent would
+    // remove the authorization root needed to access its state and asset PDAs.
+    if swig.sub_account_counter != 0 {
+        return Err(SwigError::SwigHasSubAccountV2.into());
+    }
     if let Some(claimer) = configured_rent_claimer {
         if ctx.accounts.destination.key().as_ref() != claimer.as_ref() {
             return Err(SwigError::InvalidRentClaimerDestination.into());

--- a/program/src/actions/create_sub_account_v2.rs
+++ b/program/src/actions/create_sub_account_v2.rs
@@ -1,0 +1,247 @@
+//! Module for creating V2 sub-accounts.
+//!
+//! A V2 sub-account is identified by a `u32` counter in the Swig header rather
+//! than by a role id, so it can be shared across roles. Creation:
+//! 1. requires a `SubAccountV2Create` action on the acting role (default-deny;
+//!    `All` alone does not suffice),
+//! 2. draws a fresh id from the header counter,
+//! 3. initializes the program-owned state account and the system-owned asset
+//!    account, and
+//! 4. appends a scoped `SubAccountV2All { id }` action to the acting role so the
+//!    creator can immediately use the sub-account.
+use no_padding::NoPadding;
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    sysvars::{clock::Clock, rent::Rent, Sysvar},
+    ProgramResult,
+};
+use pinocchio_system::instructions::{CreateAccount, Transfer};
+use swig_assertions::*;
+use swig_state::{
+    action::{sub_account_v2::SubAccountV2Create, Action, Permission},
+    sub_account_v2::SubAccountV2,
+    swig::{
+        sub_account_v2_asset_seeds_with_bump, sub_account_v2_state_seeds_with_bump,
+        sub_account_v2_state_signer, Swig,
+    },
+    Discriminator, IntoBytes, Transmutable, TransmutableMut,
+};
+
+use crate::{
+    actions::update_authority_v1::append_actions_to_role,
+    error::SwigError,
+    instruction::{
+        accounts::{Context, CreateSubAccountV2Accounts},
+        SwigInstruction,
+    },
+};
+
+/// Arguments for creating a V2 sub-account.
+#[repr(C, align(8))]
+#[derive(Debug, NoPadding)]
+pub struct CreateSubAccountV2Args {
+    discriminator: SwigInstruction,
+    _padding1: u16,
+    /// Role creating (and initially granted access to) the sub-account
+    pub role_id: u32,
+    /// Bump for the program-owned state PDA
+    pub state_bump: u8,
+    /// Bump for the system-owned asset PDA
+    pub asset_bump: u8,
+    _padding2: [u8; 6],
+}
+
+impl CreateSubAccountV2Args {
+    pub fn new(role_id: u32, state_bump: u8, asset_bump: u8) -> Self {
+        Self {
+            discriminator: SwigInstruction::CreateSubAccountV2,
+            _padding1: 0,
+            role_id,
+            state_bump,
+            asset_bump,
+            _padding2: [0; 6],
+        }
+    }
+}
+
+impl Transmutable for CreateSubAccountV2Args {
+    const LEN: usize = core::mem::size_of::<Self>();
+}
+
+impl IntoBytes for CreateSubAccountV2Args {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+/// Parsed create instruction.
+pub struct CreateSubAccountV2<'a> {
+    pub args: &'a CreateSubAccountV2Args,
+    pub authority_payload: &'a [u8],
+    pub data_payload: &'a [u8],
+}
+
+impl<'a> CreateSubAccountV2<'a> {
+    pub fn from_instruction_bytes(data: &'a [u8]) -> Result<Self, ProgramError> {
+        if data.len() < CreateSubAccountV2Args::LEN {
+            return Err(SwigError::InvalidSwigCreateSubAccountV2InstructionDataTooShort.into());
+        }
+        let (args_data, authority_payload) = data.split_at(CreateSubAccountV2Args::LEN);
+        let args = unsafe { CreateSubAccountV2Args::load_unchecked(args_data)? };
+        Ok(Self {
+            args,
+            authority_payload,
+            data_payload: args_data,
+        })
+    }
+}
+
+/// Builds the `[Action header][SubAccountV2All body]` bytes for the creator's
+/// auto-granted scoped action. Boundary is left zero; it is recomputed when the
+/// action is appended to the role.
+fn build_all_action_bytes(subacc_id: u32) -> [u8; Action::LEN + 8] {
+    let mut buf = [0u8; Action::LEN + 8];
+    buf[0..2].copy_from_slice(&(Permission::SubAccountV2All as u16).to_le_bytes());
+    buf[2..4].copy_from_slice(&8u16.to_le_bytes());
+    // buf[4..8] boundary = 0
+    buf[Action::LEN..Action::LEN + 4].copy_from_slice(&subacc_id.to_le_bytes());
+    // buf[12..16] padding = 0
+    buf
+}
+
+/// Creates a new V2 sub-account under a Swig wallet.
+#[inline(always)]
+pub fn create_sub_account_v2(
+    ctx: Context<CreateSubAccountV2Accounts>,
+    data: &[u8],
+    all_accounts: &[AccountInfo],
+) -> ProgramResult {
+    check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
+    // Both PDAs must be uninitialized system accounts before creation.
+    check_system_owner(
+        ctx.accounts.sub_account_state,
+        SwigError::OwnerMismatchSubAccountV2State,
+    )?;
+    check_system_owner(ctx.accounts.sub_account, SwigError::OwnerMismatchSubAccount)?;
+
+    let create = CreateSubAccountV2::from_instruction_bytes(data)?;
+
+    // Authenticate, authorize creation, and draw a fresh id under one borrow.
+    let (new_id, swig_id) = {
+        let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+        if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8
+        {
+            return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+        }
+        let parts = Swig::split_parts_mut(swig_account_data)?;
+        let swig = parts.state;
+        let swig_roles = parts.roles;
+        if swig.wallet_bump == 0 {
+            return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
+        }
+
+        let role_opt = Swig::get_mut_role(create.args.role_id, swig_roles)?;
+        if role_opt.is_none() {
+            return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+        }
+        let role = role_opt.unwrap();
+        let clock = Clock::get()?;
+        if role.authority.session_based() {
+            role.authority.authenticate_session(
+                all_accounts,
+                create.authority_payload,
+                create.data_payload,
+                clock.slot,
+            )?;
+        } else {
+            role.authority.authenticate(
+                all_accounts,
+                create.authority_payload,
+                create.data_payload,
+                clock.slot,
+            )?;
+        }
+
+        // Default-deny: creating requires an explicit SubAccountV2Create action.
+        if role.get_action::<SubAccountV2Create>(&[])?.is_none() {
+            return Err(SwigError::AuthorityCannotCreateSubAccountV2.into());
+        }
+
+        // Draw and consume a fresh sub-account id.
+        let new_id = swig.sub_account_counter;
+        swig.sub_account_counter = new_id.checked_add(1).ok_or(SwigError::StateError)?;
+        (new_id, swig.id)
+    };
+
+    // Verify both PDAs match the provided bumps.
+    let id_le = new_id.to_le_bytes();
+    let state_bump = [create.args.state_bump];
+    let asset_bump = [create.args.asset_bump];
+    let state_seeds = sub_account_v2_state_seeds_with_bump(&swig_id, &id_le, &state_bump);
+    check_self_pda(
+        &state_seeds,
+        ctx.accounts.sub_account_state.key(),
+        SwigError::InvalidSeedSubAccountV2,
+    )?;
+    let asset_seeds = sub_account_v2_asset_seeds_with_bump(&swig_id, &id_le, &asset_bump);
+    check_self_pda(
+        &asset_seeds,
+        ctx.accounts.sub_account.key(),
+        SwigError::InvalidSeedSubAccountV2,
+    )?;
+
+    // Create the program-owned state account.
+    let rent = Rent::get()?;
+    let state_rent = rent.minimum_balance(SubAccountV2::LEN);
+    let state_current = unsafe { *ctx.accounts.sub_account_state.borrow_lamports_unchecked() };
+    let state_lamports = state_rent.saturating_sub(state_current);
+    CreateAccount {
+        from: ctx.accounts.payer,
+        to: ctx.accounts.sub_account_state,
+        lamports: state_lamports,
+        space: SubAccountV2::LEN as u64,
+        owner: &crate::ID,
+    }
+    .invoke_signed(&[sub_account_v2_state_signer(&swig_id, &id_le, &state_bump)
+        .as_slice()
+        .into()])?;
+
+    // Write the state.
+    {
+        let state_data = unsafe { ctx.accounts.sub_account_state.borrow_mut_data_unchecked() };
+        let state = SubAccountV2::new(
+            create.args.state_bump,
+            create.args.asset_bump,
+            new_id,
+            swig_id,
+            *ctx.accounts.sub_account.key(),
+        );
+        state_data.copy_from_slice(state.into_bytes()?);
+    }
+
+    // Fund the system-owned asset account to rent-exemption (0 data).
+    let asset_rent = rent.minimum_balance(0);
+    let asset_current = unsafe { *ctx.accounts.sub_account.borrow_lamports_unchecked() };
+    let asset_lamports = asset_rent.saturating_sub(asset_current);
+    if asset_lamports > 0 {
+        Transfer {
+            from: ctx.accounts.payer,
+            to: ctx.accounts.sub_account,
+            lamports: asset_lamports,
+        }
+        .invoke()?;
+    }
+
+    // Auto-grant the creator scoped umbrella access via the shared, tail-preserving
+    // append path (grows the swig account and funds the delta from the payer).
+    let action_bytes = build_all_action_bytes(new_id);
+    append_actions_to_role(
+        ctx.accounts.swig,
+        ctx.accounts.payer,
+        create.args.role_id,
+        &action_bytes,
+    )?;
+
+    Ok(())
+}

--- a/program/src/actions/create_sub_account_v2.rs
+++ b/program/src/actions/create_sub_account_v2.rs
@@ -29,7 +29,7 @@ use swig_state::{
 };
 
 use crate::{
-    actions::update_authority_v1::append_actions_to_role,
+    actions::{sub_account_sign_v2::has_scoped_v2, update_authority_v1::append_actions_to_role},
     error::SwigError,
     instruction::{
         accounts::{Context, CreateSubAccountV2Accounts},
@@ -137,18 +137,18 @@ pub fn create_sub_account_v2(
     let create = CreateSubAccountV2::from_instruction_bytes(data)?;
 
     // Authenticate, authorize creation, and draw a fresh id under one borrow.
-    let (new_id, swig_id) = {
+    let (new_id, swig_id, already_granted) = {
         let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
         if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8
         {
             return Err(SwigError::InvalidSwigAccountDiscriminator.into());
         }
+        // V2 requires the wallet-address (migrated) Swig generation. Checked
+        // before the split, which needs the buffer mutably.
+        crate::require_swig_v2(swig_account_data)?;
         let parts = Swig::split_parts_mut(swig_account_data)?;
         let swig = parts.state;
         let swig_roles = parts.roles;
-        if swig.wallet_bump == 0 {
-            return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
-        }
 
         let role_opt = Swig::get_mut_role(create.args.role_id, swig_roles)?;
         if role_opt.is_none() {
@@ -180,7 +180,15 @@ pub fn create_sub_account_v2(
         // Draw and consume a fresh sub-account id.
         let new_id = swig.sub_account_counter;
         swig.sub_account_counter = new_id.checked_add(1).ok_or(SwigError::StateError)?;
-        (new_id, swig.id)
+
+        // The design allows scoping an id before it exists, so the creator may
+        // already hold `SubAccountV2All { new_id }`. Presence of the scope is the
+        // grant: appending a second copy would trip the duplicate check in
+        // `perform_replace_all_operation` and fail the whole create.
+        let already_granted =
+            has_scoped_v2(role.actions, Permission::SubAccountV2All, new_id, false)?;
+
+        (new_id, swig.id, already_granted)
     };
 
     // Verify both PDAs match the provided bumps.
@@ -257,13 +265,17 @@ pub fn create_sub_account_v2(
 
     // Auto-grant the creator scoped umbrella access via the shared, tail-preserving
     // append path (grows the swig account and funds the delta from the payer).
-    let action_bytes = build_all_action_bytes(new_id);
-    append_actions_to_role(
-        ctx.accounts.swig,
-        ctx.accounts.payer,
-        create.args.role_id,
-        &action_bytes,
-    )?;
+    // Skipped when the role was pre-granted this exact scope; the end state is the
+    // same single `SubAccountV2All { new_id }` either way.
+    if !already_granted {
+        let action_bytes = build_all_action_bytes(new_id);
+        append_actions_to_role(
+            ctx.accounts.swig,
+            ctx.accounts.payer,
+            create.args.role_id,
+            &action_bytes,
+        )?;
+    }
 
     Ok(())
 }

--- a/program/src/actions/create_sub_account_v2.rs
+++ b/program/src/actions/create_sub_account_v2.rs
@@ -16,7 +16,7 @@ use pinocchio::{
     sysvars::{clock::Clock, rent::Rent, Sysvar},
     ProgramResult,
 };
-use pinocchio_system::instructions::{CreateAccount, Transfer};
+use pinocchio_system::instructions::{Allocate, Assign, Transfer};
 use swig_assertions::*;
 use swig_state::{
     action::{sub_account_v2::SubAccountV2Create, Action, Permission},
@@ -124,6 +124,15 @@ pub fn create_sub_account_v2(
         SwigError::OwnerMismatchSubAccountV2State,
     )?;
     check_system_owner(ctx.accounts.sub_account, SwigError::OwnerMismatchSubAccount)?;
+    check_bytes_match(
+        ctx.accounts.system_program.key(),
+        &pinocchio_system::ID,
+        32,
+        SwigError::InvalidSystemProgram,
+    )?;
+    if ctx.accounts.sub_account_state.data_len() != 0 {
+        return Err(ProgramError::InvalidAccountData);
+    }
 
     let create = CreateSubAccountV2::from_instruction_bytes(data)?;
 
@@ -191,21 +200,34 @@ pub fn create_sub_account_v2(
         SwigError::InvalidSeedSubAccountV2,
     )?;
 
-    // Create the program-owned state account.
+    // Initialize the program-owned state account. Anyone can transfer SOL to
+    // this predictable PDA before creation, and `CreateAccount` rejects such a
+    // pre-funded destination. Top up, allocate, and assign separately so that
+    // pre-funding cannot permanently pin the Swig's next counter value.
     let rent = Rent::get()?;
     let state_rent = rent.minimum_balance(SubAccountV2::LEN);
     let state_current = unsafe { *ctx.accounts.sub_account_state.borrow_lamports_unchecked() };
     let state_lamports = state_rent.saturating_sub(state_current);
-    CreateAccount {
-        from: ctx.accounts.payer,
-        to: ctx.accounts.sub_account_state,
-        lamports: state_lamports,
+    if state_lamports > 0 {
+        Transfer {
+            from: ctx.accounts.payer,
+            to: ctx.accounts.sub_account_state,
+            lamports: state_lamports,
+        }
+        .invoke()?;
+    }
+    let state_signer = sub_account_v2_state_signer(&swig_id, &id_le, &state_bump);
+    let state_signers = [state_signer.as_slice().into()];
+    Allocate {
+        account: ctx.accounts.sub_account_state,
         space: SubAccountV2::LEN as u64,
+    }
+    .invoke_signed(&state_signers)?;
+    Assign {
+        account: ctx.accounts.sub_account_state,
         owner: &crate::ID,
     }
-    .invoke_signed(&[sub_account_v2_state_signer(&swig_id, &id_le, &state_bump)
-        .as_slice()
-        .into()])?;
+    .invoke_signed(&state_signers)?;
 
     // Write the state.
     {

--- a/program/src/actions/mod.rs
+++ b/program/src/actions/mod.rs
@@ -10,6 +10,7 @@ pub mod close_swig_v1;
 pub mod close_token_account_v1;
 pub mod create_session_v1;
 pub mod create_sub_account_v1;
+pub mod create_sub_account_v2;
 pub mod create_v1;
 pub mod migrate_to_wallet_address_v1;
 pub mod recover_authority_v1;
@@ -17,30 +18,35 @@ pub mod remove_authority_v1;
 pub mod set_rent_claimer_v1;
 pub mod sign_v2;
 pub mod sub_account_sign_v1;
+pub mod sub_account_sign_v2;
 pub mod toggle_sub_account_v1;
+pub mod toggle_sub_account_v2;
 pub mod transfer_assets_v1;
 pub mod update_authority_v1;
 pub mod withdraw_from_sub_account_v1;
+pub mod withdraw_from_sub_account_v2;
 
 use num_enum::FromPrimitive;
 use pinocchio::{account_info::AccountInfo, msg, program_error::ProgramError, ProgramResult};
 
 use self::{
     add_authority_v1::*, close_swig_v1::*, close_token_account_v1::*, create_session_v1::*,
-    create_sub_account_v1::*, create_v1::*, migrate_to_wallet_address_v1::*,
-    recover_authority_v1::*, remove_authority_v1::*, set_rent_claimer_v1::*, sign_v2::*,
-    sub_account_sign_v1::*, toggle_sub_account_v1::*, transfer_assets_v1::*,
-    update_authority_v1::*, withdraw_from_sub_account_v1::*,
+    create_sub_account_v1::*, create_sub_account_v2::*, create_v1::*,
+    migrate_to_wallet_address_v1::*, recover_authority_v1::*, remove_authority_v1::*,
+    set_rent_claimer_v1::*, sign_v2::*, sub_account_sign_v1::*, sub_account_sign_v2::*,
+    toggle_sub_account_v1::*, toggle_sub_account_v2::*, transfer_assets_v1::*,
+    update_authority_v1::*, withdraw_from_sub_account_v1::*, withdraw_from_sub_account_v2::*,
 };
 use crate::{
     instruction::{
         accounts::{
             AddAuthorityV1Accounts, CloseSwigV1Accounts, CloseTokenAccountV1Accounts,
-            CreateSessionV1Accounts, CreateSubAccountV1Accounts, CreateV1Accounts,
-            MigrateToWalletAddressV1Accounts, RecoverAuthorityV1Accounts,
+            CreateSessionV1Accounts, CreateSubAccountV1Accounts, CreateSubAccountV2Accounts,
+            CreateV1Accounts, MigrateToWalletAddressV1Accounts, RecoverAuthorityV1Accounts,
             RemoveAuthorityV1Accounts, SetRentClaimerV1Accounts, SignV2Accounts,
-            SubAccountSignV1Accounts, ToggleSubAccountV1Accounts, TransferAssetsV1Accounts,
-            UpdateAuthorityV1Accounts, WithdrawFromSubAccountV1Accounts,
+            SubAccountSignV1Accounts, SubAccountSignV2Accounts, ToggleSubAccountV1Accounts,
+            ToggleSubAccountV2Accounts, TransferAssetsV1Accounts, UpdateAuthorityV1Accounts,
+            WithdrawFromSubAccountV1Accounts, WithdrawFromSubAccountV2Accounts,
         },
         SwigInstruction,
     },
@@ -93,6 +99,14 @@ pub fn process_action(
             process_sub_account_sign_v1(accounts, account_classification, data)
         },
         SwigInstruction::ToggleSubAccountV1 => process_toggle_sub_account_v1(accounts, data),
+        SwigInstruction::CreateSubAccountV2 => process_create_sub_account_v2(accounts, data),
+        SwigInstruction::ToggleSubAccountV2 => process_toggle_sub_account_v2(accounts, data),
+        SwigInstruction::SubAccountSignV2 => {
+            process_sub_account_sign_v2(accounts, account_classification, data)
+        },
+        SwigInstruction::WithdrawFromSubAccountV2 => {
+            process_withdraw_from_sub_account_v2(accounts, account_classification, data)
+        },
         SwigInstruction::MigrateToWalletAddressV1 => {
             process_migrate_to_wallet_address_v1(accounts, data)
         },
@@ -202,6 +216,46 @@ fn process_withdraw_from_sub_account_v1(
 fn process_toggle_sub_account_v1(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let account_ctx = ToggleSubAccountV1Accounts::context(accounts)?;
     toggle_sub_account_v1(account_ctx, data, accounts)
+}
+
+/// Processes a CreateSubAccountV2 instruction.
+///
+/// Creates a new counter-identified V2 sub-account.
+fn process_create_sub_account_v2(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
+    let account_ctx = CreateSubAccountV2Accounts::context(accounts)?;
+    create_sub_account_v2(account_ctx, data, accounts)
+}
+
+/// Processes a ToggleSubAccountV2 instruction.
+///
+/// Flips the enabled kill-switch on a V2 sub-account.
+fn process_toggle_sub_account_v2(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
+    let account_ctx = ToggleSubAccountV2Accounts::context(accounts)?;
+    toggle_sub_account_v2(account_ctx, data, accounts)
+}
+
+/// Processes a SubAccountSignV2 instruction.
+///
+/// Signs and executes a transaction as a V2 sub-account asset account.
+fn process_sub_account_sign_v2(
+    accounts: &[AccountInfo],
+    account_classification: &[AccountClassification],
+    data: &[u8],
+) -> ProgramResult {
+    let account_ctx = SubAccountSignV2Accounts::context(accounts)?;
+    sub_account_sign_v2(account_ctx, accounts, data, account_classification)
+}
+
+/// Processes a WithdrawFromSubAccountV2 instruction.
+///
+/// Withdraws assets from a V2 sub-account to the swig wallet address.
+fn process_withdraw_from_sub_account_v2(
+    accounts: &[AccountInfo],
+    account_classification: &[AccountClassification],
+    data: &[u8],
+) -> ProgramResult {
+    let account_ctx = WithdrawFromSubAccountV2Accounts::context(accounts)?;
+    withdraw_from_sub_account_v2(account_ctx, accounts, data, account_classification)
 }
 
 /// Processes a MigrateToWalletAddressV1 instruction.

--- a/program/src/actions/sub_account_sign_v2.rs
+++ b/program/src/actions/sub_account_sign_v2.rs
@@ -1,0 +1,267 @@
+//! Module for signing transactions as a V2 sub-account asset account.
+//!
+//! Authorization is default-deny and scoped: the acting role must hold a
+//! `SubAccountV2Sign { subacc_id }` or `SubAccountV2All { subacc_id }` action.
+//! Wallet-level `All` / `ManageAuthority` grant nothing here.
+use no_padding::NoPadding;
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    sysvars::{clock::Clock, Sysvar},
+    ProgramResult,
+};
+use swig_assertions::*;
+use swig_compact_instructions::InstructionIterator;
+use swig_state::{
+    action::{Action, Permission},
+    role::RoleMut,
+    sub_account_v2::SubAccountV2,
+    swig::{sub_account_v2_asset_signer, sub_account_v2_state_seeds_with_bump, Swig},
+    Discriminator, IntoBytes, SwigAuthenticateError, Transmutable, TransmutableMut,
+};
+
+use crate::{
+    error::SwigError,
+    instruction::{
+        accounts::{Context, SubAccountSignV2Accounts},
+        SwigInstruction,
+    },
+    AccountClassification,
+};
+
+/// Authorizes a scoped V2 sub-account runtime operation.
+///
+/// Returns `Ok(())` if `role` holds a matching `specific` action for `subacc_id`
+/// or a `SubAccountV2All` action for `subacc_id`. Wallet-level overrides are
+/// intentionally not consulted — access is default-denied.
+///
+/// `specific` must be one of the scoped V2 runtime permissions
+/// (`SubAccountV2Sign`/`Withdraw`/`Toggle`). All scoped V2 bodies carry
+/// `subacc_id` as their first four little-endian bytes.
+pub(crate) fn authorize_scoped_v2(
+    role: &RoleMut<'_>,
+    specific: Permission,
+    subacc_id: u32,
+) -> ProgramResult {
+    let id_le = subacc_id.to_le_bytes();
+    let actions = &*role.actions;
+    let mut cursor = 0usize;
+    while cursor + Action::LEN <= actions.len() {
+        let header = unsafe { Action::load_unchecked(&actions[cursor..cursor + Action::LEN])? };
+        let data_start = cursor + Action::LEN;
+        let data_end = data_start
+            .checked_add(header.length() as usize)
+            .ok_or(SwigError::StateError)?;
+        if data_end > actions.len() {
+            return Err(SwigError::StateError.into());
+        }
+        let permission = header.permission()?;
+        if (permission == specific || permission == Permission::SubAccountV2All)
+            && header.length() as usize >= 4
+            && actions[data_start..data_start + 4] == id_le
+        {
+            return Ok(());
+        }
+        cursor = data_end;
+    }
+    Err(SwigError::PermissionDeniedMissingSubAccountV2Permission.into())
+}
+
+/// Loads and validates a V2 sub-account state account against the parent swig
+/// and the requested `subacc_id`, returning the cached `asset_bump`.
+///
+/// Verifies the account is the canonical state PDA (via the stored bump), has
+/// the right discriminator, belongs to this swig, matches the id, is enabled,
+/// and that `asset_account` is the state's recorded asset PDA.
+pub(crate) fn validate_v2_state(
+    state_account: &AccountInfo,
+    asset_account: &AccountInfo,
+    swig_id: &[u8; 32],
+    subacc_id: u32,
+) -> Result<u8, ProgramError> {
+    check_self_owned(state_account, SwigError::OwnerMismatchSubAccountV2State)?;
+    let state_data = unsafe { state_account.borrow_data_unchecked() };
+    let state = unsafe { SubAccountV2::load_unchecked(state_data)? };
+    state.check_discriminator()?;
+    if &state.swig_id != swig_id {
+        return Err(SwigError::InvalidSwigSubAccountV2SwigIdMismatch.into());
+    }
+    if state.subacc_id != subacc_id {
+        return Err(SwigError::InvalidSwigSubAccountV2IdMismatch.into());
+    }
+    if !state.enabled {
+        return Err(SwigError::InvalidSwigSubAccountV2Disabled.into());
+    }
+    // Bind the state account to its canonical PDA address.
+    let id_le = subacc_id.to_le_bytes();
+    let bump = [state.bump];
+    let seeds = sub_account_v2_state_seeds_with_bump(swig_id, &id_le, &bump);
+    check_self_pda(
+        &seeds,
+        state_account.key(),
+        SwigError::InvalidSeedSubAccountV2,
+    )?;
+    // Bind the asset account to the state's recorded asset PDA.
+    if &state.sub_account != asset_account.key().as_ref() {
+        return Err(SwigError::InvalidSeedSubAccountV2.into());
+    }
+    Ok(state.asset_bump)
+}
+
+/// Arguments for signing a transaction with a V2 sub-account.
+#[repr(C, align(8))]
+#[derive(Debug, NoPadding)]
+pub struct SubAccountSignV2Args {
+    instruction: SwigInstruction,
+    pub instruction_payload_len: u16,
+    pub role_id: u32,
+    pub subacc_id: u32,
+    _padding: [u8; 4],
+}
+
+impl SubAccountSignV2Args {
+    pub fn new(role_id: u32, subacc_id: u32, instruction_payload_len: u16) -> Self {
+        Self {
+            instruction: SwigInstruction::SubAccountSignV2,
+            instruction_payload_len,
+            role_id,
+            subacc_id,
+            _padding: [0; 4],
+        }
+    }
+}
+
+impl Transmutable for SubAccountSignV2Args {
+    const LEN: usize = core::mem::size_of::<Self>();
+}
+
+impl IntoBytes for SubAccountSignV2Args {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+/// Parsed sign instruction.
+pub struct SubAccountSignV2<'a> {
+    pub args: &'a SubAccountSignV2Args,
+    authority_payload: &'a [u8],
+    instruction_payload: &'a [u8],
+}
+
+impl<'a> SubAccountSignV2<'a> {
+    pub fn from_instruction_bytes(data: &'a [u8]) -> Result<Self, ProgramError> {
+        if data.len() < SubAccountSignV2Args::LEN {
+            return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
+        }
+        let (inst, rest) = unsafe { data.split_at_unchecked(SubAccountSignV2Args::LEN) };
+        let args = unsafe { SubAccountSignV2Args::load_unchecked(inst)? };
+        let instruction_payload_len = args.instruction_payload_len as usize;
+        if instruction_payload_len > rest.len() {
+            return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
+        }
+        let (instruction_payload, authority_payload) =
+            unsafe { rest.split_at_unchecked(instruction_payload_len) };
+        Ok(Self {
+            args,
+            authority_payload,
+            instruction_payload,
+        })
+    }
+}
+
+/// Signs and executes a transaction as a V2 sub-account asset account.
+#[inline(always)]
+pub fn sub_account_sign_v2(
+    ctx: Context<SubAccountSignV2Accounts>,
+    all_accounts: &[AccountInfo],
+    data: &[u8],
+    _account_classifiers: &[AccountClassification],
+) -> ProgramResult {
+    check_stack_height(1, SwigError::Cpi)?;
+    check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
+    check_system_owner(ctx.accounts.sub_account, SwigError::OwnerMismatchSubAccount)?;
+
+    let sign = SubAccountSignV2::from_instruction_bytes(data)?;
+
+    let swig_id = {
+        let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+        if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8
+        {
+            return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+        }
+        let parts = Swig::split_parts_mut(swig_account_data)?;
+        let swig = parts.state;
+        let swig_roles = parts.roles;
+        if swig.wallet_bump == 0 {
+            return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
+        }
+        let swig_id = swig.id;
+
+        let role_opt = Swig::get_mut_role(sign.args.role_id, swig_roles)?;
+        if role_opt.is_none() {
+            return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+        }
+        let role = role_opt.unwrap();
+        let clock = Clock::get()?;
+        if role.authority.session_based() {
+            role.authority.authenticate_session(
+                all_accounts,
+                sign.authority_payload,
+                sign.instruction_payload,
+                clock.slot,
+            )?;
+        } else {
+            role.authority.authenticate(
+                all_accounts,
+                sign.authority_payload,
+                sign.instruction_payload,
+                clock.slot,
+            )?;
+        }
+        authorize_scoped_v2(&role, Permission::SubAccountV2Sign, sign.args.subacc_id)?;
+        swig_id
+    };
+
+    // Validate the state account and obtain the asset bump for signing.
+    let asset_bump = validate_v2_state(
+        ctx.accounts.sub_account_state,
+        ctx.accounts.sub_account,
+        &swig_id,
+        sign.args.subacc_id,
+    )?;
+
+    // Execute the inner instructions signed by the asset PDA.
+    let rkeys: &[&Pubkey] = &[];
+    let ix_iter = InstructionIterator::new(
+        all_accounts,
+        sign.instruction_payload,
+        ctx.accounts.sub_account.key(),
+        rkeys,
+    )?;
+    let id_le = sign.args.subacc_id.to_le_bytes();
+    let bump_byte = [asset_bump];
+    let seeds = sub_account_v2_asset_signer(&swig_id, &id_le, &bump_byte);
+    let signer = seeds.as_slice();
+    for ix in ix_iter {
+        if let Ok(instruction) = ix {
+            instruction.execute(
+                all_accounts,
+                ctx.accounts.sub_account.key(),
+                &[signer.into()],
+            )?;
+        } else {
+            return Err(SwigError::InstructionExecutionError.into());
+        }
+    }
+
+    // Ensure the asset account remains rent-exempt.
+    let account_data = unsafe { ctx.accounts.sub_account.borrow_data_unchecked() };
+    let rent_exempt_minimum =
+        pinocchio::sysvars::rent::Rent::get()?.minimum_balance(account_data.len());
+    let current_lamports = unsafe { *ctx.accounts.sub_account.borrow_lamports_unchecked() };
+    if current_lamports < rent_exempt_minimum {
+        return Err(SwigAuthenticateError::PermissionDeniedInsufficientBalance.into());
+    }
+    Ok(())
+}

--- a/program/src/actions/sub_account_sign_v2.rs
+++ b/program/src/actions/sub_account_sign_v2.rs
@@ -30,22 +30,17 @@ use crate::{
     AccountClassification,
 };
 
-/// Authorizes a scoped V2 sub-account runtime operation.
+/// Reports whether an action buffer holds a scoped V2 action for `subacc_id`.
 ///
-/// Returns `Ok(())` if `role` holds a matching `specific` action for `subacc_id`
-/// or a `SubAccountV2All` action for `subacc_id`. Wallet-level overrides are
-/// intentionally not consulted — access is default-denied.
-///
-/// `specific` must be one of the scoped V2 runtime permissions
-/// (`SubAccountV2Sign`/`Withdraw`/`Toggle`). All scoped V2 bodies carry
-/// `subacc_id` as their first four little-endian bytes.
-pub(crate) fn authorize_scoped_v2(
-    role: &RoleMut<'_>,
+/// Matches `specific`, and also `SubAccountV2All` when `accept_all` is set. All
+/// scoped V2 bodies carry `subacc_id` as their first four little-endian bytes.
+pub(crate) fn has_scoped_v2(
+    actions: &[u8],
     specific: Permission,
     subacc_id: u32,
-) -> ProgramResult {
+    accept_all: bool,
+) -> Result<bool, ProgramError> {
     let id_le = subacc_id.to_le_bytes();
-    let actions = &*role.actions;
     let mut cursor = 0usize;
     while cursor + Action::LEN <= actions.len() {
         let header = unsafe { Action::load_unchecked(&actions[cursor..cursor + Action::LEN])? };
@@ -57,14 +52,35 @@ pub(crate) fn authorize_scoped_v2(
             return Err(SwigError::StateError.into());
         }
         let permission = header.permission()?;
-        if (permission == specific || permission == Permission::SubAccountV2All)
+        if (permission == specific || (accept_all && permission == Permission::SubAccountV2All))
             && header.length() as usize >= 4
             && actions[data_start..data_start + 4] == id_le
         {
-            return Ok(());
+            return Ok(true);
         }
         cursor = data_end;
     }
+
+    Ok(false)
+}
+
+/// Authorizes a scoped V2 sub-account runtime operation.
+///
+/// Returns `Ok(())` if `role` holds a matching `specific` action for `subacc_id`
+/// or a `SubAccountV2All` action for `subacc_id`. Wallet-level overrides are
+/// intentionally not consulted — access is default-denied.
+///
+/// `specific` must be one of the scoped V2 runtime permissions
+/// (`SubAccountV2Sign`/`Withdraw`/`Toggle`).
+pub(crate) fn authorize_scoped_v2(
+    role: &RoleMut<'_>,
+    specific: Permission,
+    subacc_id: u32,
+) -> ProgramResult {
+    if has_scoped_v2(role.actions, specific, subacc_id, true)? {
+        return Ok(());
+    }
+
     Err(SwigError::PermissionDeniedMissingSubAccountV2Permission.into())
 }
 
@@ -195,12 +211,12 @@ pub fn sub_account_sign_v2(
         {
             return Err(SwigError::InvalidSwigAccountDiscriminator.into());
         }
+        // V2 requires the wallet-address (migrated) Swig generation. Checked
+        // before the split, which needs the buffer mutably.
+        crate::require_swig_v2(swig_account_data)?;
         let parts = Swig::split_parts_mut(swig_account_data)?;
         let swig = parts.state;
         let swig_roles = parts.roles;
-        if swig.wallet_bump == 0 {
-            return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
-        }
         let swig_id = swig.id;
 
         let role_opt = Swig::get_mut_role(sign.args.role_id, swig_roles)?;

--- a/program/src/actions/sub_account_sign_v2.rs
+++ b/program/src/actions/sub_account_sign_v2.rs
@@ -146,6 +146,7 @@ impl IntoBytes for SubAccountSignV2Args {
 pub struct SubAccountSignV2<'a> {
     pub args: &'a SubAccountSignV2Args,
     authority_payload: &'a [u8],
+    data_payload: &'a [u8],
     instruction_payload: &'a [u8],
 }
 
@@ -157,7 +158,10 @@ impl<'a> SubAccountSignV2<'a> {
         let (inst, rest) = unsafe { data.split_at_unchecked(SubAccountSignV2Args::LEN) };
         let args = unsafe { SubAccountSignV2Args::load_unchecked(inst)? };
         let instruction_payload_len = args.instruction_payload_len as usize;
-        if instruction_payload_len > rest.len() {
+        let data_payload_len = SubAccountSignV2Args::LEN
+            .checked_add(instruction_payload_len)
+            .ok_or(SwigError::InvalidSwigSignInstructionDataTooShort)?;
+        if instruction_payload_len > rest.len() || data_payload_len > data.len() {
             return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
         }
         let (instruction_payload, authority_payload) =
@@ -165,6 +169,7 @@ impl<'a> SubAccountSignV2<'a> {
         Ok(Self {
             args,
             authority_payload,
+            data_payload: &data[..data_payload_len],
             instruction_payload,
         })
     }
@@ -208,14 +213,14 @@ pub fn sub_account_sign_v2(
             role.authority.authenticate_session(
                 all_accounts,
                 sign.authority_payload,
-                sign.instruction_payload,
+                sign.data_payload,
                 clock.slot,
             )?;
         } else {
             role.authority.authenticate(
                 all_accounts,
                 sign.authority_payload,
-                sign.instruction_payload,
+                sign.data_payload,
                 clock.slot,
             )?;
         }

--- a/program/src/actions/sub_account_sign_v2.rs
+++ b/program/src/actions/sub_account_sign_v2.rs
@@ -90,7 +90,7 @@ pub(crate) fn validate_v2_state(
     if state.subacc_id != subacc_id {
         return Err(SwigError::InvalidSwigSubAccountV2IdMismatch.into());
     }
-    if !state.enabled {
+    if !state.is_enabled()? {
         return Err(SwigError::InvalidSwigSubAccountV2Disabled.into());
     }
     // Bind the state account to its canonical PDA address.

--- a/program/src/actions/toggle_sub_account_v2.rs
+++ b/program/src/actions/toggle_sub_account_v2.rs
@@ -151,6 +151,7 @@ pub fn toggle_sub_account_v2(
     let state_data = unsafe { ctx.accounts.sub_account_state.borrow_mut_data_unchecked() };
     let state = unsafe { SubAccountV2::load_mut_unchecked(state_data)? };
     state.check_discriminator()?;
+    state.is_enabled()?;
     if state.swig_id != swig_id {
         return Err(SwigError::InvalidSwigSubAccountV2SwigIdMismatch.into());
     }
@@ -167,6 +168,6 @@ pub fn toggle_sub_account_v2(
         SwigError::InvalidSeedSubAccountV2,
     )?;
 
-    state.enabled = toggle.args.enabled == 1;
+    state.set_enabled(toggle.args.enabled == 1);
     Ok(())
 }

--- a/program/src/actions/toggle_sub_account_v2.rs
+++ b/program/src/actions/toggle_sub_account_v2.rs
@@ -111,14 +111,12 @@ pub fn toggle_sub_account_v2(
     if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
         return Err(SwigError::InvalidSwigAccountDiscriminator.into());
     }
+    // V2 requires the wallet-address (migrated) Swig generation. Checked before
+    // the split, which needs the buffer mutably.
+    crate::require_swig_v2(swig_account_data)?;
     let parts = Swig::split_parts_mut(swig_account_data)?;
     let swig = parts.state;
     let swig_roles = parts.roles;
-
-    // V2 requires the wallet-address (migrated) Swig generation.
-    if swig.wallet_bump == 0 {
-        return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
-    }
     let swig_id = swig.id;
 
     // Authenticate the acting role and require a scoped toggle permission.

--- a/program/src/actions/toggle_sub_account_v2.rs
+++ b/program/src/actions/toggle_sub_account_v2.rs
@@ -34,7 +34,7 @@ use crate::{
 pub struct ToggleSubAccountV2Args {
     discriminator: SwigInstruction,
     /// Desired enabled state
-    pub enabled: bool,
+    pub enabled: u8,
     _padding: u8,
     /// Role performing the toggle
     pub auth_role_id: u32,
@@ -47,7 +47,7 @@ impl ToggleSubAccountV2Args {
     pub fn new(auth_role_id: u32, subacc_id: u32, enabled: bool) -> Self {
         Self {
             discriminator: SwigInstruction::ToggleSubAccountV2,
-            enabled,
+            enabled: u8::from(enabled),
             _padding: 0,
             auth_role_id,
             subacc_id,
@@ -80,6 +80,9 @@ impl<'a> ToggleSubAccountV2<'a> {
         }
         let (args_data, authority_payload) = data.split_at(ToggleSubAccountV2Args::LEN);
         let args = unsafe { ToggleSubAccountV2Args::load_unchecked(args_data)? };
+        if args.enabled > 1 {
+            return Err(ProgramError::InvalidInstructionData);
+        }
         Ok(Self {
             args,
             authority_payload,
@@ -164,6 +167,6 @@ pub fn toggle_sub_account_v2(
         SwigError::InvalidSeedSubAccountV2,
     )?;
 
-    state.enabled = toggle.args.enabled;
+    state.enabled = toggle.args.enabled == 1;
     Ok(())
 }

--- a/program/src/actions/toggle_sub_account_v2.rs
+++ b/program/src/actions/toggle_sub_account_v2.rs
@@ -1,0 +1,169 @@
+//! Module for toggling the enabled kill-switch on a V2 sub-account.
+//!
+//! Unlike V1 — where the enabled flag lives inside a role's `SubAccount` action
+//! — a V2 sub-account's enabled flag lives on its program-owned state account.
+//! Authorization is default-deny: the acting role must hold a scoped
+//! `SubAccountV2Toggle { subacc_id }` or `SubAccountV2All { subacc_id }` action.
+use no_padding::NoPadding;
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    sysvars::{clock::Clock, Sysvar},
+    ProgramResult,
+};
+use swig_assertions::*;
+use swig_state::{
+    action::Permission,
+    sub_account_v2::SubAccountV2,
+    swig::{sub_account_v2_state_seeds_with_bump, Swig},
+    Discriminator, IntoBytes, Transmutable, TransmutableMut,
+};
+
+use crate::{
+    actions::sub_account_sign_v2::authorize_scoped_v2,
+    error::SwigError,
+    instruction::{
+        accounts::{Context, ToggleSubAccountV2Accounts},
+        SwigInstruction,
+    },
+};
+
+/// Arguments for toggling a V2 sub-account.
+#[repr(C, align(8))]
+#[derive(Debug, NoPadding)]
+pub struct ToggleSubAccountV2Args {
+    discriminator: SwigInstruction,
+    /// Desired enabled state
+    pub enabled: bool,
+    _padding: u8,
+    /// Role performing the toggle
+    pub auth_role_id: u32,
+    /// Sub-account being toggled
+    pub subacc_id: u32,
+    _padding2: u32,
+}
+
+impl ToggleSubAccountV2Args {
+    pub fn new(auth_role_id: u32, subacc_id: u32, enabled: bool) -> Self {
+        Self {
+            discriminator: SwigInstruction::ToggleSubAccountV2,
+            enabled,
+            _padding: 0,
+            auth_role_id,
+            subacc_id,
+            _padding2: 0,
+        }
+    }
+}
+
+impl Transmutable for ToggleSubAccountV2Args {
+    const LEN: usize = core::mem::size_of::<Self>();
+}
+
+impl IntoBytes for ToggleSubAccountV2Args {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+/// Parsed toggle instruction.
+pub struct ToggleSubAccountV2<'a> {
+    pub args: &'a ToggleSubAccountV2Args,
+    pub authority_payload: &'a [u8],
+    pub data_payload: &'a [u8],
+}
+
+impl<'a> ToggleSubAccountV2<'a> {
+    pub fn from_instruction_bytes(data: &'a [u8]) -> Result<Self, ProgramError> {
+        if data.len() < ToggleSubAccountV2Args::LEN {
+            return Err(SwigError::InvalidInstructionDataTooShort.into());
+        }
+        let (args_data, authority_payload) = data.split_at(ToggleSubAccountV2Args::LEN);
+        let args = unsafe { ToggleSubAccountV2Args::load_unchecked(args_data)? };
+        Ok(Self {
+            args,
+            authority_payload,
+            data_payload: args_data,
+        })
+    }
+}
+
+/// Flips the enabled kill-switch on a V2 sub-account.
+#[inline(always)]
+pub fn toggle_sub_account_v2(
+    ctx: Context<ToggleSubAccountV2Accounts>,
+    data: &[u8],
+    all_accounts: &[AccountInfo],
+) -> ProgramResult {
+    check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
+    // The V2 state account is program-owned.
+    check_self_owned(
+        ctx.accounts.sub_account_state,
+        SwigError::OwnerMismatchSubAccountV2State,
+    )?;
+
+    let toggle = ToggleSubAccountV2::from_instruction_bytes(data)?;
+
+    let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+    if unsafe { *swig_account_data.get_unchecked(0) } != Discriminator::SwigConfigAccount as u8 {
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+    let parts = Swig::split_parts_mut(swig_account_data)?;
+    let swig = parts.state;
+    let swig_roles = parts.roles;
+
+    // V2 requires the wallet-address (migrated) Swig generation.
+    if swig.wallet_bump == 0 {
+        return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
+    }
+    let swig_id = swig.id;
+
+    // Authenticate the acting role and require a scoped toggle permission.
+    let role_opt = Swig::get_mut_role(toggle.args.auth_role_id, swig_roles)?;
+    if role_opt.is_none() {
+        return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+    }
+    let mut role = role_opt.unwrap();
+    let clock = pinocchio::sysvars::clock::Clock::get()?;
+    if role.authority.session_based() {
+        role.authority.authenticate_session(
+            all_accounts,
+            toggle.authority_payload,
+            toggle.data_payload,
+            clock.slot,
+        )?;
+    } else {
+        role.authority.authenticate(
+            all_accounts,
+            toggle.authority_payload,
+            toggle.data_payload,
+            clock.slot,
+        )?;
+    }
+
+    // Scoped auth: SubAccountV2Toggle { id } or SubAccountV2All { id }.
+    authorize_scoped_v2(&role, Permission::SubAccountV2Toggle, toggle.args.subacc_id)?;
+
+    // Load and bind the state account, then flip enabled.
+    let state_data = unsafe { ctx.accounts.sub_account_state.borrow_mut_data_unchecked() };
+    let state = unsafe { SubAccountV2::load_mut_unchecked(state_data)? };
+    state.check_discriminator()?;
+    if state.swig_id != swig_id {
+        return Err(SwigError::InvalidSwigSubAccountV2SwigIdMismatch.into());
+    }
+    if state.subacc_id != toggle.args.subacc_id {
+        return Err(SwigError::InvalidSwigSubAccountV2IdMismatch.into());
+    }
+    // Bind the account to its canonical PDA address using the stored bump.
+    let id_le = toggle.args.subacc_id.to_le_bytes();
+    let bump = [state.bump];
+    let seeds = sub_account_v2_state_seeds_with_bump(&swig_id, &id_le, &bump);
+    check_self_pda(
+        &seeds,
+        ctx.accounts.sub_account_state.key(),
+        SwigError::InvalidSeedSubAccountV2,
+    )?;
+
+    state.enabled = toggle.args.enabled;
+    Ok(())
+}

--- a/program/src/actions/update_authority_v1.rs
+++ b/program/src/actions/update_authority_v1.rs
@@ -290,6 +290,12 @@ fn perform_replace_all_operation(
     new_actions: &[u8],
     authority_to_update_id: u32,
 ) -> Result<i64, ProgramError> {
+    // Reject duplicate V2 sub-account scoped actions on the resulting role.
+    // ReplaceAll receives the role's full new action list, and AddActions routes
+    // through here after concatenating existing + new actions, so both mutation
+    // paths are covered by this single check.
+    ActionLoader::reject_duplicate_v2_scoped(new_actions)?;
+
     let new_actions_size = new_actions.len();
     let size_diff = new_actions_size as i64 - current_actions_size as i64;
 
@@ -428,6 +434,122 @@ fn perform_add_actions_operation(
         &combined_actions,
         authority_to_update_id,
     )
+}
+
+/// Locates a role by id within the roles buffer, returning
+/// `(current_actions_size, authority_offset, actions_offset)`.
+fn find_role_action_offsets(
+    swig_roles: &[u8],
+    roles: u16,
+    roles_len: usize,
+    role_id: u32,
+) -> Result<(usize, usize, usize), ProgramError> {
+    let mut cursor = 0usize;
+    for _ in 0..roles {
+        if cursor + Position::LEN > roles_len {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let position =
+            unsafe { Position::load_unchecked(&swig_roles[cursor..cursor + Position::LEN])? };
+        let boundary = position.boundary() as usize;
+        if boundary < cursor + Position::LEN || boundary > roles_len {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if position.id() == role_id {
+            let actions_offset = cursor + Position::LEN + position.authority_length() as usize;
+            let current_actions_size = boundary - actions_offset;
+            return Ok((current_actions_size, cursor, actions_offset));
+        }
+        cursor = boundary;
+    }
+    Err(SwigError::InvalidAuthorityNotFoundByRoleId.into())
+}
+
+/// Appends `new_actions` (`[header][data]` entries) to the role identified by
+/// `role_id`, growing the Swig account and preserving the rent-claimer tail.
+///
+/// This is the shared, tail-preserving realloc + append used both by
+/// UpdateAuthorityV1's AddActions path and by CreateSubAccountV2's auto-grant of
+/// the creator's `SubAccountV2All` action. Callers must have already
+/// authenticated and authorized the mutation; this function performs no
+/// permission checks.
+pub(crate) fn append_actions_to_role(
+    swig_account: &AccountInfo,
+    payer: &AccountInfo,
+    role_id: u32,
+    new_actions: &[u8],
+) -> Result<(), ProgramError> {
+    let mut account_len: usize;
+    let (saved_tail, current_roles_len, current_actions_size, authority_offset, actions_offset) = {
+        let swig_account_data = unsafe { swig_account.borrow_mut_data_unchecked() };
+        account_len = swig_account_data.len();
+        if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+            return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+        }
+        let parts = Swig::split_parts_mut(swig_account_data)?;
+        let saved_tail = SavedTail::take(parts.tail)?;
+        let swig = parts.state;
+        let swig_roles = parts.roles;
+        let roles_len = swig_roles.len();
+        let (current_actions_size, authority_offset, actions_offset) =
+            find_role_action_offsets(swig_roles, swig.roles, roles_len, role_id)?;
+        (
+            saved_tail,
+            roles_len,
+            current_actions_size,
+            authority_offset,
+            actions_offset,
+        )
+    };
+
+    let size_diff = new_actions.len() as i64;
+
+    if size_diff > 0 {
+        let new_size = (account_len as i64 + size_diff) as usize;
+        let aligned_size =
+            core::alloc::Layout::from_size_align(new_size, core::mem::size_of::<u64>())
+                .map_err(|_| SwigError::InvalidAlignment)?
+                .pad_to_align()
+                .size();
+
+        swig_account.realloc(aligned_size, false)?;
+        account_len = aligned_size;
+
+        let cost = Rent::get()?.minimum_balance(aligned_size);
+        let current_lamports = unsafe { *swig_account.borrow_lamports_unchecked() };
+        let additional_cost = cost.saturating_sub(current_lamports);
+        if additional_cost > 0 {
+            Transfer {
+                from: payer,
+                to: swig_account,
+                lamports: additional_cost,
+            }
+            .invoke()?;
+        }
+    }
+    let _ = account_len;
+
+    // Re-borrow after realloc, restore the tail, and re-split the roles region.
+    let swig_account_data = unsafe { swig_account.borrow_mut_data_unchecked() };
+    saved_tail.restore(swig_account_data)?;
+    let (_, swig_roles_and_tail) = unsafe { swig_account_data.split_at_mut_unchecked(Swig::LEN) };
+    let roles_capacity_len = swig_roles_and_tail
+        .len()
+        .checked_sub(saved_tail.len())
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let (swig_roles, _) = unsafe { swig_roles_and_tail.split_at_mut_unchecked(roles_capacity_len) };
+
+    perform_add_actions_operation(
+        swig_roles,
+        current_roles_len,
+        authority_offset,
+        actions_offset,
+        current_actions_size,
+        new_actions,
+        role_id,
+    )?;
+
+    Ok(())
 }
 
 /// Performs a remove-actions-by-type operation on an authority.

--- a/program/src/actions/withdraw_from_sub_account_v2.rs
+++ b/program/src/actions/withdraw_from_sub_account_v2.rs
@@ -114,12 +114,12 @@ pub fn withdraw_from_sub_account_v2(
         if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
             return Err(SwigError::InvalidSwigAccountDiscriminator.into());
         }
+        // V2 requires the wallet-address (migrated) Swig generation. Checked
+        // before the split, which needs the buffer mutably.
+        crate::require_swig_v2(swig_account_data)?;
         let parts = Swig::split_parts_mut(swig_account_data)?;
         let swig = parts.state;
         let swig_roles = parts.roles;
-        if swig.wallet_bump == 0 {
-            return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
-        }
         let swig_id = swig.id;
 
         // Validate the destination is the canonical swig wallet address PDA.

--- a/program/src/actions/withdraw_from_sub_account_v2.rs
+++ b/program/src/actions/withdraw_from_sub_account_v2.rs
@@ -9,7 +9,6 @@ use no_padding::NoPadding;
 use pinocchio::{
     account_info::AccountInfo,
     memory::sol_memcmp,
-    msg,
     program_error::ProgramError,
     sysvars::{clock::Clock, Sysvar},
     ProgramResult,
@@ -17,7 +16,7 @@ use pinocchio::{
 use swig_assertions::*;
 use swig_state::{
     action::Permission,
-    swig::{sub_account_v2_asset_signer, swig_wallet_address_seeds, Swig},
+    swig::{sub_account_v2_asset_signer, swig_wallet_address_seeds_with_bump, Swig},
     Discriminator, IntoBytes, SwigAuthenticateError, Transmutable,
 };
 
@@ -124,11 +123,12 @@ pub fn withdraw_from_sub_account_v2(
         let swig_id = swig.id;
 
         // Validate the destination is the canonical swig wallet address PDA.
-        let wallet_seeds = swig_wallet_address_seeds(ctx.accounts.swig.key().as_ref());
-        let (expected_wallet_address, _bump) =
-            pinocchio::pubkey::find_program_address(&wallet_seeds, &crate::ID);
+        let wallet_bump = [swig.wallet_bump];
+        let wallet_seeds =
+            swig_wallet_address_seeds_with_bump(ctx.accounts.swig.key().as_ref(), &wallet_bump);
+        let expected_wallet_address =
+            pinocchio::pubkey::create_program_address(&wallet_seeds, &crate::ID)?;
         if expected_wallet_address != *ctx.accounts.swig_wallet_address.key() {
-            msg!("Invalid swig wallet address PDA for v2 sub account");
             return Err(SwigError::InvalidSwigSubAccountV2SwigIdMismatch.into());
         }
 

--- a/program/src/actions/withdraw_from_sub_account_v2.rs
+++ b/program/src/actions/withdraw_from_sub_account_v2.rs
@@ -1,0 +1,229 @@
+//! Module for withdrawing assets from a V2 sub-account to the swig wallet
+//! address.
+//!
+//! Authorization is default-deny and scoped: the acting role must hold a
+//! `SubAccountV2Withdraw { subacc_id }` or `SubAccountV2All { subacc_id }`
+//! action. Unlike V1, wallet-level `All` / `ManageAuthority` grant nothing, and
+//! the destination is always the swig wallet address.
+use no_padding::NoPadding;
+use pinocchio::{
+    account_info::AccountInfo,
+    memory::sol_memcmp,
+    msg,
+    program_error::ProgramError,
+    sysvars::{clock::Clock, Sysvar},
+    ProgramResult,
+};
+use swig_assertions::*;
+use swig_state::{
+    action::Permission,
+    swig::{sub_account_v2_asset_signer, swig_wallet_address_seeds, Swig},
+    Discriminator, IntoBytes, SwigAuthenticateError, Transmutable,
+};
+
+use crate::{
+    actions::sub_account_sign_v2::{authorize_scoped_v2, validate_v2_state},
+    error::SwigError,
+    instruction::{
+        accounts::{Context, WithdrawFromSubAccountV2Accounts},
+        SwigInstruction,
+    },
+    util::TokenTransfer,
+    AccountClassification, SPL_TOKEN_2022_ID, SPL_TOKEN_ID,
+};
+
+/// Number of named accounts in the WithdrawFromSubAccountV2 context. Token
+/// accounts, if any, follow at this base index.
+const NAMED_ACCOUNTS: usize = 7;
+
+/// Arguments for withdrawing from a V2 sub-account.
+#[repr(C, align(8))]
+#[derive(Debug, NoPadding)]
+pub struct WithdrawFromSubAccountV2Args {
+    discriminator: SwigInstruction,
+    _padding: u16,
+    pub role_id: u32,
+    pub subacc_id: u32,
+    _padding2: u32,
+    pub amount: u64,
+}
+
+impl WithdrawFromSubAccountV2Args {
+    pub fn new(role_id: u32, subacc_id: u32, amount: u64) -> Self {
+        Self {
+            discriminator: SwigInstruction::WithdrawFromSubAccountV2,
+            _padding: 0,
+            role_id,
+            subacc_id,
+            _padding2: 0,
+            amount,
+        }
+    }
+}
+
+impl Transmutable for WithdrawFromSubAccountV2Args {
+    const LEN: usize = core::mem::size_of::<Self>();
+}
+
+impl IntoBytes for WithdrawFromSubAccountV2Args {
+    fn into_bytes(&self) -> Result<&[u8], ProgramError> {
+        Ok(unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, Self::LEN) })
+    }
+}
+
+/// Parsed withdraw instruction.
+pub struct WithdrawFromSubAccountV2<'a> {
+    pub args: &'a WithdrawFromSubAccountV2Args,
+    pub authority_payload: &'a [u8],
+    pub data_payload: &'a [u8],
+}
+
+impl<'a> WithdrawFromSubAccountV2<'a> {
+    pub fn from_instruction_bytes(data: &'a [u8]) -> Result<Self, ProgramError> {
+        if data.len() < WithdrawFromSubAccountV2Args::LEN {
+            return Err(SwigError::InvalidSwigSignInstructionDataTooShort.into());
+        }
+        let (args_data, authority_payload) = data.split_at(WithdrawFromSubAccountV2Args::LEN);
+        let args = unsafe { WithdrawFromSubAccountV2Args::load_unchecked(args_data)? };
+        Ok(Self {
+            args,
+            authority_payload,
+            data_payload: args_data,
+        })
+    }
+}
+
+/// Withdraws SOL or SPL tokens from a V2 sub-account to the swig wallet address.
+#[inline(always)]
+pub fn withdraw_from_sub_account_v2(
+    ctx: Context<WithdrawFromSubAccountV2Accounts>,
+    all_accounts: &[AccountInfo],
+    data: &[u8],
+    _account_classifiers: &[AccountClassification],
+) -> ProgramResult {
+    check_self_owned(ctx.accounts.swig, SwigError::OwnerMismatchSwigAccount)?;
+    check_system_owner(ctx.accounts.sub_account, SwigError::OwnerMismatchSubAccount)?;
+    check_system_owner(
+        ctx.accounts.swig_wallet_address,
+        SwigError::OwnerMismatchSwigAccount,
+    )?;
+
+    let withdraw = WithdrawFromSubAccountV2::from_instruction_bytes(data)?;
+
+    let swig_id = {
+        let swig_account_data = unsafe { ctx.accounts.swig.borrow_mut_data_unchecked() };
+        if swig_account_data[0] != Discriminator::SwigConfigAccount as u8 {
+            return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+        }
+        let parts = Swig::split_parts_mut(swig_account_data)?;
+        let swig = parts.state;
+        let swig_roles = parts.roles;
+        if swig.wallet_bump == 0 {
+            return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
+        }
+        let swig_id = swig.id;
+
+        // Validate the destination is the canonical swig wallet address PDA.
+        let wallet_seeds = swig_wallet_address_seeds(ctx.accounts.swig.key().as_ref());
+        let (expected_wallet_address, _bump) =
+            pinocchio::pubkey::find_program_address(&wallet_seeds, &crate::ID);
+        if expected_wallet_address != *ctx.accounts.swig_wallet_address.key() {
+            msg!("Invalid swig wallet address PDA for v2 sub account");
+            return Err(SwigError::InvalidSwigSubAccountV2SwigIdMismatch.into());
+        }
+
+        let role_opt = Swig::get_mut_role(withdraw.args.role_id, swig_roles)?;
+        if role_opt.is_none() {
+            return Err(SwigError::InvalidAuthorityNotFoundByRoleId.into());
+        }
+        let role = role_opt.unwrap();
+        let clock = Clock::get()?;
+        if role.authority.session_based() {
+            role.authority.authenticate_session(
+                all_accounts,
+                withdraw.authority_payload,
+                withdraw.data_payload,
+                clock.slot,
+            )?;
+        } else {
+            role.authority.authenticate(
+                all_accounts,
+                withdraw.authority_payload,
+                withdraw.data_payload,
+                clock.slot,
+            )?;
+        }
+        authorize_scoped_v2(
+            &role,
+            Permission::SubAccountV2Withdraw,
+            withdraw.args.subacc_id,
+        )?;
+        swig_id
+    };
+
+    // Validate the state account and bind the asset account.
+    let asset_bump = validate_v2_state(
+        ctx.accounts.sub_account_state,
+        ctx.accounts.sub_account,
+        &swig_id,
+        withdraw.args.subacc_id,
+    )?;
+
+    let id_le = withdraw.args.subacc_id.to_le_bytes();
+    let bump_byte = [asset_bump];
+    let seeds = sub_account_v2_asset_signer(&swig_id, &id_le, &bump_byte);
+    let signer = seeds.as_slice();
+    let amount = withdraw.args.amount;
+
+    // Token accounts (source, destination, token_program) follow the named
+    // accounts. Their presence selects a token withdrawal; otherwise SOL.
+    if all_accounts.len() >= NAMED_ACCOUNTS + 3 {
+        let token_account = &all_accounts[NAMED_ACCOUNTS];
+        let swig_token_account = &all_accounts[NAMED_ACCOUNTS + 1];
+
+        // Destination token account must be owned by the swig wallet address.
+        let swig_token_account_data = unsafe { swig_token_account.borrow_data_unchecked() };
+        let swig_token_account_owner = unsafe { swig_token_account_data.get_unchecked(32..64) };
+        if unsafe {
+            sol_memcmp(
+                ctx.accounts.swig_wallet_address.key(),
+                swig_token_account_owner,
+                32,
+            )
+        } != 0
+        {
+            return Err(SwigError::InvalidSwigTokenAccountOwner.into());
+        }
+
+        let token_account_program_owner = token_account.owner();
+        let destination_program_owner = swig_token_account.owner();
+        if token_account_program_owner != &SPL_TOKEN_ID
+            && token_account_program_owner != &SPL_TOKEN_2022_ID
+        {
+            return Err(SwigError::OwnerMismatchTokenAccount.into());
+        }
+        if destination_program_owner != token_account_program_owner {
+            return Err(SwigError::InvalidOperation.into());
+        }
+
+        let token_transfer = TokenTransfer {
+            from: token_account,
+            to: swig_token_account,
+            authority: ctx.accounts.sub_account,
+            amount,
+            token_program: token_account_program_owner,
+        };
+        token_transfer.invoke_signed(&[signer.into()])?;
+    } else {
+        if amount > ctx.accounts.sub_account.lamports() {
+            return Err(SwigAuthenticateError::PermissionDeniedInsufficientBalance.into());
+        }
+        pinocchio_system::instructions::Transfer {
+            from: ctx.accounts.sub_account,
+            to: ctx.accounts.swig_wallet_address,
+            lamports: amount,
+        }
+        .invoke_signed(&[signer.into()])?;
+    }
+    Ok(())
+}

--- a/program/src/actions/withdraw_from_sub_account_v2.rs
+++ b/program/src/actions/withdraw_from_sub_account_v2.rs
@@ -200,6 +200,12 @@ pub fn withdraw_from_sub_account_v2(
         // Both Token and Token-2022 use the same 165-byte base account layout.
         // Extensions may follow it, so validate the base before reading it.
         const TOKEN_ACCOUNT_BASE_LEN: usize = 165;
+        // Offset of the `state` field in that layout:
+        // mint(32) + owner(32) + amount(8) + delegate COption<Pubkey>(36).
+        const TOKEN_ACCOUNT_STATE_OFFSET: usize = 108;
+        // `AccountState::Initialized`. `Uninitialized`(0) and `Frozen`(2) are
+        // both rejected.
+        const TOKEN_ACCOUNT_STATE_INITIALIZED: u8 = 1;
         if token_account.data_len() < TOKEN_ACCOUNT_BASE_LEN
             || swig_token_account.data_len() < TOKEN_ACCOUNT_BASE_LEN
         {
@@ -209,7 +215,10 @@ pub fn withdraw_from_sub_account_v2(
         let swig_token_account_data = unsafe { swig_token_account.borrow_data_unchecked() };
 
         // Only initialized, transferable token accounts are accepted.
-        if token_account_data[108] != 1 || swig_token_account_data[108] != 1 {
+        if token_account_data[TOKEN_ACCOUNT_STATE_OFFSET] != TOKEN_ACCOUNT_STATE_INITIALIZED
+            || swig_token_account_data[TOKEN_ACCOUNT_STATE_OFFSET]
+                != TOKEN_ACCOUNT_STATE_INITIALIZED
+        {
             return Err(ProgramError::InvalidAccountData);
         }
         if unsafe {

--- a/program/src/actions/withdraw_from_sub_account_v2.rs
+++ b/program/src/actions/withdraw_from_sub_account_v2.rs
@@ -176,24 +176,12 @@ pub fn withdraw_from_sub_account_v2(
     let amount = withdraw.args.amount;
 
     // Token accounts (source, destination, token_program) follow the named
-    // accounts. Their presence selects a token withdrawal; otherwise SOL.
-    if all_accounts.len() >= NAMED_ACCOUNTS + 3 {
+    // accounts. Accept exactly the SOL or token layout so unrelated trailing
+    // accounts cannot silently change the operation type.
+    if all_accounts.len() == NAMED_ACCOUNTS + 3 {
         let token_account = &all_accounts[NAMED_ACCOUNTS];
         let swig_token_account = &all_accounts[NAMED_ACCOUNTS + 1];
-
-        // Destination token account must be owned by the swig wallet address.
-        let swig_token_account_data = unsafe { swig_token_account.borrow_data_unchecked() };
-        let swig_token_account_owner = unsafe { swig_token_account_data.get_unchecked(32..64) };
-        if unsafe {
-            sol_memcmp(
-                ctx.accounts.swig_wallet_address.key(),
-                swig_token_account_owner,
-                32,
-            )
-        } != 0
-        {
-            return Err(SwigError::InvalidSwigTokenAccountOwner.into());
-        }
+        let token_program = &all_accounts[NAMED_ACCOUNTS + 2];
 
         let token_account_program_owner = token_account.owner();
         let destination_program_owner = swig_token_account.owner();
@@ -205,16 +193,65 @@ pub fn withdraw_from_sub_account_v2(
         if destination_program_owner != token_account_program_owner {
             return Err(SwigError::InvalidOperation.into());
         }
+        if token_program.key() != token_account_program_owner {
+            return Err(SwigError::OwnerMismatchTokenAccount.into());
+        }
+
+        // Both Token and Token-2022 use the same 165-byte base account layout.
+        // Extensions may follow it, so validate the base before reading it.
+        const TOKEN_ACCOUNT_BASE_LEN: usize = 165;
+        if token_account.data_len() < TOKEN_ACCOUNT_BASE_LEN
+            || swig_token_account.data_len() < TOKEN_ACCOUNT_BASE_LEN
+        {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let token_account_data = unsafe { token_account.borrow_data_unchecked() };
+        let swig_token_account_data = unsafe { swig_token_account.borrow_data_unchecked() };
+
+        // Only initialized, transferable token accounts are accepted.
+        if token_account_data[108] != 1 || swig_token_account_data[108] != 1 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if unsafe {
+            sol_memcmp(
+                &token_account_data[..32],
+                &swig_token_account_data[..32],
+                32,
+            )
+        } != 0
+        {
+            return Err(SwigError::InvalidOperation.into());
+        }
+        if unsafe {
+            sol_memcmp(
+                ctx.accounts.sub_account.key(),
+                &token_account_data[32..64],
+                32,
+            )
+        } != 0
+        {
+            return Err(SwigError::InvalidSwigTokenAccountOwner.into());
+        }
+        if unsafe {
+            sol_memcmp(
+                ctx.accounts.swig_wallet_address.key(),
+                &swig_token_account_data[32..64],
+                32,
+            )
+        } != 0
+        {
+            return Err(SwigError::InvalidSwigTokenAccountOwner.into());
+        }
 
         let token_transfer = TokenTransfer {
             from: token_account,
             to: swig_token_account,
             authority: ctx.accounts.sub_account,
             amount,
-            token_program: token_account_program_owner,
+            token_program: token_program.key(),
         };
         token_transfer.invoke_signed(&[signer.into()])?;
-    } else {
+    } else if all_accounts.len() == NAMED_ACCOUNTS {
         if amount > ctx.accounts.sub_account.lamports() {
             return Err(SwigAuthenticateError::PermissionDeniedInsufficientBalance.into());
         }
@@ -224,6 +261,8 @@ pub fn withdraw_from_sub_account_v2(
             lamports: amount,
         }
         .invoke_signed(&[signer.into()])?;
+    } else {
+        return Err(SwigError::InvalidAccountsLength.into());
     }
     Ok(())
 }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -164,8 +164,6 @@ pub enum SwigError {
     InvalidSwigSubAccountV2Disabled,
     /// Invalid seed used for V2 sub-account derivation
     InvalidSeedSubAccountV2,
-    /// A Swig with V2 sub-accounts cannot be closed
-    SwigHasSubAccountV2,
 }
 
 /// Implements conversion from SwigError to ProgramError.

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -146,6 +146,24 @@ pub enum SwigError {
     InvalidRentClaimerValue,
     /// Destination does not match configured rent claimer
     InvalidRentClaimerDestination,
+    /// V2 sub-account instruction data is too short
+    InvalidSwigCreateSubAccountV2InstructionDataTooShort,
+    /// Authority lacks the required V2 sub-account permission
+    AuthorityCannotCreateSubAccountV2,
+    /// Authority lacks a scoped V2 sub-account permission for this operation
+    PermissionDeniedMissingSubAccountV2Permission,
+    /// V2 sub-account state account has an invalid discriminator
+    InvalidSwigSubAccountV2Discriminator,
+    /// V2 sub-account state account owner mismatch
+    OwnerMismatchSubAccountV2State,
+    /// V2 sub-account Swig ID mismatch
+    InvalidSwigSubAccountV2SwigIdMismatch,
+    /// V2 sub-account id mismatch between state and instruction
+    InvalidSwigSubAccountV2IdMismatch,
+    /// V2 sub-account is disabled (kill-switch off)
+    InvalidSwigSubAccountV2Disabled,
+    /// Invalid seed used for V2 sub-account derivation
+    InvalidSeedSubAccountV2,
 }
 
 /// Implements conversion from SwigError to ProgramError.

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -164,6 +164,8 @@ pub enum SwigError {
     InvalidSwigSubAccountV2Disabled,
     /// Invalid seed used for V2 sub-account derivation
     InvalidSeedSubAccountV2,
+    /// A Swig with V2 sub-accounts cannot be closed
+    SwigHasSubAccountV2,
 }
 
 /// Implements conversion from SwigError to ProgramError.

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -152,8 +152,6 @@ pub enum SwigError {
     AuthorityCannotCreateSubAccountV2,
     /// Authority lacks a scoped V2 sub-account permission for this operation
     PermissionDeniedMissingSubAccountV2Permission,
-    /// V2 sub-account state account has an invalid discriminator
-    InvalidSwigSubAccountV2Discriminator,
     /// V2 sub-account state account owner mismatch
     OwnerMismatchSubAccountV2State,
     /// V2 sub-account Swig ID mismatch

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -271,10 +271,10 @@ pub enum SwigInstruction {
     ///
     /// Required accounts:
     /// 1. `[writable]` Swig wallet account
-    /// 2. `[signer]` Payer account
+    /// 2. `[writable, signer]` Payer account
     /// 3. `[writable]` V2 sub-account state account
     #[account(0, writable, name="swig", desc="the swig smart wallet")]
-    #[account(1, signer, name="payer", desc="the payer")]
+    #[account(1, writable, signer, name="payer", desc="the payer")]
     #[account(2, writable, name="sub_account_state", desc="the v2 sub account state account to toggle")]
     ToggleSubAccountV2 = 19,
 

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -251,4 +251,65 @@ pub enum SwigInstruction {
     #[account(1, writable, signer, name="payer", desc="the payer")]
     #[account(2, name="system_program", desc="the system program")]
     SetRentClaimerV1 = 17,
+
+    /// Creates a new V2 sub-account.
+    ///
+    /// Required accounts:
+    /// 1. `[writable]` Swig wallet account
+    /// 2. `[writable, signer]` Payer account for rent
+    /// 3. `[writable]` V2 sub-account state account to create
+    /// 4. `[writable]` V2 sub-account asset account to create
+    /// 5. System program account
+    #[account(0, writable, name="swig", desc="the swig smart wallet")]
+    #[account(1, writable, signer, name="payer", desc="the payer")]
+    #[account(2, writable, name="sub_account_state", desc="the v2 sub account state account to create")]
+    #[account(3, writable, name="sub_account", desc="the v2 sub account asset account to create")]
+    #[account(4, name="system_program", desc="the system program")]
+    CreateSubAccountV2 = 18,
+
+    /// Toggles the enabled kill-switch on a V2 sub-account.
+    ///
+    /// Required accounts:
+    /// 1. `[writable]` Swig wallet account
+    /// 2. `[signer]` Payer account
+    /// 3. `[writable]` V2 sub-account state account
+    #[account(0, writable, name="swig", desc="the swig smart wallet")]
+    #[account(1, signer, name="payer", desc="the payer")]
+    #[account(2, writable, name="sub_account_state", desc="the v2 sub account state account to toggle")]
+    ToggleSubAccountV2 = 19,
+
+    /// Signs and executes a transaction as a V2 sub-account asset account.
+    ///
+    /// Swig is writable because Secp authorities record their signature odometer
+    /// in the swig account during authentication.
+    ///
+    /// Required accounts:
+    /// 1. `[writable]` Swig wallet account
+    /// 2. V2 sub-account state account
+    /// 3. `[writable]` V2 sub-account asset account (CPI signer)
+    /// 4. System program account
+    #[account(0, writable, name="swig", desc="the swig smart wallet")]
+    #[account(1, name="sub_account_state", desc="the v2 sub account state account")]
+    #[account(2, writable, name="sub_account", desc="the v2 sub account asset account")]
+    #[account(3, name="system_program", desc="the system program")]
+    SubAccountSignV2 = 20,
+
+    /// Withdraws assets from a V2 sub-account to the swig wallet address.
+    ///
+    /// Required accounts:
+    /// 1. `[writable]` Swig wallet account
+    /// 2. `[writable, signer]` Payer account
+    /// 3. V2 sub-account state account
+    /// 4. `[writable]` V2 sub-account asset account (source)
+    /// 5. `[writable]` Swig wallet address account (destination)
+    /// 6. `[name]` authority context (signer for Ed25519, sysvar for Secp256r1, placeholder for Secp256k1)
+    /// 7. System program account
+    #[account(0, writable, name="swig", desc="the swig smart wallet")]
+    #[account(1, writable, signer, name="payer", desc="the payer")]
+    #[account(2, name="sub_account_state", desc="the v2 sub account state account")]
+    #[account(3, writable, name="sub_account", desc="the v2 sub account asset account to withdraw from")]
+    #[account(4, writable, name="swig_wallet_address", desc="the swig wallet address (destination)")]
+    #[account(5, name="authority_context", desc="authority context: signer for Ed25519, sysvar for Secp256r1, or placeholder for Secp256k1")]
+    #[account(6, name="system_program", desc="the system program")]
+    WithdrawFromSubAccountV2 = 21,
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -210,6 +210,28 @@ pub(crate) unsafe fn is_swig_v2(data: &[u8]) -> bool {
     window & 0xFF != 0 && window >> 8 == 0
 }
 
+/// Rejects a pre-wallet-address (V1) Swig account.
+///
+/// The V2-only instructions require the migrated generation. Testing
+/// `wallet_bump != 0` on its own is not enough: on a V1 account that byte is the
+/// low byte of `reserved_lamports`, which a rent-carrying balance leaves
+/// non-zero, so such a check accepts nearly every real V1 account. Route the
+/// decision through [`is_swig_v2`] so every caller shares one definition.
+///
+/// The length check is required before the unchecked read in [`is_swig_v2`] —
+/// the program owns accounts smaller than a Swig header.
+#[inline(always)]
+pub(crate) fn require_swig_v2(data: &[u8]) -> ProgramResult {
+    if data.len() < Swig::LEN {
+        return Err(SwigError::InvalidSwigAccountDiscriminator.into());
+    }
+    if !unsafe { is_swig_v2(data) } {
+        return Err(SwigError::SignV2CannotBeUsedWithSwigV1.into());
+    }
+
+    Ok(())
+}
+
 /// Core instruction execution function.
 ///
 /// This function processes all accounts in the instruction context, classifies

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -145,41 +145,50 @@ unsafe fn is_swig_config_account(account: &AccountInfo) -> bool {
     data.len() >= Swig::LEN && *data.get_unchecked(0) == Discriminator::SwigConfigAccount as u8
 }
 
-/// Determines if a Swig account is v2 format by checking the last 7 bytes.
+/// Byte offset of `Swig::wallet_bump`, the first byte of the window
+/// [`is_swig_v2`] reads.
+const WALLET_BUMP_OFFSET: usize = core::mem::offset_of!(Swig, wallet_bump);
+
+// The window is exactly `wallet_bump ++ _padding`. Any field added after
+// `_padding` must stay outside it: `sub_account_counter` is non-zero for a swig
+// that has created a V2 sub-account, and including it would flip a live V2
+// account back to being read as V1.
+const _: () = {
+    assert!(core::mem::offset_of!(Swig, _padding) == WALLET_BUMP_OFFSET + 1);
+    assert!(core::mem::offset_of!(Swig, sub_account_counter) == WALLET_BUMP_OFFSET + 4);
+};
+
+/// Determines if a Swig account is v2 format from its wallet bump and the three
+/// reserved bytes that follow it.
 ///
 /// # Account Format Differences
 ///
-/// **Swig V2** (last 8 bytes): `[wallet_bump: u8, _padding: [u8; 7]]`
-/// - Example bytes: `[253, 0, 0, 0, 0, 0, 0, 0]` where 253 is the bump seed
-/// - As little-endian u64: `0x0000000000000FD` (the wallet_bump in the lowest
-///   byte)
-/// - After right shift by 8: `0x000000000000000` (removes wallet_bump, leaves
-///   only padding)
-/// - Result: equals 0 ✓ → **V2 account**
+/// **Swig V2** stores `wallet_bump: u8` followed by `_padding: [u8; 3]`. A
+/// migrated account always has a non-zero bump and zeroed padding.
+/// - Example bytes: `[253, 0, 0, 0]` where 253 is the bump seed
+/// - Low byte non-zero, upper three zero ✓ → **V2 account**
 ///
-/// **Swig V1** (last 8 bytes): `u64` value (typically role_counter,
-/// session_expiry, etc.)
-/// - Example values: 1, 2, 100, 256, 1000, etc.
-/// - Example bytes for 256: `[0, 1, 0, 0, 0, 0, 0, 0]` (little-endian)
-/// - As little-endian u64: `0x0000000000000100`
-/// - After right shift by 8: `0x0000000000000001` (non-zero in upper 7 bytes)
-/// - Result: non-zero ✓ → **V1 account**
+/// **Swig V1** stored a `reserved_lamports: u64` starting at the same offset.
+/// - A rent-carrying balance sets at least one of the upper three bytes
+/// - Result: non-zero upper bytes ✓ → **V1 account**
 ///
-/// # Why This Works
+/// # Why the counter is excluded
 ///
-/// The key insight is that v2 accounts have 7 consecutive zero bytes (padding),
-/// while v1 accounts store a u64 value that, when interpreted as bytes, will
-/// almost certainly have at least one non-zero byte in positions other than the
-/// first byte. Even small u64 values like 1, 2, 100 will have zeros in the
-/// first byte but the actual value stored in subsequent bytes.
+/// `sub_account_counter` occupies the four bytes after `_padding` and becomes
+/// non-zero as soon as a V2 sub-account is created. The previous check read the
+/// last eight bytes as a `u64` and required the upper seven to be zero, which
+/// covered the counter — so creating a single sub-account permanently flipped a
+/// V2 account to being read as V1.
 ///
-/// By reading the last 8 bytes as a u64 and right-shifting by 8 bits, we:
-/// 1. Remove the first byte (wallet_bump in v2, or low byte of u64 in v1)
-/// 2. Check if the remaining 7 bytes are all zeros
+/// # Known limits
 ///
-/// This is a zero-copy operation using a single unaligned u64 read, followed by
-/// a single shift and comparison, making it extremely efficient (3 CPU
-/// operations total).
+/// This is a heuristic over bytes V1 used for a different purpose, so it is not
+/// exact. A V1 account misreads as V2 when `reserved_lamports % 2^32` lands in
+/// `1..=255`. The previous check was wrong for `reserved_lamports <= 255`,
+/// including `0`, which is the more likely V1 state; this narrows the common
+/// case at the cost of a wrap-around band around every 2^32 lamports. The only
+/// caller, `close_token_account_v1`, tries the other authority as a fallback,
+/// so a misread costs an extra comparison rather than correctness.
 ///
 /// # Safety
 ///
@@ -190,13 +199,15 @@ unsafe fn is_swig_config_account(account: &AccountInfo) -> bool {
 /// * `data` - The account data slice, must be `Swig::LEN` bytes
 ///
 /// # Returns
-/// * `true` if the account is v2 format (last 7 bytes are zero)
-/// * `false` if the account is v1 format (last 7 bytes contain non-zero values)
+/// * `true` if the account is v2 format (non-zero bump, zeroed padding)
+/// * `false` otherwise
 #[inline(always)]
 pub(crate) unsafe fn is_swig_v2(data: &[u8]) -> bool {
-    let last_8_bytes_ptr = data.as_ptr().add(Swig::LEN - 8) as *const u64;
-    let last_8_bytes = last_8_bytes_ptr.read_unaligned();
-    last_8_bytes >> 8 == 0
+    // `wallet_bump ++ _padding` as one little-endian u32: bump in the low byte,
+    // the three reserved bytes above it. Equivalent to
+    // `wallet_bump != 0 && _padding == [0u8; 3]`, without a fallible load.
+    let window = (data.as_ptr().add(WALLET_BUMP_OFFSET) as *const u32).read_unaligned();
+    window & 0xFF != 0 && window >> 8 == 0
 }
 
 /// Core instruction execution function.
@@ -515,6 +526,61 @@ mod tests {
     fn validate_account_capacity_rejects_array_capacity_overflow() {
         assert_invalid_accounts_length(validate_account_capacity(4, 3, 4));
         assert_invalid_accounts_length(validate_account_capacity(4, 4, 3));
+    }
+
+    /// Serializes a Swig header with the given wallet bump and V2 sub-account
+    /// counter.
+    fn swig_header_bytes(wallet_bump: u8, sub_account_counter: u32) -> Vec<u8> {
+        use swig_state::IntoBytes;
+
+        let mut swig = Swig::new([7u8; 32], 254, wallet_bump);
+        swig.sub_account_counter = sub_account_counter;
+        swig.into_bytes().unwrap().to_vec()
+    }
+
+    /// Overlays a V1 `reserved_lamports: u64` over the bump+padding window.
+    fn v1_header_bytes(reserved_lamports: u64) -> Vec<u8> {
+        let mut data = swig_header_bytes(0, 0);
+        data[WALLET_BUMP_OFFSET..WALLET_BUMP_OFFSET + 8]
+            .copy_from_slice(&reserved_lamports.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn is_swig_v2_accepts_migrated_account() {
+        assert!(unsafe { is_swig_v2(&swig_header_bytes(253, 0)) });
+    }
+
+    /// Regression: `sub_account_counter` reuses former padding, so it must sit
+    /// outside the window `is_swig_v2` reads. Creating a V2 sub-account must
+    /// not flip a migrated account back to being read as V1.
+    #[test]
+    fn is_swig_v2_ignores_sub_account_counter() {
+        for counter in [1u32, 2, 255, 256, 65_536, u32::MAX] {
+            assert!(
+                unsafe { is_swig_v2(&swig_header_bytes(253, counter)) },
+                "counter {counter} must not affect v2 detection"
+            );
+        }
+    }
+
+    /// A rent-carrying V1 `reserved_lamports` sets the upper window bytes.
+    #[test]
+    fn is_swig_v2_rejects_v1_reserved_lamports() {
+        for reserved_lamports in [256u64, 890_880, 1_392_000, 2_039_280, 1u64 << 32, u64::MAX] {
+            assert!(
+                !unsafe { is_swig_v2(&v1_header_bytes(reserved_lamports)) },
+                "reserved_lamports {reserved_lamports} must read as v1"
+            );
+        }
+    }
+
+    /// An unmigrated account with a zero bump is V1. The previous last-8-bytes
+    /// check read this as V2.
+    #[test]
+    fn is_swig_v2_rejects_zero_wallet_bump() {
+        assert!(!unsafe { is_swig_v2(&v1_header_bytes(0)) });
+        assert!(!unsafe { is_swig_v2(&swig_header_bytes(0, 0)) });
     }
 
     #[test]

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -605,6 +605,63 @@ mod tests {
         assert!(!unsafe { is_swig_v2(&swig_header_bytes(0, 0)) });
     }
 
+    /// Pins the documented limit of the heuristic, so narrowing or widening it
+    /// is a deliberate decision rather than a silent one.
+    ///
+    /// `reserved_lamports % 2^32` in `1..=255` leaves the three padding bytes
+    /// zero and is therefore indistinguishable from a V2 bump. 256 is the
+    /// smallest value that reads as V1. No such account exists in practice —
+    /// a rent reserve is at least ~890k lamports — and a mainnet scan found
+    /// none, but the band is real and worth stating.
+    #[test]
+    fn is_swig_v2_known_limit_below_256_reads_as_v2() {
+        assert!(!unsafe { is_swig_v2(&v1_header_bytes(256)) }, "256 is v1");
+        for reserved_lamports in [1u64, 128, 255] {
+            assert!(
+                unsafe { is_swig_v2(&v1_header_bytes(reserved_lamports)) },
+                "reserved_lamports {reserved_lamports} is the documented blind spot"
+            );
+        }
+    }
+
+    /// The low byte alone is not a version test: it is the low byte of a V1
+    /// `reserved_lamports`, which a rent-carrying balance leaves non-zero. This
+    /// is the bug `require_swig_v2` replaced.
+    #[test]
+    fn require_swig_v2_rejects_v1_that_a_bump_only_check_would_accept() {
+        // A real mainnet reserve; low byte 0x80, so `wallet_bump != 0` passes.
+        let data = v1_header_bytes(1_614_720);
+        assert_ne!(data[WALLET_BUMP_OFFSET], 0);
+        assert!(matches!(
+            require_swig_v2(&data),
+            Err(ProgramError::Custom(code))
+                if code == SwigError::SignV2CannotBeUsedWithSwigV1 as u32
+        ));
+    }
+
+    #[test]
+    fn require_swig_v2_accepts_a_migrated_account_with_sub_accounts() {
+        assert!(require_swig_v2(&swig_header_bytes(253, 0)).is_ok());
+        assert!(require_swig_v2(&swig_header_bytes(253, 7)).is_ok());
+    }
+
+    /// `is_swig_v2` reads offset 40..44 unchecked, so anything shorter than a
+    /// header must be rejected before it runs.
+    #[test]
+    fn require_swig_v2_rejects_data_shorter_than_the_header() {
+        let full = swig_header_bytes(253, 0);
+        for len in [0usize, 1, WALLET_BUMP_OFFSET, Swig::LEN - 1] {
+            assert!(
+                matches!(
+                    require_swig_v2(&full[..len]),
+                    Err(ProgramError::Custom(code))
+                        if code == SwigError::InvalidSwigAccountDiscriminator as u32
+                ),
+                "length {len} must be rejected"
+            );
+        }
+    }
+
     #[test]
     fn validated_duplicate_account_index_requires_prior_account() {
         assert_eq!(validated_duplicate_account_index(0, 1).unwrap(), 0);

--- a/program/tests/common/mod.rs
+++ b/program/tests/common/mod.rs
@@ -27,6 +27,11 @@ use swig_state::{
     IntoBytes, Transmutable,
 };
 pub type Context = SwigTestContext;
+
+/// Reusable realloc-stability harness (snapshot the swig, run a size-modifying
+/// op, assert unrelated roles + rent claimer survive). See [`stability`].
+pub mod stability;
+
 pub fn program_id() -> Pubkey {
     swig::ID.into()
 }

--- a/program/tests/common/stability.rs
+++ b/program/tests/common/stability.rs
@@ -1,0 +1,152 @@
+#![allow(dead_code)]
+//! Reusable harness for asserting swig-account stability across the
+//! *size-modifying* instructions — add/remove/update authority, V2 sub-account
+//! create, and set-rent-claimer — each of which reallocs the swig account.
+//!
+//! The pattern is always the same: snapshot the account, run an op that grows
+//! or shrinks it, then assert that every *unrelated* role and the rent-claimer
+//! tail survived byte-for-byte. Roles are matched by authority identity (not by
+//! role id), so the assertions are robust to roles being added or removed.
+//!
+//! ```ignore
+//! let before = SwigSnapshot::capture(&context, &swig);
+//! // ... an op that reallocs the account (e.g. creator makes a sub-account) ...
+//! let after = SwigSnapshot::capture(&context, &swig);
+//! before.assert_others_stable(&after, &[creator.pubkey().to_bytes()]); // only creator changed
+//! ```
+
+use solana_sdk::pubkey::Pubkey;
+use swig_state::{
+    action::{Action, Permission},
+    swig::{Swig, SwigWithRoles},
+    tail::rent_claimer,
+    Transmutable,
+};
+
+use super::SwigTestContext;
+
+/// A role's permissions as `(permission, body-bytes)` pairs, in on-chain order.
+pub type ActionList = Vec<(Permission, Vec<u8>)>;
+
+/// One role's on-chain identity and permission list.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoleSnapshot {
+    pub id: u32,
+    pub identity: Vec<u8>,
+    pub actions: ActionList,
+}
+
+/// A comparable snapshot of a swig account's mutable regions: the roles (each
+/// with its authority + actions), the rent-claimer tail, the sub-account
+/// counter, and the total account length.
+#[derive(Clone, Debug)]
+pub struct SwigSnapshot {
+    pub account_len: usize,
+    pub counter: u32,
+    pub rent_claimer: Option<[u8; 32]>,
+    pub roles: Vec<RoleSnapshot>,
+}
+
+impl SwigSnapshot {
+    /// Capture the current state of `swig_key`.
+    pub fn capture(context: &SwigTestContext, swig_key: &Pubkey) -> Self {
+        let data = context.svm.get_account(swig_key).unwrap().data;
+        let tail = Swig::split_parts(&data).unwrap().tail.to_vec();
+        let with_roles = SwigWithRoles::from_bytes(&data).unwrap();
+        let counter = with_roles.state.sub_account_counter;
+
+        let mut roles = Vec::new();
+        for id in 0..with_roles.state.roles as u32 {
+            let role = with_roles.get_role(id).unwrap().unwrap();
+            roles.push(RoleSnapshot {
+                id,
+                identity: role.authority.identity().unwrap().to_vec(),
+                actions: decode_actions(role.actions, role.position.num_actions()),
+            });
+        }
+
+        let rent_claimer = rent_claimer::read_strict(&tail).unwrap().copied();
+        Self {
+            account_len: data.len(),
+            counter,
+            rent_claimer,
+            roles,
+        }
+    }
+
+    /// Look up a role by its authority identity (its pubkey, for Ed25519).
+    pub fn role_by_identity(&self, identity: &[u8]) -> Option<&RoleSnapshot> {
+        self.roles.iter().find(|r| r.identity == identity)
+    }
+
+    /// The action list for the given authority, or panics if it is absent.
+    pub fn actions_of(&self, identity: &[u8]) -> &ActionList {
+        &self
+            .role_by_identity(identity)
+            .unwrap_or_else(|| panic!("no role for the given authority"))
+            .actions
+    }
+
+    /// Assert the rent-claimer tail is byte-identical between `self` and `after`.
+    pub fn assert_claimer_unchanged(&self, after: &SwigSnapshot) {
+        assert_eq!(
+            self.rent_claimer, after.rent_claimer,
+            "rent claimer changed across the op"
+        );
+    }
+
+    /// Assert that every role present in `self` whose identity is NOT listed in
+    /// `changed` still exists in `after` with byte-identical authority and
+    /// actions, and that the rent claimer is unchanged.
+    ///
+    /// Pass the identities you *expect* the op to touch (the added/removed/
+    /// updated authorities) in `changed`; everything else must be untouched.
+    pub fn assert_others_stable(&self, after: &SwigSnapshot, changed: &[[u8; 32]]) {
+        self.assert_claimer_unchanged(after);
+        for before in &self.roles {
+            if changed
+                .iter()
+                .any(|c| c.as_slice() == before.identity.as_slice())
+            {
+                continue;
+            }
+            let now = after.role_by_identity(&before.identity).unwrap_or_else(|| {
+                panic!(
+                    "an unrelated role (was id {}) disappeared after the op",
+                    before.id
+                )
+            });
+            assert_eq!(
+                now.actions, before.actions,
+                "an unrelated role (was id {}) had its permissions corrupted by the realloc",
+                before.id
+            );
+        }
+    }
+}
+
+fn decode_actions(actions: &[u8], num_actions: u16) -> ActionList {
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    for _ in 0..num_actions {
+        let header =
+            unsafe { Action::load_unchecked(&actions[cursor..cursor + Action::LEN]).unwrap() };
+        cursor += Action::LEN;
+        let len = header.length() as usize;
+        out.push((
+            header.permission().unwrap(),
+            actions[cursor..cursor + len].to_vec(),
+        ));
+        cursor += len;
+    }
+    out
+}
+
+/// The 8-byte body of a scoped V2 action: `subacc_id` little-endian + 4 zero
+/// padding bytes. Matches both the auto-granted `SubAccountV2All` and any
+/// manually-added scoped V2 permission.
+pub fn scoped_v2_body(subacc_id: u32) -> Vec<u8> {
+    let mut b = subacc_id.to_le_bytes().to_vec();
+    b.extend_from_slice(&[0u8; 4]);
+    b
+}

--- a/program/tests/sub_account_v2_cu_comparison.rs
+++ b/program/tests/sub_account_v2_cu_comparison.rs
@@ -1,0 +1,287 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! Compute-unit comparison for the first and twentieth V2 sub-accounts owned
+//! by one Ed25519 authority.
+
+mod common;
+
+use common::*;
+use litesvm::types::TransactionMetadata;
+use solana_sdk::{
+    instruction::Instruction,
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{
+    AuthorityConfig, ClientAction, CreateSubAccountV2Instruction, SubAccountSignV2Instruction,
+    ToggleSubAccountV2Instruction, WithdrawFromSubAccountV2Instruction,
+};
+use swig_state::{
+    action::sub_account_v2::SubAccountV2Create,
+    authority::AuthorityType,
+    swig::{sub_account_v2_asset_seeds, sub_account_v2_state_seeds, swig_wallet_address_seeds},
+};
+
+const CREATOR_ROLE_ID: u32 = 1;
+const LAST_SUBACCOUNT_ID: u32 = 19;
+
+#[derive(Clone, Copy)]
+struct SubAccountAddresses {
+    state: Pubkey,
+    asset: Pubkey,
+}
+
+#[derive(Clone, Copy)]
+struct ComputeUnitPair {
+    first: u64,
+    last: u64,
+}
+
+#[test]
+fn compare_ed25519_sub_account_v2_compute_units() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let creator = Keypair::new();
+    context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&creator.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let swig_id = rand::random::<[u8; 32]>();
+    let (swig, _) = create_swig_ed25519(&mut context, &root, swig_id).unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: creator.pubkey().as_ref(),
+        },
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )
+    .unwrap();
+
+    let mut first_addresses = None;
+    let mut last_addresses = None;
+    let mut create_first = None;
+    let mut create_last = None;
+
+    for subacc_id in 0..=LAST_SUBACCOUNT_ID {
+        let addresses = sub_account_addresses(&swig_id, subacc_id);
+        let state_bump = Pubkey::find_program_address(
+            &sub_account_v2_state_seeds(&swig_id, &subacc_id.to_le_bytes()),
+            &program_id(),
+        )
+        .1;
+        let asset_bump = Pubkey::find_program_address(
+            &sub_account_v2_asset_seeds(&swig_id, &subacc_id.to_le_bytes()),
+            &program_id(),
+        )
+        .1;
+        let create = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+            swig,
+            creator.pubkey(),
+            creator.pubkey(),
+            addresses.state,
+            addresses.asset,
+            CREATOR_ROLE_ID,
+            state_bump,
+            asset_bump,
+        )
+        .unwrap();
+        let consumed = send(&mut context, &creator, create).compute_units_consumed;
+        context
+            .svm
+            .airdrop(&addresses.asset, 1_000_000_000)
+            .unwrap();
+
+        if subacc_id == 0 {
+            first_addresses = Some(addresses);
+            create_first = Some(consumed);
+        } else if subacc_id == LAST_SUBACCOUNT_ID {
+            last_addresses = Some(addresses);
+            create_last = Some(consumed);
+        }
+    }
+
+    let first_addresses = first_addresses.unwrap();
+    let last_addresses = last_addresses.unwrap();
+    let create = ComputeUnitPair {
+        first: create_first.unwrap(),
+        last: create_last.unwrap(),
+    };
+
+    let sign = ComputeUnitPair {
+        first: send_sign(&mut context, &creator, swig, first_addresses, 0),
+        last: send_sign(
+            &mut context,
+            &creator,
+            swig,
+            last_addresses,
+            LAST_SUBACCOUNT_ID,
+        ),
+    };
+
+    let swig_wallet =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id()).0;
+    let withdraw = ComputeUnitPair {
+        first: send_withdraw(
+            &mut context,
+            &creator,
+            swig,
+            swig_wallet,
+            first_addresses,
+            0,
+        ),
+        last: send_withdraw(
+            &mut context,
+            &creator,
+            swig,
+            swig_wallet,
+            last_addresses,
+            LAST_SUBACCOUNT_ID,
+        ),
+    };
+
+    let toggle = ComputeUnitPair {
+        first: send_toggle(&mut context, &creator, swig, first_addresses.state, 0),
+        last: send_toggle(
+            &mut context,
+            &creator,
+            swig,
+            last_addresses.state,
+            LAST_SUBACCOUNT_ID,
+        ),
+    };
+
+    println!("| **Ed25519 operation** | **Subaccount 0** | **Subaccount 19** | **Increase** |");
+    println!("| --- | ---: | ---: | ---: |");
+    print_row("Create", create);
+    print_row("Sign", sign);
+    print_row("Withdraw", withdraw);
+    print_row("Toggle", toggle);
+}
+
+fn sub_account_addresses(swig_id: &[u8; 32], subacc_id: u32) -> SubAccountAddresses {
+    let id = subacc_id.to_le_bytes();
+    SubAccountAddresses {
+        state: Pubkey::find_program_address(
+            &sub_account_v2_state_seeds(swig_id, &id),
+            &program_id(),
+        )
+        .0,
+        asset: Pubkey::find_program_address(
+            &sub_account_v2_asset_seeds(swig_id, &id),
+            &program_id(),
+        )
+        .0,
+    }
+}
+
+fn send(context: &mut SwigTestContext, payer: &Keypair, ix: Instruction) -> TransactionMetadata {
+    context.svm.expire_blockhash();
+    let message =
+        v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+            .unwrap();
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(message), &[payer]).unwrap();
+    context.svm.send_transaction(tx).unwrap()
+}
+
+fn send_sign(
+    context: &mut SwigTestContext,
+    creator: &Keypair,
+    swig: Pubkey,
+    addresses: SubAccountAddresses,
+    subacc_id: u32,
+) -> u64 {
+    let recipient = Keypair::new();
+    let transfer = solana_system_interface::instruction::transfer(
+        &addresses.asset,
+        &recipient.pubkey(),
+        1_000,
+    );
+    let sign = SubAccountSignV2Instruction::new_with_ed25519_authority(
+        swig,
+        addresses.state,
+        addresses.asset,
+        creator.pubkey(),
+        CREATOR_ROLE_ID,
+        subacc_id,
+        vec![transfer],
+    )
+    .unwrap();
+    send(context, creator, sign).compute_units_consumed
+}
+
+fn send_withdraw(
+    context: &mut SwigTestContext,
+    creator: &Keypair,
+    swig: Pubkey,
+    swig_wallet: Pubkey,
+    addresses: SubAccountAddresses,
+    subacc_id: u32,
+) -> u64 {
+    let withdraw = WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+        swig,
+        creator.pubkey(),
+        creator.pubkey(),
+        addresses.state,
+        addresses.asset,
+        swig_wallet,
+        CREATOR_ROLE_ID,
+        subacc_id,
+        1_000,
+    )
+    .unwrap();
+    send(context, creator, withdraw).compute_units_consumed
+}
+
+fn send_toggle(
+    context: &mut SwigTestContext,
+    creator: &Keypair,
+    swig: Pubkey,
+    state: Pubkey,
+    subacc_id: u32,
+) -> u64 {
+    let toggle = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig,
+        creator.pubkey(),
+        creator.pubkey(),
+        state,
+        CREATOR_ROLE_ID,
+        subacc_id,
+        false,
+    )
+    .unwrap();
+    send(context, creator, toggle).compute_units_consumed
+}
+
+fn print_row(operation: &str, pair: ComputeUnitPair) {
+    assert!(
+        pair.last >= pair.first,
+        "{operation} unexpectedly used fewer compute units for subaccount 19"
+    );
+    let increase = pair.last - pair.first;
+    let percent = ((increase as f64 / pair.first as f64) * 100.0).round() as u64;
+    println!(
+        "| {operation} | {} CU | {} CU | +{} / {percent}% |",
+        with_thousands_separator(pair.first),
+        with_thousands_separator(pair.last),
+        with_thousands_separator(increase),
+    );
+}
+
+fn with_thousands_separator(value: u64) -> String {
+    let digits = value.to_string();
+    let mut formatted = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, digit) in digits.chars().enumerate() {
+        if index != 0 && (digits.len() - index).is_multiple_of(3) {
+            formatted.push(',');
+        }
+        formatted.push(digit);
+    }
+    formatted
+}

--- a/program/tests/sub_account_v2_matrix_test.rs
+++ b/program/tests/sub_account_v2_matrix_test.rs
@@ -1,0 +1,557 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! Normative authorization-matrix coverage for V2 sub-accounts.
+//!
+//! Each test maps to a row of the V2 auth table: default-deny for wallet-level
+//! overrides (All / ManageAuthority / AllButManageAuthority), scope-limited
+//! grants, id-scoping of the `All` umbrella, cross-role sharing, self-grant
+//! recovery, atomic role-deletion, V1/V2 seed non-collision, and duplicate
+//! rejection.
+mod common;
+
+use common::*;
+use solana_sdk::{
+    instruction::Instruction,
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{
+    AuthorityConfig, ClientAction, CreateSubAccountV2Instruction, SubAccountSignV2Instruction,
+    ToggleSubAccountV2Instruction, WithdrawFromSubAccountV2Instruction,
+};
+use swig_state::{
+    action::{
+        all::All,
+        all_but_manage_authority::AllButManageAuthority,
+        manage_authority::ManageAuthority,
+        sub_account_v2::{
+            SubAccountV2All, SubAccountV2Create, SubAccountV2Sign, SubAccountV2Toggle,
+            SubAccountV2Withdraw,
+        },
+    },
+    authority::AuthorityType,
+    swig::{
+        sub_account_seeds, sub_account_v2_asset_seeds, sub_account_v2_state_seeds,
+        swig_wallet_address_seeds, SwigWithRoles,
+    },
+};
+
+// ---- helpers ----------------------------------------------------------------
+
+fn v2_state_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &sub_account_v2_state_seeds(id, &subacc_id.to_le_bytes()),
+        &program_id(),
+    )
+}
+
+fn v2_asset_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &sub_account_v2_asset_seeds(id, &subacc_id.to_le_bytes()),
+        &program_id(),
+    )
+}
+
+fn role_id_of(context: &SwigTestContext, swig: &Pubkey, authority: &Pubkey) -> u32 {
+    let data = context.svm.get_account(swig).unwrap().data;
+    SwigWithRoles::from_bytes(&data)
+        .unwrap()
+        .lookup_role_id(authority.as_ref())
+        .unwrap()
+        .unwrap()
+}
+
+fn send(context: &mut SwigTestContext, payer: &Keypair, ix: Instruction) -> anyhow::Result<()> {
+    let message =
+        v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+            .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[payer.insecure_clone()])
+            .unwrap();
+    context
+        .svm
+        .send_transaction(tx)
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("tx failed: {:?}", e))
+}
+
+/// Root wallet + a creator role (SubAccountV2Create) that creates sub-account 0.
+/// Returns (swig_key, root, id, creator, state_pda, asset_pda).
+fn setup(context: &mut SwigTestContext) -> (Pubkey, Keypair, [u8; 32], Keypair, Pubkey, Pubkey) {
+    let root = Keypair::new();
+    let creator = Keypair::new();
+    context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&creator.pubkey(), 10_000_000_000)
+        .unwrap();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(context, &root, id).unwrap();
+
+    add_authority_with_ed25519_root(
+        context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: creator.pubkey().as_ref(),
+        },
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )
+    .unwrap();
+
+    let creator_role = role_id_of(context, &swig_key, &creator.pubkey());
+    let (state_pda, state_bump) = v2_state_pda(&id, 0);
+    let (asset_pda, asset_bump) = v2_asset_pda(&id, 0);
+    let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        creator_role,
+        state_bump,
+        asset_bump,
+    )
+    .unwrap();
+    send(context, &creator, ix).unwrap();
+    context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
+    (swig_key, root, id, creator, state_pda, asset_pda)
+}
+
+/// Adds a role holding `actions` and returns (keypair, role_id).
+fn add_role(
+    context: &mut SwigTestContext,
+    swig: &Pubkey,
+    root: &Keypair,
+    actions: Vec<ClientAction>,
+) -> (Keypair, u32) {
+    let kp = Keypair::new();
+    context.svm.airdrop(&kp.pubkey(), 10_000_000_000).unwrap();
+    add_authority_with_ed25519_root(
+        context,
+        swig,
+        root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: kp.pubkey().as_ref(),
+        },
+        actions,
+    )
+    .unwrap();
+    let role = role_id_of(context, swig, &kp.pubkey());
+    (kp, role)
+}
+
+fn sign_ix(
+    swig: Pubkey,
+    state: Pubkey,
+    asset: Pubkey,
+    authority: &Keypair,
+    role_id: u32,
+    subacc_id: u32,
+    recipient: &Pubkey,
+    amount: u64,
+) -> Instruction {
+    let inner = solana_system_interface::instruction::transfer(&asset, recipient, amount);
+    SubAccountSignV2Instruction::new_with_ed25519_authority(
+        swig,
+        state,
+        asset,
+        authority.pubkey(),
+        role_id,
+        subacc_id,
+        vec![inner],
+    )
+    .unwrap()
+}
+
+fn withdraw_ix(
+    swig: Pubkey,
+    state: Pubkey,
+    asset: Pubkey,
+    authority: &Keypair,
+    role_id: u32,
+    subacc_id: u32,
+    amount: u64,
+) -> Instruction {
+    let (wallet, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+    WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+        swig,
+        authority.pubkey(),
+        authority.pubkey(),
+        state,
+        asset,
+        wallet,
+        role_id,
+        subacc_id,
+        amount,
+    )
+    .unwrap()
+}
+
+fn toggle_ix(
+    swig: Pubkey,
+    state: Pubkey,
+    authority: &Keypair,
+    role_id: u32,
+    subacc_id: u32,
+    enabled: bool,
+) -> Instruction {
+    ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig,
+        authority.pubkey(),
+        authority.pubkey(),
+        state,
+        role_id,
+        subacc_id,
+        enabled,
+    )
+    .unwrap()
+}
+
+// ---- wallet-level overrides are denied --------------------------------------
+
+fn assert_override_denied_all_runtime(actions: Vec<ClientAction>) {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, id, _creator, state, asset) = setup(&mut context);
+    let recipient = Keypair::new();
+    let (role_kp, role) = add_role(&mut context, &swig, &root, actions);
+
+    // sign / withdraw / toggle all denied for sub-account 0.
+    let s = sign_ix(
+        swig,
+        state,
+        asset,
+        &role_kp,
+        role,
+        0,
+        &recipient.pubkey(),
+        1_000,
+    );
+    assert!(
+        send(&mut context, &role_kp, s).is_err(),
+        "sign must be denied"
+    );
+    let w = withdraw_ix(swig, state, asset, &role_kp, role, 0, 1_000);
+    assert!(
+        send(&mut context, &role_kp, w).is_err(),
+        "withdraw must be denied"
+    );
+    let t = toggle_ix(swig, state, &role_kp, role, 0, false);
+    assert!(
+        send(&mut context, &role_kp, t).is_err(),
+        "toggle must be denied"
+    );
+}
+
+#[test]
+fn test_all_override_denied_v2_runtime() {
+    assert_override_denied_all_runtime(vec![ClientAction::All(All {})]);
+}
+
+#[test]
+fn test_manage_authority_override_denied_v2_runtime() {
+    assert_override_denied_all_runtime(vec![ClientAction::ManageAuthority(ManageAuthority {})]);
+}
+
+#[test]
+fn test_all_but_manage_authority_override_denied_v2_runtime() {
+    assert_override_denied_all_runtime(vec![ClientAction::AllButManageAuthority(
+        AllButManageAuthority {},
+    )]);
+}
+
+// ---- scoped permissions authorize exactly their op --------------------------
+
+#[test]
+fn test_scoped_sign_only() {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, _id, _creator, state, asset) = setup(&mut context);
+    let recipient = Keypair::new();
+    let (kp, role) = add_role(
+        &mut context,
+        &swig,
+        &root,
+        vec![ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(0))],
+    );
+
+    // sign OK
+    let s = sign_ix(swig, state, asset, &kp, role, 0, &recipient.pubkey(), 5_000);
+    assert!(send(&mut context, &kp, s).is_ok());
+    assert_eq!(
+        context
+            .svm
+            .get_account(&recipient.pubkey())
+            .unwrap()
+            .lamports,
+        5_000
+    );
+    // withdraw + toggle denied
+    let w = withdraw_ix(swig, state, asset, &kp, role, 0, 1_000);
+    assert!(send(&mut context, &kp, w).is_err());
+    let t = toggle_ix(swig, state, &kp, role, 0, false);
+    assert!(send(&mut context, &kp, t).is_err());
+}
+
+#[test]
+fn test_scoped_withdraw_only() {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, id, _creator, state, asset) = setup(&mut context);
+    let recipient = Keypair::new();
+    let (kp, role) = add_role(
+        &mut context,
+        &swig,
+        &root,
+        vec![ClientAction::SubAccountV2Withdraw(
+            SubAccountV2Withdraw::new(0),
+        )],
+    );
+
+    let (wallet, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+    let before = context.svm.get_account(&wallet).unwrap().lamports;
+    let w = withdraw_ix(swig, state, asset, &kp, role, 0, 7_000);
+    assert!(send(&mut context, &kp, w).is_ok());
+    assert_eq!(
+        context.svm.get_account(&wallet).unwrap().lamports - before,
+        7_000
+    );
+    // sign + toggle denied
+    let s = sign_ix(swig, state, asset, &kp, role, 0, &recipient.pubkey(), 1_000);
+    assert!(send(&mut context, &kp, s).is_err());
+    let t = toggle_ix(swig, state, &kp, role, 0, false);
+    assert!(send(&mut context, &kp, t).is_err());
+}
+
+#[test]
+fn test_scoped_toggle_only() {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, _id, _creator, state, asset) = setup(&mut context);
+    let recipient = Keypair::new();
+    let (kp, role) = add_role(
+        &mut context,
+        &swig,
+        &root,
+        vec![ClientAction::SubAccountV2Toggle(SubAccountV2Toggle::new(0))],
+    );
+
+    let t = toggle_ix(swig, state, &kp, role, 0, false);
+    assert!(send(&mut context, &kp, t).is_ok());
+    // sign + withdraw denied
+    let s = sign_ix(swig, state, asset, &kp, role, 0, &recipient.pubkey(), 1_000);
+    assert!(send(&mut context, &kp, s).is_err());
+    let w = withdraw_ix(swig, state, asset, &kp, role, 0, 1_000);
+    assert!(send(&mut context, &kp, w).is_err());
+}
+
+#[test]
+fn test_all_scope_is_id_scoped() {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, id, creator, state0, asset0) = setup(&mut context);
+    let recipient = Keypair::new();
+
+    // Create a second sub-account (id 1) with the creator role.
+    let creator_role = role_id_of(&context, &swig, &creator.pubkey());
+    let (state1, sb1) = v2_state_pda(&id, 1);
+    let (asset1, ab1) = v2_asset_pda(&id, 1);
+    let create1 = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        swig,
+        creator.pubkey(),
+        creator.pubkey(),
+        state1,
+        asset1,
+        creator_role,
+        sb1,
+        ab1,
+    )
+    .unwrap();
+    send(&mut context, &creator, create1).unwrap();
+    context.svm.airdrop(&asset1, 1_000_000_000).unwrap();
+
+    // Role scoped to id 0 only.
+    let (kp, role) = add_role(
+        &mut context,
+        &swig,
+        &root,
+        vec![ClientAction::SubAccountV2All(SubAccountV2All::new(0))],
+    );
+
+    // Works on id 0.
+    let s0 = sign_ix(
+        swig,
+        state0,
+        asset0,
+        &kp,
+        role,
+        0,
+        &recipient.pubkey(),
+        3_000,
+    );
+    assert!(send(&mut context, &kp, s0).is_ok());
+    // Denied on id 1.
+    let s1 = sign_ix(
+        swig,
+        state1,
+        asset1,
+        &kp,
+        role,
+        1,
+        &recipient.pubkey(),
+        3_000,
+    );
+    assert!(
+        send(&mut context, &kp, s1).is_err(),
+        "All{{0}} must not reach id 1"
+    );
+}
+
+// ---- sharing one sub-account across roles -----------------------------------
+
+#[test]
+fn test_share_one_subaccount_across_roles() {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, _id, _creator, state, asset) = setup(&mut context);
+    let recipient = Keypair::new();
+
+    // Two independent roles both granted Sign{0} for the same sub-account.
+    let (a, ra) = add_role(
+        &mut context,
+        &swig,
+        &root,
+        vec![ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(0))],
+    );
+    let (b, rb) = add_role(
+        &mut context,
+        &swig,
+        &root,
+        vec![ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(0))],
+    );
+
+    let sa = sign_ix(swig, state, asset, &a, ra, 0, &recipient.pubkey(), 1_000);
+    assert!(send(&mut context, &a, sa).is_ok());
+    let sb = sign_ix(swig, state, asset, &b, rb, 0, &recipient.pubkey(), 2_000);
+    assert!(send(&mut context, &b, sb).is_ok());
+    assert_eq!(
+        context
+            .svm
+            .get_account(&recipient.pubkey())
+            .unwrap()
+            .lamports,
+        3_000
+    );
+}
+
+// ---- self-grant recovery ----------------------------------------------------
+
+#[test]
+fn test_self_grant_recovery() {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, id, _creator, state, asset) = setup(&mut context);
+
+    // Root holds All (role 0) but cannot withdraw a V2 sub-account by default.
+    let root_role = role_id_of(&context, &swig, &root.pubkey());
+    let w = withdraw_ix(swig, state, asset, &root, root_role, 0, 1_000);
+    assert!(
+        send(&mut context, &root, w).is_err(),
+        "All must not withdraw by default"
+    );
+
+    // Root grants itself a scoped Withdraw and then succeeds.
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        root_role,
+        vec![
+            ClientAction::All(All {}),
+            ClientAction::SubAccountV2Withdraw(SubAccountV2Withdraw::new(0)),
+        ],
+    )
+    .unwrap();
+    let w2 = withdraw_ix(swig, state, asset, &root, root_role, 0, 1_000);
+    assert!(
+        send(&mut context, &root, w2).is_ok(),
+        "self-granted withdraw should succeed"
+    );
+}
+
+// ---- role deletion removes scoped grants atomically -------------------------
+
+#[test]
+fn test_role_deletion_removes_scoped_grant() {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, _id, _creator, state, asset) = setup(&mut context);
+    let recipient = Keypair::new();
+    let (kp, role) = add_role(
+        &mut context,
+        &swig,
+        &root,
+        vec![ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(0))],
+    );
+
+    // Works before deletion.
+    let s = sign_ix(swig, state, asset, &kp, role, 0, &recipient.pubkey(), 1_000);
+    assert!(send(&mut context, &kp, s).is_ok());
+
+    // Remove the role; its scoped grant is gone with it.
+    remove_authority_with_ed25519_root(&mut context, &swig, &root, role).unwrap();
+    let s2 = sign_ix(swig, state, asset, &kp, role, 0, &recipient.pubkey(), 1_000);
+    assert!(
+        send(&mut context, &kp, s2).is_err(),
+        "removed role cannot sign"
+    );
+}
+
+// ---- V1 / V2 seed non-collision ---------------------------------------------
+
+#[test]
+fn test_v1_v2_seed_non_collision() {
+    let id = rand::random::<[u8; 32]>();
+    for n in 0u32..4 {
+        let n_le = n.to_le_bytes();
+        let (v1, _) = Pubkey::find_program_address(&sub_account_seeds(&id, &n_le), &program_id());
+        let (v2_asset, _) = v2_asset_pda(&id, n);
+        let (v2_state, _) = v2_state_pda(&id, n);
+        assert_ne!(
+            v1, v2_asset,
+            "V1 sub-account collides with V2 asset for id {}",
+            n
+        );
+        assert_ne!(
+            v1, v2_state,
+            "V1 sub-account collides with V2 state for id {}",
+            n
+        );
+        assert_ne!(v2_asset, v2_state);
+    }
+}
+
+// ---- duplicate scoped action rejected ---------------------------------------
+
+#[test]
+fn test_duplicate_scoped_action_rejected() {
+    let mut context = setup_test_context().unwrap();
+    let (swig, root, _id, _creator, _state, _asset) = setup(&mut context);
+
+    // Two Sign{0} actions on one role must be rejected at add time.
+    let kp = Keypair::new();
+    context.svm.airdrop(&kp.pubkey(), 10_000_000_000).unwrap();
+    let res = add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: kp.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(0)),
+            ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(0)),
+        ],
+    );
+    assert!(res.is_err(), "duplicate (Sign, id=0) must be rejected");
+}

--- a/program/tests/sub_account_v2_secp_test.rs
+++ b/program/tests/sub_account_v2_secp_test.rs
@@ -227,7 +227,10 @@ fn test_secp256k1_sub_account_sign_v2() {
         ))],
     );
 
-    context.svm.airdrop(&fixture.asset_pda, 1_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&fixture.asset_pda, 1_000_000_000)
+        .unwrap();
     let recipient = Keypair::new();
     let transfer_amount = 100_000_000;
     let inner = solana_system_interface::instruction::transfer(
@@ -259,7 +262,11 @@ fn test_secp256k1_sub_account_sign_v2() {
 
     send(&mut context, &fixture.payer, vec![ix]).expect("secp256k1 sign v2 should succeed");
     assert_eq!(
-        context.svm.get_account(&recipient.pubkey()).unwrap().lamports,
+        context
+            .svm
+            .get_account(&recipient.pubkey())
+            .unwrap()
+            .lamports,
         transfer_amount
     );
     assert_eq!(
@@ -281,7 +288,10 @@ fn test_secp256r1_sub_account_sign_v2() {
         ))],
     );
 
-    context.svm.airdrop(&fixture.asset_pda, 1_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&fixture.asset_pda, 1_000_000_000)
+        .unwrap();
     let recipient = Keypair::new();
     let transfer_amount = 100_000_000;
     let inner = solana_system_interface::instruction::transfer(
@@ -316,7 +326,11 @@ fn test_secp256r1_sub_account_sign_v2() {
 
     send(&mut context, &fixture.payer, ixs).expect("secp256r1 sign v2 should succeed");
     assert_eq!(
-        context.svm.get_account(&recipient.pubkey()).unwrap().lamports,
+        context
+            .svm
+            .get_account(&recipient.pubkey())
+            .unwrap()
+            .lamports,
         transfer_amount
     );
     assert_eq!(
@@ -341,7 +355,10 @@ fn test_secp256k1_withdraw_sol_from_sub_account_v2() {
         )],
     );
 
-    context.svm.airdrop(&fixture.asset_pda, 1_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&fixture.asset_pda, 1_000_000_000)
+        .unwrap();
     let before = context
         .svm
         .get_account(&fixture.swig_wallet_address)
@@ -396,7 +413,10 @@ fn test_secp256r1_withdraw_sol_from_sub_account_v2() {
         )],
     );
 
-    context.svm.airdrop(&fixture.asset_pda, 1_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&fixture.asset_pda, 1_000_000_000)
+        .unwrap();
     let before = context
         .svm
         .get_account(&fixture.swig_wallet_address)

--- a/program/tests/sub_account_v2_secp_test.rs
+++ b/program/tests/sub_account_v2_secp_test.rs
@@ -1,0 +1,532 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! Secp256k1 and Secp256r1 coverage for the V2 sub-account runtime operations.
+//!
+//! `sub_account_v2_test.rs` and `sub_account_v2_matrix_test.rs` exercise the
+//! semantics under Ed25519. This file covers the same runtime operations —
+//! sign, SOL withdraw, and toggle — under both Secp authority types, where the
+//! authenticated payload additionally commits to the instruction's account
+//! list and the authority's replay odometer.
+//!
+//! Sub-accounts are created by an Ed25519 role; the Secp authority is then
+//! granted the scoped action under test. That keeps each test focused on the
+//! Secp authentication path for one runtime operation.
+mod common;
+
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::{LocalSigner, PrivateKeySigner};
+use common::*;
+use solana_sdk::{
+    clock::Clock,
+    instruction::Instruction,
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{
+    AuthorityConfig, ClientAction, CreateSubAccountV2Instruction, SubAccountSignV2Instruction,
+    ToggleSubAccountV2Instruction, WithdrawFromSubAccountV2Instruction,
+};
+use swig_state::{
+    action::sub_account_v2::{
+        SubAccountV2Create, SubAccountV2Sign, SubAccountV2Toggle, SubAccountV2Withdraw,
+    },
+    authority::{secp256k1::Secp256k1Authority, secp256r1::Secp256r1Authority, AuthorityType},
+    sub_account_v2::SubAccountV2,
+    swig::{
+        sub_account_v2_asset_seeds, sub_account_v2_state_seeds, swig_wallet_address_seeds,
+        SwigWithRoles,
+    },
+    Transmutable,
+};
+
+const CREATOR_ROLE_ID: u32 = 1;
+const SECP_ROLE_ID: u32 = 2;
+const SUBACC_ID: u32 = 0;
+
+/// Generates a secp256r1 key pair, returning the signing key and its
+/// compressed public key.
+fn secp256r1_keypair() -> (openssl::ec::EcKey<openssl::pkey::Private>, [u8; 33]) {
+    use openssl::{
+        bn::BigNumContext,
+        ec::{EcGroup, EcKey, PointConversionForm},
+        nid::Nid,
+    };
+
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    let signing_key = EcKey::generate(&group).unwrap();
+    let mut ctx = BigNumContext::new().unwrap();
+    let pubkey_bytes = signing_key
+        .public_key()
+        .to_bytes(&group, PointConversionForm::COMPRESSED, &mut ctx)
+        .unwrap();
+    (signing_key, pubkey_bytes.try_into().unwrap())
+}
+
+/// The 64-byte uncompressed public key a Secp256k1 authority is registered
+/// under (the leading format byte is dropped).
+fn secp256k1_authority_bytes(wallet: &PrivateKeySigner) -> Vec<u8> {
+    let encoded = wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes();
+    encoded[1..].to_vec()
+}
+
+/// Reads the replay odometer for a Secp authority role. Secp signatures commit
+/// to `odometer + 1`, so every test derives its counter from this rather than
+/// assuming a fixed value.
+fn odometer(context: &SwigTestContext, swig_key: &Pubkey, role_id: u32, r1: bool) -> u32 {
+    let data = context.svm.get_account(swig_key).unwrap().data;
+    let swig = SwigWithRoles::from_bytes(&data).unwrap();
+    let role = swig.get_role(role_id).unwrap().unwrap();
+    if r1 {
+        role.authority
+            .as_any()
+            .downcast_ref::<Secp256r1Authority>()
+            .unwrap()
+            .signature_odometer
+    } else {
+        role.authority
+            .as_any()
+            .downcast_ref::<Secp256k1Authority>()
+            .unwrap()
+            .signature_odometer
+    }
+}
+
+fn v2_state_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
+    let id_le = subacc_id.to_le_bytes();
+    Pubkey::find_program_address(&sub_account_v2_state_seeds(id, &id_le), &program_id())
+}
+
+fn v2_asset_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
+    let id_le = subacc_id.to_le_bytes();
+    Pubkey::find_program_address(&sub_account_v2_asset_seeds(id, &id_le), &program_id())
+}
+
+fn send(
+    context: &mut SwigTestContext,
+    payer: &Keypair,
+    ixs: Vec<Instruction>,
+) -> anyhow::Result<()> {
+    let message =
+        v0::Message::try_compile(&payer.pubkey(), &ixs, &[], context.svm.latest_blockhash())
+            .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[payer.insecure_clone()])
+            .unwrap();
+    context
+        .svm
+        .send_transaction(tx)
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("tx failed: {:?}", e))
+}
+
+struct SecpFixture {
+    swig: Pubkey,
+    id: [u8; 32],
+    payer: Keypair,
+    state_pda: Pubkey,
+    asset_pda: Pubkey,
+    swig_wallet_address: Pubkey,
+}
+
+/// Builds a swig with an Ed25519 root, an Ed25519 creator role that creates
+/// sub-account 0, and a Secp authority (role 2) holding `secp_actions`.
+fn setup(
+    context: &mut SwigTestContext,
+    authority_type: AuthorityType,
+    authority_bytes: &[u8],
+    secp_actions: Vec<ClientAction>,
+) -> SecpFixture {
+    let root = Keypair::new();
+    let creator = Keypair::new();
+    context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&creator.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _) = create_swig_ed25519(context, &root, id).unwrap();
+    let (swig_wallet_address, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig.as_ref()), &program_id());
+
+    add_authority_with_ed25519_root(
+        context,
+        &swig,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: creator.pubkey().as_ref(),
+        },
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )
+    .unwrap();
+
+    let (state_pda, state_bump) = v2_state_pda(&id, SUBACC_ID);
+    let (asset_pda, asset_bump) = v2_asset_pda(&id, SUBACC_ID);
+    let create_ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        swig,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        CREATOR_ROLE_ID,
+        state_bump,
+        asset_bump,
+    )
+    .unwrap();
+    send(context, &creator, vec![create_ix]).unwrap();
+
+    add_authority_with_ed25519_root(
+        context,
+        &swig,
+        &root,
+        AuthorityConfig {
+            authority_type,
+            authority: authority_bytes,
+        },
+        secp_actions,
+    )
+    .unwrap();
+
+    SecpFixture {
+        swig,
+        id,
+        payer: creator,
+        state_pda,
+        asset_pda,
+        swig_wallet_address,
+    }
+}
+
+fn state_enabled(context: &SwigTestContext, state_pda: &Pubkey) -> bool {
+    let data = context.svm.get_account(state_pda).unwrap().data;
+    let state = unsafe { SubAccountV2::load_unchecked(&data).unwrap() };
+    state.is_enabled().unwrap()
+}
+
+// ---------------------------------------------------------------- sign
+
+#[test_log::test]
+fn test_secp256k1_sub_account_sign_v2() {
+    let mut context = setup_test_context().unwrap();
+    let wallet = LocalSigner::random();
+    let authority_bytes = secp256k1_authority_bytes(&wallet);
+    let fixture = setup(
+        &mut context,
+        AuthorityType::Secp256k1,
+        &authority_bytes,
+        vec![ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(
+            SUBACC_ID,
+        ))],
+    );
+
+    context.svm.airdrop(&fixture.asset_pda, 1_000_000_000).unwrap();
+    let recipient = Keypair::new();
+    let transfer_amount = 100_000_000;
+    let inner = solana_system_interface::instruction::transfer(
+        &fixture.asset_pda,
+        &recipient.pubkey(),
+        transfer_amount,
+    );
+
+    let signing_fn = |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        wallet.sign_hash_sync(&B256::from(hash)).unwrap().as_bytes()
+    };
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let counter = odometer(&context, &fixture.swig, SECP_ROLE_ID, false) + 1;
+
+    let ix = SubAccountSignV2Instruction::new_with_secp256k1_authority(
+        fixture.swig,
+        fixture.state_pda,
+        fixture.asset_pda,
+        signing_fn,
+        current_slot,
+        counter,
+        SECP_ROLE_ID,
+        SUBACC_ID,
+        vec![inner],
+    )
+    .unwrap();
+
+    send(&mut context, &fixture.payer, vec![ix]).expect("secp256k1 sign v2 should succeed");
+    assert_eq!(
+        context.svm.get_account(&recipient.pubkey()).unwrap().lamports,
+        transfer_amount
+    );
+    assert_eq!(
+        odometer(&context, &fixture.swig, SECP_ROLE_ID, false),
+        counter
+    );
+}
+
+#[test_log::test]
+fn test_secp256r1_sub_account_sign_v2() {
+    let mut context = setup_test_context().unwrap();
+    let (signing_key, public_key) = secp256r1_keypair();
+    let fixture = setup(
+        &mut context,
+        AuthorityType::Secp256r1,
+        &public_key,
+        vec![ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(
+            SUBACC_ID,
+        ))],
+    );
+
+    context.svm.airdrop(&fixture.asset_pda, 1_000_000_000).unwrap();
+    let recipient = Keypair::new();
+    let transfer_amount = 100_000_000;
+    let inner = solana_system_interface::instruction::transfer(
+        &fixture.asset_pda,
+        &recipient.pubkey(),
+        transfer_amount,
+    );
+
+    let mut signing_fn = |message_hash: &[u8]| -> [u8; 64] {
+        solana_secp256r1_program::sign_message(
+            message_hash,
+            &signing_key.private_key_to_der().unwrap(),
+        )
+        .unwrap()
+    };
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let counter = odometer(&context, &fixture.swig, SECP_ROLE_ID, true) + 1;
+
+    let ixs = SubAccountSignV2Instruction::new_with_secp256r1_authority(
+        fixture.swig,
+        fixture.state_pda,
+        fixture.asset_pda,
+        &mut signing_fn,
+        current_slot,
+        counter,
+        SECP_ROLE_ID,
+        SUBACC_ID,
+        vec![inner],
+        &public_key,
+    )
+    .unwrap();
+
+    send(&mut context, &fixture.payer, ixs).expect("secp256r1 sign v2 should succeed");
+    assert_eq!(
+        context.svm.get_account(&recipient.pubkey()).unwrap().lamports,
+        transfer_amount
+    );
+    assert_eq!(
+        odometer(&context, &fixture.swig, SECP_ROLE_ID, true),
+        counter
+    );
+}
+
+// ------------------------------------------------------------ sol withdraw
+
+#[test_log::test]
+fn test_secp256k1_withdraw_sol_from_sub_account_v2() {
+    let mut context = setup_test_context().unwrap();
+    let wallet = LocalSigner::random();
+    let authority_bytes = secp256k1_authority_bytes(&wallet);
+    let fixture = setup(
+        &mut context,
+        AuthorityType::Secp256k1,
+        &authority_bytes,
+        vec![ClientAction::SubAccountV2Withdraw(
+            SubAccountV2Withdraw::new(SUBACC_ID),
+        )],
+    );
+
+    context.svm.airdrop(&fixture.asset_pda, 1_000_000_000).unwrap();
+    let before = context
+        .svm
+        .get_account(&fixture.swig_wallet_address)
+        .unwrap()
+        .lamports;
+    let amount = 250_000_000;
+
+    let signing_fn = |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        wallet.sign_hash_sync(&B256::from(hash)).unwrap().as_bytes()
+    };
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let counter = odometer(&context, &fixture.swig, SECP_ROLE_ID, false) + 1;
+
+    let ix = WithdrawFromSubAccountV2Instruction::new_with_secp256k1_authority(
+        fixture.swig,
+        fixture.payer.pubkey(),
+        signing_fn,
+        current_slot,
+        counter,
+        fixture.state_pda,
+        fixture.asset_pda,
+        fixture.swig_wallet_address,
+        SECP_ROLE_ID,
+        SUBACC_ID,
+        amount,
+    )
+    .unwrap();
+
+    send(&mut context, &fixture.payer, vec![ix]).expect("secp256k1 sol withdraw should succeed");
+    assert_eq!(
+        context
+            .svm
+            .get_account(&fixture.swig_wallet_address)
+            .unwrap()
+            .lamports,
+        before + amount
+    );
+}
+
+#[test_log::test]
+fn test_secp256r1_withdraw_sol_from_sub_account_v2() {
+    let mut context = setup_test_context().unwrap();
+    let (signing_key, public_key) = secp256r1_keypair();
+    let fixture = setup(
+        &mut context,
+        AuthorityType::Secp256r1,
+        &public_key,
+        vec![ClientAction::SubAccountV2Withdraw(
+            SubAccountV2Withdraw::new(SUBACC_ID),
+        )],
+    );
+
+    context.svm.airdrop(&fixture.asset_pda, 1_000_000_000).unwrap();
+    let before = context
+        .svm
+        .get_account(&fixture.swig_wallet_address)
+        .unwrap()
+        .lamports;
+    let amount = 250_000_000;
+
+    let mut signing_fn = |message_hash: &[u8]| -> [u8; 64] {
+        solana_secp256r1_program::sign_message(
+            message_hash,
+            &signing_key.private_key_to_der().unwrap(),
+        )
+        .unwrap()
+    };
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let counter = odometer(&context, &fixture.swig, SECP_ROLE_ID, true) + 1;
+
+    let ixs = WithdrawFromSubAccountV2Instruction::new_with_secp256r1_authority(
+        fixture.swig,
+        fixture.payer.pubkey(),
+        &mut signing_fn,
+        current_slot,
+        counter,
+        fixture.state_pda,
+        fixture.asset_pda,
+        fixture.swig_wallet_address,
+        SECP_ROLE_ID,
+        SUBACC_ID,
+        amount,
+        &public_key,
+    )
+    .unwrap();
+
+    send(&mut context, &fixture.payer, ixs).expect("secp256r1 sol withdraw should succeed");
+    assert_eq!(
+        context
+            .svm
+            .get_account(&fixture.swig_wallet_address)
+            .unwrap()
+            .lamports,
+        before + amount
+    );
+}
+
+// --------------------------------------------------------------- toggle
+
+#[test_log::test]
+fn test_secp256k1_toggle_sub_account_v2() {
+    let mut context = setup_test_context().unwrap();
+    let wallet = LocalSigner::random();
+    let authority_bytes = secp256k1_authority_bytes(&wallet);
+    let fixture = setup(
+        &mut context,
+        AuthorityType::Secp256k1,
+        &authority_bytes,
+        vec![ClientAction::SubAccountV2Toggle(SubAccountV2Toggle::new(
+            SUBACC_ID,
+        ))],
+    );
+    assert!(state_enabled(&context, &fixture.state_pda));
+
+    let signing_fn = |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        wallet.sign_hash_sync(&B256::from(hash)).unwrap().as_bytes()
+    };
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let counter = odometer(&context, &fixture.swig, SECP_ROLE_ID, false) + 1;
+
+    let ix = ToggleSubAccountV2Instruction::new_with_secp256k1_authority(
+        fixture.swig,
+        fixture.payer.pubkey(),
+        signing_fn,
+        current_slot,
+        counter,
+        fixture.state_pda,
+        SECP_ROLE_ID,
+        SUBACC_ID,
+        false,
+    )
+    .unwrap();
+
+    send(&mut context, &fixture.payer, vec![ix]).expect("secp256k1 toggle should succeed");
+    assert!(
+        !state_enabled(&context, &fixture.state_pda),
+        "kill-switch should be off"
+    );
+}
+
+#[test_log::test]
+fn test_secp256r1_toggle_sub_account_v2() {
+    let mut context = setup_test_context().unwrap();
+    let (signing_key, public_key) = secp256r1_keypair();
+    let fixture = setup(
+        &mut context,
+        AuthorityType::Secp256r1,
+        &public_key,
+        vec![ClientAction::SubAccountV2Toggle(SubAccountV2Toggle::new(
+            SUBACC_ID,
+        ))],
+    );
+    assert!(state_enabled(&context, &fixture.state_pda));
+
+    let mut signing_fn = |message_hash: &[u8]| -> [u8; 64] {
+        solana_secp256r1_program::sign_message(
+            message_hash,
+            &signing_key.private_key_to_der().unwrap(),
+        )
+        .unwrap()
+    };
+    let current_slot = context.svm.get_sysvar::<Clock>().slot;
+    let counter = odometer(&context, &fixture.swig, SECP_ROLE_ID, true) + 1;
+
+    let ixs = ToggleSubAccountV2Instruction::new_with_secp256r1_authority(
+        fixture.swig,
+        fixture.payer.pubkey(),
+        &mut signing_fn,
+        current_slot,
+        counter,
+        fixture.state_pda,
+        SECP_ROLE_ID,
+        SUBACC_ID,
+        false,
+        &public_key,
+    )
+    .unwrap();
+
+    send(&mut context, &fixture.payer, ixs).expect("secp256r1 toggle should succeed");
+    assert!(
+        !state_enabled(&context, &fixture.state_pda),
+        "kill-switch should be off"
+    );
+}

--- a/program/tests/sub_account_v2_test.rs
+++ b/program/tests/sub_account_v2_test.rs
@@ -42,6 +42,15 @@ const CREATOR_ROLE_ID: u32 = 1;
 /// `SubAccountV2Create` permission. Returns
 /// (swig_key, root_keypair, creator_keypair, id).
 fn setup_v2(context: &mut SwigTestContext) -> anyhow::Result<(Pubkey, Keypair, Keypair, [u8; 32])> {
+    setup_v2_with_extra_actions(context, vec![])
+}
+
+/// As [`setup_v2`], with `extra` actions granted to the creator role alongside
+/// `SubAccountV2Create`.
+fn setup_v2_with_extra_actions(
+    context: &mut SwigTestContext,
+    extra: Vec<ClientAction>,
+) -> anyhow::Result<(Pubkey, Keypair, Keypair, [u8; 32])> {
     let root = Keypair::new();
     let creator = Keypair::new();
     context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
@@ -53,6 +62,8 @@ fn setup_v2(context: &mut SwigTestContext) -> anyhow::Result<(Pubkey, Keypair, K
     let id = rand::random::<[u8; 32]>();
     let (swig_key, _) = create_swig_ed25519(context, &root, id)?;
 
+    let mut actions = vec![ClientAction::SubAccountV2Create(SubAccountV2Create)];
+    actions.extend(extra);
     add_authority_with_ed25519_root(
         context,
         &swig_key,
@@ -61,7 +72,7 @@ fn setup_v2(context: &mut SwigTestContext) -> anyhow::Result<(Pubkey, Keypair, K
             authority_type: AuthorityType::Ed25519,
             authority: creator.pubkey().as_ref(),
         },
-        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+        actions,
     )?;
     Ok((swig_key, root, creator, id))
 }
@@ -122,6 +133,39 @@ fn decode_counter(context: &SwigTestContext, swig_key: &Pubkey) -> u32 {
     let data = context.svm.get_account(swig_key).unwrap().data;
     let swig = unsafe { Swig::load_unchecked(&data[..Swig::LEN]).unwrap() };
     swig.sub_account_counter
+}
+
+/// Counts how many `SubAccountV2All` actions the role holds for `subacc_id`.
+///
+/// The auto-grant must never leave two: a role may hold at most one scoped V2
+/// action per `(type, id)`, and a second copy is what
+/// `reject_duplicate_v2_scoped` fails the whole create over.
+fn role_all_scope_count(
+    context: &SwigTestContext,
+    swig_key: &Pubkey,
+    role_id: u32,
+    subacc_id: u32,
+) -> usize {
+    let data = context.svm.get_account(swig_key).unwrap().data;
+    let swig = SwigWithRoles::from_bytes(&data).unwrap();
+    let role = swig.get_role(role_id).unwrap().unwrap();
+    let mut cursor = 0;
+    let mut count = 0;
+    for _ in 0..role.position.num_actions() {
+        let header =
+            unsafe { Action::load_unchecked(&role.actions[cursor..cursor + Action::LEN]).unwrap() };
+        cursor += Action::LEN;
+        let len = header.length() as usize;
+        if header.permission().unwrap() == Permission::SubAccountV2All {
+            let body = &role.actions[cursor..cursor + len];
+            let read_id = u32::from_le_bytes([body[0], body[1], body[2], body[3]]);
+            if read_id == subacc_id {
+                count += 1;
+            }
+        }
+        cursor += len;
+    }
+    count
 }
 
 /// Returns true if the given role holds a `SubAccountV2All` action for
@@ -683,4 +727,67 @@ fn test_create_sub_account_v2_preserves_other_roles_and_permissions() {
     let after3 = SwigSnapshot::capture(&context, &swig_key);
     after2.assert_others_stable(&after3, &[id_creator]);
     assert_eq!(after3.counter, 3);
+}
+
+/// The design allows scoping a sub-account id before it exists. When the id the
+/// counter then draws is that same id, the auto-grant must not append a second
+/// `SubAccountV2All` — the duplicate check would fail the whole create.
+#[test_log::test]
+fn test_create_v2_when_creator_pre_granted_all_for_the_drawn_id() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _root, creator, id) = setup_v2_with_extra_actions(
+        &mut context,
+        vec![ClientAction::SubAccountV2All(SubAccountV2All::new(0))],
+    )
+    .unwrap();
+
+    // Pre-grant is in place before anything is created.
+    assert_eq!(decode_counter(&context, &swig_key), 0);
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, CREATOR_ROLE_ID, 0),
+        1
+    );
+
+    // Creating id 0 used to fail with DuplicateV2SubAccountAction (1009).
+    let (state_pda, _asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0)
+        .expect("create must succeed when the scope is already granted");
+
+    assert_eq!(decode_counter(&context, &swig_key), 1);
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, CREATOR_ROLE_ID, 0),
+        1,
+        "the pre-grant must be left alone, not duplicated"
+    );
+
+    // The sub-account really was created, and the scope still authorizes it.
+    let state_acc = context.svm.get_account(&state_pda).unwrap();
+    assert_eq!(state_acc.owner, program_id());
+    let state = unsafe { SubAccountV2::load_unchecked(&state_acc.data).unwrap() };
+    assert_eq!(state.subacc_id, 0);
+    assert!(state.is_enabled().unwrap());
+}
+
+/// A pre-grant for a *different* id must not suppress the auto-grant: the role
+/// ends up holding both scopes.
+#[test_log::test]
+fn test_create_v2_pre_grant_for_other_id_still_auto_grants() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _root, creator, id) = setup_v2_with_extra_actions(
+        &mut context,
+        vec![ClientAction::SubAccountV2All(SubAccountV2All::new(5))],
+    )
+    .unwrap();
+
+    create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, CREATOR_ROLE_ID, 0),
+        1,
+        "the drawn id must still be auto-granted"
+    );
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, CREATOR_ROLE_ID, 5),
+        1,
+        "the unrelated pre-grant must survive"
+    );
 }

--- a/program/tests/sub_account_v2_test.rs
+++ b/program/tests/sub_account_v2_test.rs
@@ -5,16 +5,19 @@
 mod common;
 
 use common::*;
+use litesvm_token::spl_token;
 use solana_sdk::{
     message::{v0, VersionedMessage},
+    program_pack::Pack,
     pubkey::Pubkey,
     signature::Keypair,
     signer::Signer,
     transaction::VersionedTransaction,
 };
 use swig_interface::{
-    AuthorityConfig, ClientAction, CreateSubAccountV2Instruction, SubAccountSignV2Instruction,
-    ToggleSubAccountV2Instruction, WithdrawFromSubAccountV2Instruction,
+    AuthorityConfig, ClientAction, CloseSwigV1Instruction, CreateSubAccountV2Instruction,
+    SubAccountSignV2Instruction, ToggleSubAccountV2Instruction,
+    WithdrawFromSubAccountV2Instruction,
 };
 use swig_state::{
     action::{
@@ -31,8 +34,9 @@ use swig_state::{
 const CREATOR_ROLE_ID: u32 = 1;
 
 /// Creates a swig with a root authority plus a role (id 1) holding a
-/// `SubAccountV2Create` permission. Returns (swig_key, creator_keypair, id).
-fn setup_v2(context: &mut SwigTestContext) -> anyhow::Result<(Pubkey, Keypair, [u8; 32])> {
+/// `SubAccountV2Create` permission. Returns
+/// (swig_key, root_keypair, creator_keypair, id).
+fn setup_v2(context: &mut SwigTestContext) -> anyhow::Result<(Pubkey, Keypair, Keypair, [u8; 32])> {
     let root = Keypair::new();
     let creator = Keypair::new();
     context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
@@ -54,7 +58,7 @@ fn setup_v2(context: &mut SwigTestContext) -> anyhow::Result<(Pubkey, Keypair, [
         },
         vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
     )?;
-    Ok((swig_key, creator, id))
+    Ok((swig_key, root, creator, id))
 }
 
 fn v2_state_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
@@ -147,7 +151,7 @@ fn role_has_all_scope(
 #[test]
 fn test_create_sub_account_v2_initializes_state_and_grants_creator() {
     let mut context = setup_test_context().unwrap();
-    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
 
     assert_eq!(decode_counter(&context, &swig_key), 0);
 
@@ -176,9 +180,28 @@ fn test_create_sub_account_v2_initializes_state_and_grants_creator() {
 }
 
 #[test]
+fn test_create_sub_account_v2_accepts_prefunded_state_pda() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
+    let (state_pda, _) = v2_state_pda(&id, 0);
+
+    // A receiver does not sign a system transfer, so any account can pre-fund
+    // the predictable state PDA.
+    let prefund = solana_system_interface::instruction::transfer(&creator.pubkey(), &state_pda, 1);
+    send(&mut context, &creator, prefund).unwrap();
+
+    let (created_state, _asset) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    assert_eq!(created_state, state_pda);
+    assert_eq!(decode_counter(&context, &swig_key), 1);
+    let state_account = context.svm.get_account(&state_pda).unwrap();
+    assert_eq!(state_account.owner, program_id());
+    assert_eq!(state_account.data.len(), SubAccountV2::LEN);
+}
+
+#[test]
 fn test_create_multiple_sub_accounts_from_one_role() {
     let mut context = setup_test_context().unwrap();
-    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
 
     create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
     create_v2(&mut context, &swig_key, &creator, &id, 1).unwrap();
@@ -191,7 +214,7 @@ fn test_create_multiple_sub_accounts_from_one_role() {
 #[test]
 fn test_withdraw_sol_from_sub_account_v2() {
     let mut context = setup_test_context().unwrap();
-    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
     let (_state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
 
     let (swig_wallet_address, _) = Pubkey::find_program_address(
@@ -233,9 +256,71 @@ fn test_withdraw_sol_from_sub_account_v2() {
 }
 
 #[test]
+fn test_withdraw_token_from_sub_account_v2() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
+    let (state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_state::swig::swig_wallet_address_seeds(swig_key.as_ref()),
+        &program_id(),
+    );
+
+    let mint = setup_mint(&mut context.svm, &context.default_payer).unwrap();
+    let source_token =
+        setup_ata(&mut context.svm, &mint, &asset_pda, &context.default_payer).unwrap();
+    let destination_token = setup_ata(
+        &mut context.svm,
+        &mint,
+        &swig_wallet_address,
+        &context.default_payer,
+    )
+    .unwrap();
+    mint_to(
+        &mut context.svm,
+        &mint,
+        &context.default_payer,
+        &source_token,
+        10_000,
+    )
+    .unwrap();
+
+    let ix = WithdrawFromSubAccountV2Instruction::new_token_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        swig_wallet_address,
+        source_token,
+        destination_token,
+        spl_token::ID,
+        CREATOR_ROLE_ID,
+        0,
+        4_000,
+    )
+    .unwrap();
+    send(&mut context, &creator, ix).unwrap();
+
+    let source = context.svm.get_account(&source_token).unwrap();
+    let destination = context.svm.get_account(&destination_token).unwrap();
+    assert_eq!(
+        spl_token::state::Account::unpack(&source.data)
+            .unwrap()
+            .amount,
+        6_000
+    );
+    assert_eq!(
+        spl_token::state::Account::unpack(&destination.data)
+            .unwrap()
+            .amount,
+        4_000
+    );
+}
+
+#[test]
 fn test_toggle_disables_withdraw() {
     let mut context = setup_test_context().unwrap();
-    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
     let (state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
     context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
 
@@ -277,6 +362,58 @@ fn test_toggle_disables_withdraw() {
     assert!(
         send(&mut context, &creator, ix).is_err(),
         "withdraw should fail while sub-account is disabled"
+    );
+}
+
+#[test]
+fn test_toggle_rejects_invalid_enabled_byte() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
+    let (state_pda, _asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+
+    let mut toggle = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        CREATOR_ROLE_ID,
+        0,
+        false,
+    )
+    .unwrap();
+    // SwigInstruction is u16, followed by the enabled wire byte.
+    toggle.data[2] = 2;
+    assert!(send(&mut context, &creator, toggle).is_err());
+
+    let state = context.svm.get_account(&state_pda).unwrap();
+    let decoded = unsafe { SubAccountV2::load_unchecked(&state.data).unwrap() };
+    assert!(decoded.enabled);
+}
+
+#[test]
+fn test_close_swig_rejects_existing_sub_account_v2() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, root, creator, id) = setup_v2(&mut context).unwrap();
+    create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_state::swig::swig_wallet_address_seeds(swig_key.as_ref()),
+        &program_id(),
+    );
+    let destination = Keypair::new();
+    let close = CloseSwigV1Instruction::new_with_ed25519_authority(
+        swig_key,
+        swig_wallet_address,
+        root.pubkey(),
+        destination.pubkey(),
+        0,
+    )
+    .unwrap();
+
+    assert!(send(&mut context, &root, close).is_err());
+    let swig_account = context.svm.get_account(&swig_key).unwrap();
+    assert_eq!(
+        swig_account.data[0],
+        swig_state::Discriminator::SwigConfigAccount as u8
     );
 }
 
@@ -331,7 +468,7 @@ fn test_all_permission_cannot_create_sub_account_v2() {
 #[test]
 fn test_sign_transfers_from_asset_pda() {
     let mut context = setup_test_context().unwrap();
-    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
     let (state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
     context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
 

--- a/program/tests/sub_account_v2_test.rs
+++ b/program/tests/sub_account_v2_test.rs
@@ -4,6 +4,7 @@
 //! that `All` alone cannot create.
 mod common;
 
+use common::stability::{scoped_v2_body, SwigSnapshot};
 use common::*;
 use litesvm_token::spl_token;
 use solana_sdk::{
@@ -22,7 +23,11 @@ use swig_interface::{
 use swig_state::{
     action::{
         all::All,
-        sub_account_v2::{SubAccountV2All, SubAccountV2Create},
+        manage_authority::ManageAuthority,
+        sub_account_v2::{
+            SubAccountV2All, SubAccountV2Create, SubAccountV2Sign, SubAccountV2Toggle,
+            SubAccountV2Withdraw,
+        },
         Action, Permission,
     },
     authority::AuthorityType,
@@ -496,4 +501,141 @@ fn test_sign_transfers_from_asset_pda() {
         .unwrap()
         .lamports;
     assert_eq!(recipient_balance, amount);
+}
+
+/// Creating a V2 sub-account appends `SubAccountV2All { id }` to the creator's
+/// role, which reallocs the swig account. When the creator is a *middle* role,
+/// this shifts every role after it in the buffer. This test proves that neither
+/// the shift nor the append corrupts any other role's authority or permissions.
+///
+/// Layout: role 0 = root (`All`), role 1 = creator (`SubAccountV2Create`),
+/// role 2 = two permissions, role 3 = four permissions.
+#[test]
+fn test_create_sub_account_v2_preserves_other_roles_and_permissions() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    // Role 1: the creator (a middle role once 2 and 3 are added).
+    let creator = Keypair::new();
+    context
+        .svm
+        .airdrop(&creator.pubkey(), 10_000_000_000)
+        .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: creator.pubkey().as_ref(),
+        },
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )
+    .unwrap();
+
+    // Role 2: two permissions (ManageAuthority + a scoped sign).
+    let role2 = Keypair::new();
+    context
+        .svm
+        .airdrop(&role2.pubkey(), 10_000_000_000)
+        .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: role2.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::ManageAuthority(ManageAuthority {}),
+            ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(100)),
+        ],
+    )
+    .unwrap();
+
+    // Role 3: four permissions of varied types with distinct scoped ids.
+    let role3 = Keypair::new();
+    context
+        .svm
+        .airdrop(&role3.pubkey(), 10_000_000_000)
+        .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: role3.pubkey().as_ref(),
+        },
+        vec![
+            ClientAction::SubAccountV2Create(SubAccountV2Create),
+            ClientAction::SubAccountV2All(SubAccountV2All::new(101)),
+            ClientAction::SubAccountV2Withdraw(SubAccountV2Withdraw::new(102)),
+            ClientAction::SubAccountV2Toggle(SubAccountV2Toggle::new(103)),
+        ],
+    )
+    .unwrap();
+
+    // Snapshot the whole wallet before any sub-account exists.
+    let id_creator = creator.pubkey().to_bytes();
+    let id_role3 = role3.pubkey().to_bytes();
+    let before = SwigSnapshot::capture(&context, &swig_key);
+    assert_eq!(before.roles.len(), 4);
+    assert_eq!(
+        before.actions_of(&root.pubkey().to_bytes()).len(),
+        1,
+        "root: All"
+    );
+    assert_eq!(before.actions_of(&id_creator).len(), 1, "creator: Create");
+    assert_eq!(
+        before.actions_of(&role2.pubkey().to_bytes()).len(),
+        2,
+        "role 2: 2 perms"
+    );
+    assert_eq!(before.actions_of(&id_role3).len(), 4, "role 3: 4 perms");
+
+    // Create sub-account 0 as the creator (a MIDDLE role): appends All{0} and
+    // reallocs, shifting roles 2 and 3. Only the creator's role may change.
+    create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    let after = SwigSnapshot::capture(&context, &swig_key);
+    before.assert_others_stable(&after, &[id_creator]);
+    assert_eq!(after.counter, before.counter + 1);
+    let mut expected_creator = before.actions_of(&id_creator).clone();
+    expected_creator.push((Permission::SubAccountV2All, scoped_v2_body(0)));
+    assert_eq!(
+        after.actions_of(&id_creator),
+        &expected_creator,
+        "creator's auto-granted All{{0}} is wrong"
+    );
+
+    // Functional proof: role 3's authority + SubAccountV2Create survived the
+    // realloc and still work — it creates sub-account 1. Only role 3 changes.
+    let (state_pda, state_bump) = v2_state_pda(&id, 1);
+    let (asset_pda, asset_bump) = v2_asset_pda(&id, 1);
+    let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        role3.pubkey(),
+        role3.pubkey(),
+        state_pda,
+        asset_pda,
+        3,
+        state_bump,
+        asset_bump,
+    )
+    .unwrap();
+    send(&mut context, &role3, ix).unwrap();
+    let after2 = SwigSnapshot::capture(&context, &swig_key);
+    after.assert_others_stable(&after2, &[id_role3]);
+    assert_eq!(after2.counter, 2);
+
+    // Repeat a MIDDLE-role realloc: the creator creates sub-account 2, shifting
+    // roles 2 and 3 again. Everything except the creator stays byte-identical.
+    create_v2(&mut context, &swig_key, &creator, &id, 2).unwrap();
+    let after3 = SwigSnapshot::capture(&context, &swig_key);
+    after2.assert_others_stable(&after3, &[id_creator]);
+    assert_eq!(after3.counter, 3);
 }

--- a/program/tests/sub_account_v2_test.rs
+++ b/program/tests/sub_account_v2_test.rs
@@ -791,3 +791,148 @@ fn test_create_v2_pre_grant_for_other_id_still_auto_grants() {
         "the unrelated pre-grant must survive"
     );
 }
+
+/// The skip must key on `SubAccountV2All` exactly. A pre-granted *specific*
+/// scope for the same id is a different dedup key, so the umbrella still has to
+/// be auto-granted -- otherwise the creator silently ends up with narrower
+/// access than every other creator gets.
+#[test_log::test]
+fn test_pre_granted_specific_scope_does_not_suppress_auto_grant() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _root, creator, id) = setup_v2_with_extra_actions(
+        &mut context,
+        vec![ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(0))],
+    )
+    .unwrap();
+
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, CREATOR_ROLE_ID, 0),
+        0
+    );
+
+    create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, CREATOR_ROLE_ID, 0),
+        1,
+        "a pre-granted Sign scope must not be mistaken for the All umbrella"
+    );
+}
+
+/// Dedup is per-role, so another role holding `All { id }` must not suppress the
+/// acting role's auto-grant.
+#[test_log::test]
+fn test_pre_grant_on_another_role_does_not_suppress_creator_auto_grant() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, root, creator, id) = setup_v2(&mut context).unwrap();
+
+    let bystander = Keypair::new();
+    context
+        .svm
+        .airdrop(&bystander.pubkey(), 10_000_000_000)
+        .unwrap();
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: bystander.pubkey().as_ref(),
+        },
+        vec![ClientAction::SubAccountV2All(SubAccountV2All::new(0))],
+    )
+    .unwrap();
+    let bystander_role = 2;
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, bystander_role, 0),
+        1
+    );
+
+    create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, CREATOR_ROLE_ID, 0),
+        1,
+        "creator must still receive its own umbrella"
+    );
+    assert_eq!(
+        role_all_scope_count(&context, &swig_key, bystander_role, 0),
+        1,
+        "the other role's scope is untouched"
+    );
+}
+
+/// After the auto-grant is skipped, the pre-granted scope must actually
+/// authorize the runtime operations -- the skip must not leave the creator
+/// under-privileged.
+#[test_log::test]
+fn test_pre_granted_scope_authorizes_runtime_ops_after_skip() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _root, creator, id) = setup_v2_with_extra_actions(
+        &mut context,
+        vec![ClientAction::SubAccountV2All(SubAccountV2All::new(0))],
+    )
+    .unwrap();
+
+    let (state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
+
+    // sign
+    let recipient = Keypair::new();
+    let inner =
+        solana_system_interface::instruction::transfer(&asset_pda, &recipient.pubkey(), 10_000_000);
+    let sign = SubAccountSignV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        state_pda,
+        asset_pda,
+        creator.pubkey(),
+        CREATOR_ROLE_ID,
+        0,
+        vec![inner],
+    )
+    .unwrap();
+    send(&mut context, &creator, sign).expect("sign must be authorized by the pre-granted scope");
+    assert_eq!(
+        context
+            .svm
+            .get_account(&recipient.pubkey())
+            .unwrap()
+            .lamports,
+        10_000_000
+    );
+
+    // withdraw
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_state::swig::swig_wallet_address_seeds(swig_key.as_ref()),
+        &program_id(),
+    );
+    let withdraw = WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        swig_wallet_address,
+        CREATOR_ROLE_ID,
+        0,
+        5_000_000,
+    )
+    .unwrap();
+    send(&mut context, &creator, withdraw).expect("withdraw must be authorized");
+
+    // toggle
+    let toggle = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        CREATOR_ROLE_ID,
+        0,
+        false,
+    )
+    .unwrap();
+    send(&mut context, &creator, toggle).expect("toggle must be authorized");
+    let state_acc = context.svm.get_account(&state_pda).unwrap();
+    let state = unsafe { SubAccountV2::load_unchecked(&state_acc.data).unwrap() };
+    assert!(!state.is_enabled().unwrap());
+}

--- a/program/tests/sub_account_v2_test.rs
+++ b/program/tests/sub_account_v2_test.rs
@@ -391,7 +391,7 @@ fn test_toggle_rejects_invalid_enabled_byte() {
 }
 
 #[test]
-fn test_close_swig_rejects_existing_sub_account_v2() {
+fn test_close_swig_allows_existing_sub_account_v2() {
     let mut context = setup_test_context().unwrap();
     let (swig_key, root, creator, id) = setup_v2(&mut context).unwrap();
     create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
@@ -400,6 +400,7 @@ fn test_close_swig_rejects_existing_sub_account_v2() {
         &program_id(),
     );
     let destination = Keypair::new();
+    context.svm.airdrop(&destination.pubkey(), 0).unwrap();
     let close = CloseSwigV1Instruction::new_with_ed25519_authority(
         swig_key,
         swig_wallet_address,
@@ -409,11 +410,11 @@ fn test_close_swig_rejects_existing_sub_account_v2() {
     )
     .unwrap();
 
-    assert!(send(&mut context, &root, close).is_err());
+    send(&mut context, &root, close).unwrap();
     let swig_account = context.svm.get_account(&swig_key).unwrap();
     assert_eq!(
         swig_account.data[0],
-        swig_state::Discriminator::SwigConfigAccount as u8
+        swig_state::Discriminator::ClosedSwigAccount as u8
     );
 }
 

--- a/program/tests/sub_account_v2_test.rs
+++ b/program/tests/sub_account_v2_test.rs
@@ -1,0 +1,361 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! End-to-end tests for V2 sub-accounts: creation (with auto-granted scoped
+//! access), SOL withdrawal, the enabled kill-switch, and the default-deny rule
+//! that `All` alone cannot create.
+mod common;
+
+use common::*;
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{
+    AuthorityConfig, ClientAction, CreateSubAccountV2Instruction, SubAccountSignV2Instruction,
+    ToggleSubAccountV2Instruction, WithdrawFromSubAccountV2Instruction,
+};
+use swig_state::{
+    action::{
+        all::All,
+        sub_account_v2::{SubAccountV2All, SubAccountV2Create},
+        Action, Permission,
+    },
+    authority::AuthorityType,
+    sub_account_v2::SubAccountV2,
+    swig::{sub_account_v2_asset_seeds, sub_account_v2_state_seeds, Swig, SwigWithRoles},
+    Transmutable,
+};
+
+const CREATOR_ROLE_ID: u32 = 1;
+
+/// Creates a swig with a root authority plus a role (id 1) holding a
+/// `SubAccountV2Create` permission. Returns (swig_key, creator_keypair, id).
+fn setup_v2(context: &mut SwigTestContext) -> anyhow::Result<(Pubkey, Keypair, [u8; 32])> {
+    let root = Keypair::new();
+    let creator = Keypair::new();
+    context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&creator.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(context, &root, id)?;
+
+    add_authority_with_ed25519_root(
+        context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: creator.pubkey().as_ref(),
+        },
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )?;
+    Ok((swig_key, creator, id))
+}
+
+fn v2_state_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
+    let id_le = subacc_id.to_le_bytes();
+    Pubkey::find_program_address(&sub_account_v2_state_seeds(id, &id_le), &program_id())
+}
+
+fn v2_asset_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
+    let id_le = subacc_id.to_le_bytes();
+    Pubkey::find_program_address(&sub_account_v2_asset_seeds(id, &id_le), &program_id())
+}
+
+fn create_v2(
+    context: &mut SwigTestContext,
+    swig_key: &Pubkey,
+    creator: &Keypair,
+    id: &[u8; 32],
+    subacc_id: u32,
+) -> anyhow::Result<(Pubkey, Pubkey)> {
+    let (state_pda, state_bump) = v2_state_pda(id, subacc_id);
+    let (asset_pda, asset_bump) = v2_asset_pda(id, subacc_id);
+    let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        *swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        CREATOR_ROLE_ID,
+        state_bump,
+        asset_bump,
+    )
+    .map_err(|e| anyhow::anyhow!("build create v2: {:?}", e))?;
+    send(context, creator, ix)?;
+    Ok((state_pda, asset_pda))
+}
+
+fn send(
+    context: &mut SwigTestContext,
+    payer: &Keypair,
+    ix: solana_sdk::instruction::Instruction,
+) -> anyhow::Result<()> {
+    let message =
+        v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+            .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[payer.insecure_clone()])
+            .unwrap();
+    context
+        .svm
+        .send_transaction(tx)
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("tx failed: {:?}", e))
+}
+
+fn decode_counter(context: &SwigTestContext, swig_key: &Pubkey) -> u32 {
+    let data = context.svm.get_account(swig_key).unwrap().data;
+    let swig = unsafe { Swig::load_unchecked(&data[..Swig::LEN]).unwrap() };
+    swig.sub_account_counter
+}
+
+/// Returns true if the given role holds a `SubAccountV2All` action for
+/// `subacc_id`.
+fn role_has_all_scope(
+    context: &SwigTestContext,
+    swig_key: &Pubkey,
+    role_id: u32,
+    subacc_id: u32,
+) -> bool {
+    let data = context.svm.get_account(swig_key).unwrap().data;
+    let swig = SwigWithRoles::from_bytes(&data).unwrap();
+    let role = swig.get_role(role_id).unwrap().unwrap();
+    let mut cursor = 0;
+    for _ in 0..role.position.num_actions() {
+        let header =
+            unsafe { Action::load_unchecked(&role.actions[cursor..cursor + Action::LEN]).unwrap() };
+        cursor += Action::LEN;
+        let len = header.length() as usize;
+        if header.permission().unwrap() == Permission::SubAccountV2All {
+            let body = &role.actions[cursor..cursor + len];
+            let read_id = u32::from_le_bytes([body[0], body[1], body[2], body[3]]);
+            if read_id == subacc_id {
+                return true;
+            }
+        }
+        cursor += len;
+    }
+    false
+}
+
+#[test]
+fn test_create_sub_account_v2_initializes_state_and_grants_creator() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+
+    assert_eq!(decode_counter(&context, &swig_key), 0);
+
+    let (state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+
+    // Counter advanced.
+    assert_eq!(decode_counter(&context, &swig_key), 1);
+
+    // State account is program-owned and correctly populated.
+    let state_acc = context.svm.get_account(&state_pda).unwrap();
+    assert_eq!(state_acc.owner, program_id());
+    assert_eq!(state_acc.data.len(), SubAccountV2::LEN);
+    let state = unsafe { SubAccountV2::load_unchecked(&state_acc.data).unwrap() };
+    assert!(state.enabled);
+    assert_eq!(state.subacc_id, 0);
+    assert_eq!(state.swig_id, id);
+    assert_eq!(state.sub_account, asset_pda.to_bytes());
+
+    // Asset account is system-owned and rent-exempt.
+    let asset_acc = context.svm.get_account(&asset_pda).unwrap();
+    assert_eq!(asset_acc.owner, solana_system_interface::program::id());
+    assert!(asset_acc.lamports > 0);
+
+    // Creator role auto-granted SubAccountV2All { 0 }.
+    assert!(role_has_all_scope(&context, &swig_key, CREATOR_ROLE_ID, 0));
+}
+
+#[test]
+fn test_create_multiple_sub_accounts_from_one_role() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+
+    create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    create_v2(&mut context, &swig_key, &creator, &id, 1).unwrap();
+
+    assert_eq!(decode_counter(&context, &swig_key), 2);
+    assert!(role_has_all_scope(&context, &swig_key, CREATOR_ROLE_ID, 0));
+    assert!(role_has_all_scope(&context, &swig_key, CREATOR_ROLE_ID, 1));
+}
+
+#[test]
+fn test_withdraw_sol_from_sub_account_v2() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+    let (_state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_state::swig::swig_wallet_address_seeds(swig_key.as_ref()),
+        &program_id(),
+    );
+
+    context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
+    let asset_before = context.svm.get_account(&asset_pda).unwrap().lamports;
+    let dest_before = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .unwrap()
+        .lamports;
+
+    let amount = 100_000_000u64;
+    let ix = WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        _state_pda,
+        asset_pda,
+        swig_wallet_address,
+        CREATOR_ROLE_ID,
+        0,
+        amount,
+    )
+    .unwrap();
+    send(&mut context, &creator, ix).unwrap();
+
+    let asset_after = context.svm.get_account(&asset_pda).unwrap().lamports;
+    let dest_after = context
+        .svm
+        .get_account(&swig_wallet_address)
+        .unwrap()
+        .lamports;
+    assert_eq!(asset_before - asset_after, amount);
+    assert_eq!(dest_after - dest_before, amount);
+}
+
+#[test]
+fn test_toggle_disables_withdraw() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+    let (state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
+
+    let (swig_wallet_address, _) = Pubkey::find_program_address(
+        &swig_state::swig::swig_wallet_address_seeds(swig_key.as_ref()),
+        &program_id(),
+    );
+
+    // Disable the sub-account.
+    let toggle = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        CREATOR_ROLE_ID,
+        0,
+        false,
+    )
+    .unwrap();
+    send(&mut context, &creator, toggle).unwrap();
+
+    let state = context.svm.get_account(&state_pda).unwrap();
+    let decoded = unsafe { SubAccountV2::load_unchecked(&state.data).unwrap() };
+    assert!(!decoded.enabled);
+
+    // Withdrawing from a disabled sub-account must fail.
+    let ix = WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        swig_wallet_address,
+        CREATOR_ROLE_ID,
+        0,
+        10_000_000,
+    )
+    .unwrap();
+    assert!(
+        send(&mut context, &creator, ix).is_err(),
+        "withdraw should fail while sub-account is disabled"
+    );
+}
+
+#[test]
+fn test_all_permission_cannot_create_sub_account_v2() {
+    let mut context = setup_test_context().unwrap();
+    let root = Keypair::new();
+    let all_authority = Keypair::new();
+    context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&all_authority.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    // Role 1 holds only `All` — no SubAccountV2Create.
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: all_authority.pubkey().as_ref(),
+        },
+        vec![ClientAction::All(All {})],
+    )
+    .unwrap();
+
+    let (state_pda, state_bump) = v2_state_pda(&id, 0);
+    let (asset_pda, asset_bump) = v2_asset_pda(&id, 0);
+    let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        all_authority.pubkey(),
+        all_authority.pubkey(),
+        state_pda,
+        asset_pda,
+        1,
+        state_bump,
+        asset_bump,
+    )
+    .unwrap();
+    assert!(
+        send(&mut context, &all_authority, ix).is_err(),
+        "All alone must not be able to create a V2 sub-account"
+    );
+    // Counter must not have advanced.
+    assert_eq!(decode_counter(&context, &swig_key), 0);
+}
+
+#[test]
+fn test_sign_transfers_from_asset_pda() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, creator, id) = setup_v2(&mut context).unwrap();
+    let (state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
+
+    let recipient = Keypair::new();
+    let amount = 50_000_000u64;
+    let inner =
+        solana_system_interface::instruction::transfer(&asset_pda, &recipient.pubkey(), amount);
+
+    let ix = SubAccountSignV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        state_pda,
+        asset_pda,
+        creator.pubkey(),
+        CREATOR_ROLE_ID,
+        0,
+        vec![inner],
+    )
+    .unwrap();
+    send(&mut context, &creator, ix).unwrap();
+
+    let recipient_balance = context
+        .svm
+        .get_account(&recipient.pubkey())
+        .unwrap()
+        .lamports;
+    assert_eq!(recipient_balance, amount);
+}

--- a/program/tests/sub_account_v2_test.rs
+++ b/program/tests/sub_account_v2_test.rs
@@ -170,7 +170,7 @@ fn test_create_sub_account_v2_initializes_state_and_grants_creator() {
     assert_eq!(state_acc.owner, program_id());
     assert_eq!(state_acc.data.len(), SubAccountV2::LEN);
     let state = unsafe { SubAccountV2::load_unchecked(&state_acc.data).unwrap() };
-    assert!(state.enabled);
+    assert!(state.is_enabled().unwrap());
     assert_eq!(state.subacc_id, 0);
     assert_eq!(state.swig_id, id);
     assert_eq!(state.sub_account, asset_pda.to_bytes());
@@ -349,7 +349,7 @@ fn test_toggle_disables_withdraw() {
 
     let state = context.svm.get_account(&state_pda).unwrap();
     let decoded = unsafe { SubAccountV2::load_unchecked(&state.data).unwrap() };
-    assert!(!decoded.enabled);
+    assert!(!decoded.is_enabled().unwrap());
 
     // Withdrawing from a disabled sub-account must fail.
     let ix = WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
@@ -392,7 +392,52 @@ fn test_toggle_rejects_invalid_enabled_byte() {
 
     let state = context.svm.get_account(&state_pda).unwrap();
     let decoded = unsafe { SubAccountV2::load_unchecked(&state.data).unwrap() };
-    assert!(decoded.enabled);
+    assert!(decoded.is_enabled().unwrap());
+}
+
+#[test]
+fn test_invalid_stored_enabled_byte_is_rejected() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _root, creator, id) = setup_v2(&mut context).unwrap();
+    let (state_pda, asset_pda) = create_v2(&mut context, &swig_key, &creator, &id, 0).unwrap();
+    context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
+
+    let mut state_account = context.svm.get_account(&state_pda).unwrap();
+    state_account.data[3] = 2;
+    context.svm.set_account(state_pda, state_account).unwrap();
+
+    let recipient = Keypair::new();
+    let inner =
+        solana_system_interface::instruction::transfer(&asset_pda, &recipient.pubkey(), 1_000);
+    let sign = SubAccountSignV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        state_pda,
+        asset_pda,
+        creator.pubkey(),
+        CREATOR_ROLE_ID,
+        0,
+        vec![inner],
+    )
+    .unwrap();
+    assert!(
+        send(&mut context, &creator, sign).is_err(),
+        "runtime use must reject a non-canonical enabled value"
+    );
+
+    let toggle = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        CREATOR_ROLE_ID,
+        0,
+        false,
+    )
+    .unwrap();
+    assert!(
+        send(&mut context, &creator, toggle).is_err(),
+        "toggle must not silently canonicalize corrupt state"
+    );
 }
 
 #[test]

--- a/program/tests/sub_account_v2_version_guard_test.rs
+++ b/program/tests/sub_account_v2_version_guard_test.rs
@@ -36,6 +36,10 @@ use swig_state::{
 /// private to the crate, so the code is mirrored here.
 const ERR_V2_WITH_SWIG_V1: u32 = 47;
 
+/// `SwigError::InvalidSwigAccountDiscriminator`, which `require_swig_v2` also
+/// uses for an account too short to hold a header.
+const ERR_INVALID_DISCRIMINATOR: u32 = 0;
+
 /// Byte offset of `Swig::wallet_bump`; V1 stored `reserved_lamports: u64` here.
 const WALLET_BUMP_OFFSET: usize = 40;
 
@@ -139,12 +143,9 @@ fn setup_v1_before_any_sub_account(
     (swig_key, id, creator, creator_role)
 }
 
-/// Builds a V2 swig with one sub-account, then rewrites the header's trailing
-/// `u64` so the account presents as V1. Returns everything the runtime
-/// instructions need.
-fn setup_then_downgrade(
+/// Builds a healthy V2 swig with a creator role and sub-account 0, funded.
+fn setup_v2_with_sub_account(
     context: &mut SwigTestContext,
-    reserved_lamports: u64,
 ) -> (Pubkey, [u8; 32], Keypair, u32, Pubkey, Pubkey) {
     let root = Keypair::new();
     let creator = Keypair::new();
@@ -187,14 +188,26 @@ fn setup_then_downgrade(
     send(context, &creator, ix).unwrap();
     context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
 
-    // Downgrade: overwrite `wallet_bump ++ _padding ++ sub_account_counter` with
-    // the `reserved_lamports: u64` a V1 account carried at the same offset.
+    (swig_key, id, creator, creator_role, state_pda, asset_pda)
+}
+
+/// As [`setup_v2_with_sub_account`], then rewrites the header's trailing `u64`
+/// so the account presents as V1.
+fn setup_then_downgrade(
+    context: &mut SwigTestContext,
+    reserved_lamports: u64,
+) -> (Pubkey, [u8; 32], Keypair, u32, Pubkey, Pubkey) {
+    let parts = setup_v2_with_sub_account(context);
+    let swig_key = parts.0;
+
+    // Overwrite `wallet_bump ++ _padding ++ sub_account_counter` with the
+    // `reserved_lamports: u64` a V1 account carried at the same offset.
     let mut account = context.svm.get_account(&swig_key).unwrap();
     account.data[WALLET_BUMP_OFFSET..WALLET_BUMP_OFFSET + 8]
         .copy_from_slice(&reserved_lamports.to_le_bytes());
     context.svm.set_account(swig_key, account).unwrap();
 
-    (swig_key, id, creator, creator_role, state_pda, asset_pda)
+    parts
 }
 
 #[test_log::test]
@@ -364,4 +377,163 @@ fn test_v1_swig_with_zero_low_byte_still_rejected() {
     .unwrap();
 
     assert_rejected_as_v1(send(&mut context, &creator, ix), "ToggleSubAccountV2");
+}
+
+/// `is_swig_v2` is a conjunction: non-zero bump **and** zeroed padding. This
+/// pins the second half. A header with the real wallet bump but dirty padding
+/// is not a shape the program writes, and the old `wallet_bump == 0` check
+/// would have waved it straight through.
+#[test_log::test]
+fn test_v2_header_with_dirty_padding_is_rejected() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _id, creator, creator_role, state_pda, _asset) =
+        setup_then_downgrade(&mut context, V1_RESERVE_NONZERO_LOW_BYTE);
+
+    // Restore the genuine wallet bump, then dirty only the padding.
+    let mut account = context.svm.get_account(&swig_key).unwrap();
+    let (_, wallet_bump) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig_key.as_ref()), &program_id());
+    account.data[WALLET_BUMP_OFFSET] = wallet_bump;
+    account.data[WALLET_BUMP_OFFSET + 1] = 0;
+    account.data[WALLET_BUMP_OFFSET + 2] = 1;
+    account.data[WALLET_BUMP_OFFSET + 3] = 0;
+    context.svm.set_account(swig_key, account).unwrap();
+
+    let ix = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        creator_role,
+        0,
+        false,
+    )
+    .unwrap();
+
+    assert_rejected_as_v1(send(&mut context, &creator, ix), "ToggleSubAccountV2");
+}
+
+/// An account too short to hold a Swig header must be rejected before
+/// `is_swig_v2` reads offset 40..44 -- that read is `unsafe` and assumes the
+/// length was checked. The program does own short accounts.
+#[test_log::test]
+fn test_swig_shorter_than_the_header_is_rejected() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _id, creator, creator_role, state_pda, _asset) =
+        setup_then_downgrade(&mut context, V1_RESERVE_NONZERO_LOW_BYTE);
+
+    // Keep a valid discriminator so the length guard is what stops us.
+    let mut account = context.svm.get_account(&swig_key).unwrap();
+    account.data.truncate(Swig::LEN - 1);
+    context.svm.set_account(swig_key, account).unwrap();
+
+    let ix = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        creator_role,
+        0,
+        false,
+    )
+    .unwrap();
+
+    match send(&mut context, &creator, ix) {
+        Ok(()) => panic!("a truncated swig must not be accepted"),
+        Err(TransactionError::InstructionError(_, InstructionError::Custom(code))) => {
+            assert_eq!(
+                code, ERR_INVALID_DISCRIMINATOR,
+                "expected the length guard to reject, got custom error {code}"
+            );
+        },
+        Err(other) => panic!("expected a custom program error, got {other:?}"),
+    }
+}
+
+/// Regression for the window `is_swig_v2` reads.
+///
+/// `sub_account_counter` sits in the four bytes above `_padding` and becomes
+/// non-zero the moment a V2 sub-account exists. An earlier version of the check
+/// read the last eight header bytes as one `u64`, which covered the counter --
+/// so creating a single sub-account flipped a healthy V2 wallet to being read as
+/// V1 and bricked every subsequent V2 instruction. Widening the window again
+/// must fail here.
+#[test_log::test]
+fn test_sub_account_counter_does_not_flip_swig_to_v1() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, id, creator, creator_role, state_pda, asset_pda) =
+        setup_v2_with_sub_account(&mut context);
+
+    // Drive the counter well past zero.
+    for subacc_id in 1..4u32 {
+        let (state, state_bump) = v2_state_pda(&id, subacc_id);
+        let (asset, asset_bump) = v2_asset_pda(&id, subacc_id);
+        let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+            swig_key,
+            creator.pubkey(),
+            creator.pubkey(),
+            state,
+            asset,
+            creator_role,
+            state_bump,
+            asset_bump,
+        )
+        .unwrap();
+        send(&mut context, &creator, ix).unwrap();
+    }
+
+    let counter = {
+        let data = context.svm.get_account(&swig_key).unwrap().data;
+        let swig = unsafe { Swig::load_unchecked(&data[..Swig::LEN]).unwrap() };
+        swig.sub_account_counter
+    };
+    assert_eq!(
+        counter, 4,
+        "counter must be non-zero for this to mean anything"
+    );
+
+    // Every runtime instruction must still see a V2 wallet. The asset PDA is
+    // already funded by the setup.
+    let recipient = Keypair::new();
+    let inner =
+        solana_system_interface::instruction::transfer(&asset_pda, &recipient.pubkey(), 1_000_000);
+    let sign = SubAccountSignV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        state_pda,
+        asset_pda,
+        creator.pubkey(),
+        creator_role,
+        0,
+        vec![inner],
+    )
+    .unwrap();
+    send(&mut context, &creator, sign).expect("sign must work with a non-zero counter");
+
+    let (wallet, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig_key.as_ref()), &program_id());
+    let withdraw = WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        wallet,
+        creator_role,
+        0,
+        1_000,
+    )
+    .unwrap();
+    send(&mut context, &creator, withdraw).expect("withdraw must work with a non-zero counter");
+
+    let toggle = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        creator_role,
+        0,
+        false,
+    )
+    .unwrap();
+    send(&mut context, &creator, toggle).expect("toggle must work with a non-zero counter");
 }

--- a/program/tests/sub_account_v2_version_guard_test.rs
+++ b/program/tests/sub_account_v2_version_guard_test.rs
@@ -1,0 +1,367 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! The V2 sub-account instructions must refuse a pre-wallet-address (V1) Swig.
+//!
+//! The guard used to be `swig.wallet_bump == 0`, which reads only byte 40. On a
+//! V1 account that byte is the low byte of `reserved_lamports`, and a
+//! rent-carrying balance leaves it non-zero — so the check accepted nearly every
+//! real V1 account. A mainnet census at the time of writing found 72 of 78 V1
+//! accounts slipping through. These tests pin the behaviour to `is_swig_v2`,
+//! which also requires the three padding bytes above the bump to be zero.
+mod common;
+
+use common::*;
+use solana_sdk::{
+    instruction::{Instruction, InstructionError},
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::{TransactionError, VersionedTransaction},
+};
+use swig_interface::{
+    AuthorityConfig, ClientAction, CreateSubAccountV2Instruction, SubAccountSignV2Instruction,
+    ToggleSubAccountV2Instruction, WithdrawFromSubAccountV2Instruction,
+};
+use swig_state::{
+    action::sub_account_v2::SubAccountV2Create,
+    authority::AuthorityType,
+    swig::{
+        sub_account_v2_asset_seeds, sub_account_v2_state_seeds, swig_wallet_address_seeds, Swig,
+        SwigWithRoles,
+    },
+    Transmutable,
+};
+
+/// `SwigError::SignV2CannotBeUsedWithSwigV1`. The program's `error` module is
+/// private to the crate, so the code is mirrored here.
+const ERR_V2_WITH_SWIG_V1: u32 = 47;
+
+/// Byte offset of `Swig::wallet_bump`; V1 stored `reserved_lamports: u64` here.
+const WALLET_BUMP_OFFSET: usize = 40;
+
+/// A real mainnet V1 reserve. Low byte is `0x80`, so the old `wallet_bump == 0`
+/// guard let it through; bytes above it are non-zero, so `is_swig_v2` rejects it.
+const V1_RESERVE_NONZERO_LOW_BYTE: u64 = 1_614_720;
+
+/// The rarer V1 reserve whose low byte is zero — the only shape the old guard
+/// caught. Must stay rejected.
+const V1_RESERVE_ZERO_LOW_BYTE: u64 = 3_786_240;
+
+fn role_id_of(context: &SwigTestContext, swig: &Pubkey, authority: &Pubkey) -> u32 {
+    let data = context.svm.get_account(swig).unwrap().data;
+    SwigWithRoles::from_bytes(&data)
+        .unwrap()
+        .lookup_role_id(authority.as_ref())
+        .unwrap()
+        .unwrap()
+}
+
+fn v2_state_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
+    let id_le = subacc_id.to_le_bytes();
+    Pubkey::find_program_address(&sub_account_v2_state_seeds(id, &id_le), &program_id())
+}
+
+fn v2_asset_pda(id: &[u8; 32], subacc_id: u32) -> (Pubkey, u8) {
+    let id_le = subacc_id.to_le_bytes();
+    Pubkey::find_program_address(&sub_account_v2_asset_seeds(id, &id_le), &program_id())
+}
+
+fn send(
+    context: &mut SwigTestContext,
+    payer: &Keypair,
+    ix: Instruction,
+) -> Result<(), TransactionError> {
+    let message =
+        v0::Message::try_compile(&payer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+            .unwrap();
+    let tx =
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[payer.insecure_clone()])
+            .unwrap();
+    context
+        .svm
+        .send_transaction(tx)
+        .map(|_| ())
+        .map_err(|e| e.err)
+}
+
+/// Asserts the transaction failed with `SignV2CannotBeUsedWithSwigV1` rather
+/// than merely failing — the V1 guard is easy to "pass" for the wrong reason.
+fn assert_rejected_as_v1(result: Result<(), TransactionError>, what: &str) {
+    match result {
+        Ok(()) => panic!("{what} must be rejected on a V1 swig, but it succeeded"),
+        Err(TransactionError::InstructionError(_, InstructionError::Custom(code))) => {
+            assert_eq!(
+                code, ERR_V2_WITH_SWIG_V1,
+                "{what} failed with custom error {code}, expected \
+                 SignV2CannotBeUsedWithSwigV1 ({ERR_V2_WITH_SWIG_V1})"
+            );
+        },
+        Err(other) => panic!("{what} failed with {other:?}, expected a custom program error"),
+    }
+}
+
+/// Builds a V2 swig with a creator role but *no* sub-account, then downgrades
+/// the header to V1. Leaving the counter unused means a create would draw id 0
+/// and its PDAs are still free — so without the guard the create genuinely
+/// succeeds, rather than reverting on a PDA mismatch.
+fn setup_v1_before_any_sub_account(
+    context: &mut SwigTestContext,
+    reserved_lamports: u64,
+) -> (Pubkey, [u8; 32], Keypair, u32) {
+    let root = Keypair::new();
+    let creator = Keypair::new();
+    context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&creator.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(context, &root, id).unwrap();
+    add_authority_with_ed25519_root(
+        context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: creator.pubkey().as_ref(),
+        },
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )
+    .unwrap();
+    let creator_role = role_id_of(context, &swig_key, &creator.pubkey());
+
+    let mut account = context.svm.get_account(&swig_key).unwrap();
+    account.data[WALLET_BUMP_OFFSET..WALLET_BUMP_OFFSET + 8]
+        .copy_from_slice(&reserved_lamports.to_le_bytes());
+    context.svm.set_account(swig_key, account).unwrap();
+
+    (swig_key, id, creator, creator_role)
+}
+
+/// Builds a V2 swig with one sub-account, then rewrites the header's trailing
+/// `u64` so the account presents as V1. Returns everything the runtime
+/// instructions need.
+fn setup_then_downgrade(
+    context: &mut SwigTestContext,
+    reserved_lamports: u64,
+) -> (Pubkey, [u8; 32], Keypair, u32, Pubkey, Pubkey) {
+    let root = Keypair::new();
+    let creator = Keypair::new();
+    context.svm.airdrop(&root.pubkey(), 10_000_000_000).unwrap();
+    context
+        .svm
+        .airdrop(&creator.pubkey(), 10_000_000_000)
+        .unwrap();
+
+    let id = rand::random::<[u8; 32]>();
+    let (swig_key, _) = create_swig_ed25519(context, &root, id).unwrap();
+    add_authority_with_ed25519_root(
+        context,
+        &swig_key,
+        &root,
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: creator.pubkey().as_ref(),
+        },
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )
+    .unwrap();
+    let creator_role = role_id_of(context, &swig_key, &creator.pubkey());
+
+    // Create sub-account 0 while the swig is still V2, so the state and asset
+    // accounts the runtime instructions need actually exist.
+    let (state_pda, state_bump) = v2_state_pda(&id, 0);
+    let (asset_pda, asset_bump) = v2_asset_pda(&id, 0);
+    let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        creator_role,
+        state_bump,
+        asset_bump,
+    )
+    .unwrap();
+    send(context, &creator, ix).unwrap();
+    context.svm.airdrop(&asset_pda, 1_000_000_000).unwrap();
+
+    // Downgrade: overwrite `wallet_bump ++ _padding ++ sub_account_counter` with
+    // the `reserved_lamports: u64` a V1 account carried at the same offset.
+    let mut account = context.svm.get_account(&swig_key).unwrap();
+    account.data[WALLET_BUMP_OFFSET..WALLET_BUMP_OFFSET + 8]
+        .copy_from_slice(&reserved_lamports.to_le_bytes());
+    context.svm.set_account(swig_key, account).unwrap();
+
+    (swig_key, id, creator, creator_role, state_pda, asset_pda)
+}
+
+#[test_log::test]
+fn test_v1_header_shape_is_what_the_old_guard_missed() {
+    // Guards the premise of these tests: this reserve leaves byte 40 non-zero,
+    // so `wallet_bump == 0` would not have fired.
+    let bytes = V1_RESERVE_NONZERO_LOW_BYTE.to_le_bytes();
+    assert_ne!(bytes[0], 0, "low byte must be non-zero to model the bypass");
+    assert!(
+        bytes[1..4].iter().any(|b| *b != 0),
+        "padding bytes must be non-zero for is_swig_v2 to reject"
+    );
+
+    // And the offset this test file pokes really is `wallet_bump`.
+    assert_eq!(WALLET_BUMP_OFFSET, core::mem::offset_of!(Swig, wallet_bump));
+    assert_eq!(Swig::LEN, 48);
+}
+
+#[test_log::test]
+fn test_create_sub_account_v2_rejects_v1_swig() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, id, creator, creator_role, ..) =
+        setup_then_downgrade(&mut context, V1_RESERVE_NONZERO_LOW_BYTE);
+
+    // A V1 header exposes no counter, so the id a create would draw is garbage;
+    // any id is fine here because the guard must fire before the draw.
+    let (state_pda, state_bump) = v2_state_pda(&id, 1);
+    let (asset_pda, asset_bump) = v2_asset_pda(&id, 1);
+    let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        creator_role,
+        state_bump,
+        asset_bump,
+    )
+    .unwrap();
+
+    assert_rejected_as_v1(send(&mut context, &creator, ix), "CreateSubAccountV2");
+}
+
+#[test_log::test]
+fn test_create_sub_account_v2_does_not_corrupt_a_v1_header() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, id, creator, creator_role) =
+        setup_v1_before_any_sub_account(&mut context, V1_RESERVE_NONZERO_LOW_BYTE);
+
+    let before = context.svm.get_account(&swig_key).unwrap().data
+        [WALLET_BUMP_OFFSET..WALLET_BUMP_OFFSET + 8]
+        .to_vec();
+
+    // Bytes 44..48 of this reserve are zero, so a create reads the counter as 0
+    // and draws id 0. Building for id 0 means the PDAs line up and nothing else
+    // can reject the instruction — only the version guard stands in the way.
+    let (state_pda, state_bump) = v2_state_pda(&id, 0);
+    let (asset_pda, asset_bump) = v2_asset_pda(&id, 0);
+    let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        creator_role,
+        state_bump,
+        asset_bump,
+    )
+    .unwrap();
+    assert_rejected_as_v1(send(&mut context, &creator, ix), "CreateSubAccountV2");
+
+    // Consuming an id writes `counter + 1` into bytes 44..48, which on a V1
+    // account silently adds 2^32 to reserved_lamports.
+    let after = context.svm.get_account(&swig_key).unwrap().data
+        [WALLET_BUMP_OFFSET..WALLET_BUMP_OFFSET + 8]
+        .to_vec();
+    assert_eq!(before, after, "V1 header must be left untouched");
+    assert!(
+        context.svm.get_account(&state_pda).is_none()
+            || context.svm.get_account(&state_pda).unwrap().owner != program_id(),
+        "no V2 state account may be created under a V1 swig"
+    );
+}
+
+#[test_log::test]
+fn test_sub_account_sign_v2_rejects_v1_swig() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _id, creator, creator_role, state_pda, asset_pda) =
+        setup_then_downgrade(&mut context, V1_RESERVE_NONZERO_LOW_BYTE);
+
+    let recipient = Keypair::new();
+    let inner = solana_system_interface::instruction::transfer(&asset_pda, &recipient.pubkey(), 1);
+    let ix = SubAccountSignV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        state_pda,
+        asset_pda,
+        creator.pubkey(),
+        creator_role,
+        0,
+        vec![inner],
+    )
+    .unwrap();
+
+    assert_rejected_as_v1(send(&mut context, &creator, ix), "SubAccountSignV2");
+}
+
+#[test_log::test]
+fn test_withdraw_from_sub_account_v2_rejects_v1_swig() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _id, creator, creator_role, state_pda, asset_pda) =
+        setup_then_downgrade(&mut context, V1_RESERVE_NONZERO_LOW_BYTE);
+
+    let (wallet, _) =
+        Pubkey::find_program_address(&swig_wallet_address_seeds(swig_key.as_ref()), &program_id());
+    let ix = WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        asset_pda,
+        wallet,
+        creator_role,
+        0,
+        1_000,
+    )
+    .unwrap();
+
+    assert_rejected_as_v1(send(&mut context, &creator, ix), "WithdrawFromSubAccountV2");
+}
+
+#[test_log::test]
+fn test_toggle_sub_account_v2_rejects_v1_swig() {
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _id, creator, creator_role, state_pda, _asset) =
+        setup_then_downgrade(&mut context, V1_RESERVE_NONZERO_LOW_BYTE);
+
+    let ix = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        creator_role,
+        0,
+        false,
+    )
+    .unwrap();
+
+    assert_rejected_as_v1(send(&mut context, &creator, ix), "ToggleSubAccountV2");
+}
+
+#[test_log::test]
+fn test_v1_swig_with_zero_low_byte_still_rejected() {
+    // The one shape the old guard did catch must keep being rejected.
+    let mut context = setup_test_context().unwrap();
+    let (swig_key, _id, creator, creator_role, state_pda, _asset) =
+        setup_then_downgrade(&mut context, V1_RESERVE_ZERO_LOW_BYTE);
+
+    let ix = ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+        swig_key,
+        creator.pubkey(),
+        creator.pubkey(),
+        state_pda,
+        creator_role,
+        0,
+        false,
+    )
+    .unwrap();
+
+    assert_rejected_as_v1(send(&mut context, &creator, ix), "ToggleSubAccountV2");
+}

--- a/program/tests/swig_realloc_stability_test.rs
+++ b/program/tests/swig_realloc_stability_test.rs
@@ -1,0 +1,272 @@
+#![cfg(not(feature = "program_scope_test"))]
+//! Combination realloc-stability test.
+//!
+//! A wallet with multiple roles and a rent claimer, driven through every swig
+//! account **size-modifying** instruction — add authority, update authority
+//! (grow and shrink), create V2 sub-account, remove authority. After each op the
+//! *unrelated* roles and the rent-claimer tail must survive byte-for-byte, and
+//! the rent claimer must never change. Built on the reusable `common::stability`
+//! harness so this kind of test needs no bespoke decode/compare boilerplate.
+
+mod common;
+
+use common::{
+    stability::{scoped_v2_body, SwigSnapshot},
+    *,
+};
+use solana_sdk::{
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+use swig_interface::{AuthorityConfig, ClientAction, CreateSubAccountV2Instruction};
+use swig_state::{
+    action::{
+        manage_authority::ManageAuthority,
+        sol_limit::SolLimit,
+        sub_account_v2::{
+            SubAccountV2All, SubAccountV2Create, SubAccountV2Sign, SubAccountV2Toggle,
+            SubAccountV2Withdraw,
+        },
+        Permission,
+    },
+    authority::AuthorityType,
+    swig::{sub_account_v2_asset_seeds, sub_account_v2_state_seeds, SwigWithRoles},
+};
+
+fn ed(authority: &Pubkey) -> AuthorityConfig<'_> {
+    AuthorityConfig {
+        authority_type: AuthorityType::Ed25519,
+        authority: authority.as_ref(),
+    }
+}
+
+fn fund(context: &mut SwigTestContext, kp: &Keypair) {
+    context.svm.airdrop(&kp.pubkey(), 100_000_000_000).unwrap();
+}
+
+fn role_id(context: &SwigTestContext, swig: &Pubkey, authority: &Pubkey) -> u32 {
+    let data = context.svm.get_account(swig).unwrap().data;
+    SwigWithRoles::from_bytes(&data)
+        .unwrap()
+        .lookup_role_id(authority.as_ref())
+        .unwrap()
+        .unwrap()
+}
+
+/// Sends a `CreateSubAccountV2` signed by `signer`, which must hold
+/// `SubAccountV2Create` on `role`.
+fn create_v2(
+    context: &mut SwigTestContext,
+    swig: &Pubkey,
+    signer: &Keypair,
+    role: u32,
+    id: &[u8; 32],
+    subacc_id: u32,
+) {
+    let id_le = subacc_id.to_le_bytes();
+    let (state_pda, state_bump) =
+        Pubkey::find_program_address(&sub_account_v2_state_seeds(id, &id_le), &program_id());
+    let (asset_pda, asset_bump) =
+        Pubkey::find_program_address(&sub_account_v2_asset_seeds(id, &id_le), &program_id());
+    let ix = CreateSubAccountV2Instruction::new_with_ed25519_authority(
+        *swig,
+        signer.pubkey(),
+        signer.pubkey(),
+        state_pda,
+        asset_pda,
+        role,
+        state_bump,
+        asset_bump,
+    )
+    .unwrap();
+    let msg =
+        v0::Message::try_compile(&signer.pubkey(), &[ix], &[], context.svm.latest_blockhash())
+            .unwrap();
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &[signer.insecure_clone()])
+        .unwrap();
+    context
+        .svm
+        .send_transaction(tx)
+        .expect("create_sub_account_v2 failed");
+}
+
+#[test]
+fn test_realloc_stability_with_rent_claimer_and_multiple_roles() {
+    let mut context = setup_test_context().unwrap();
+
+    // Role 0: root (All).
+    let root = Keypair::new();
+    fund(&mut context, &root);
+    let id = rand::random::<[u8; 32]>();
+    let (swig, _) = create_swig_ed25519(&mut context, &root, id).unwrap();
+
+    // Role 1: the creator (SubAccountV2Create) — a middle role once 2 & 3 exist.
+    let creator = Keypair::new();
+    fund(&mut context, &creator);
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed(&creator.pubkey()),
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )
+    .unwrap();
+
+    // Role 2: two permissions — the untouched witness throughout the whole run.
+    let role2 = Keypair::new();
+    fund(&mut context, &role2);
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed(&role2.pubkey()),
+        vec![
+            ClientAction::ManageAuthority(ManageAuthority {}),
+            ClientAction::SolLimit(SolLimit { amount: 111 }),
+        ],
+    )
+    .unwrap();
+
+    // Role 3: four permissions (varied scoped V2 types, distinct ids).
+    let role3 = Keypair::new();
+    fund(&mut context, &role3);
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed(&role3.pubkey()),
+        vec![
+            ClientAction::SubAccountV2Create(SubAccountV2Create),
+            ClientAction::SubAccountV2All(SubAccountV2All::new(201)),
+            ClientAction::SubAccountV2Withdraw(SubAccountV2Withdraw::new(202)),
+            ClientAction::SubAccountV2Toggle(SubAccountV2Toggle::new(203)),
+        ],
+    )
+    .unwrap();
+
+    // Set the rent claimer (grows the tail), signed by root.
+    let claimer = Keypair::new().pubkey();
+    set_rent_claimer_with_ed25519(&mut context, &swig, &root, 0, claimer).unwrap();
+
+    let id_creator = creator.pubkey().to_bytes();
+    let id_r3 = role3.pubkey().to_bytes();
+
+    let s = SwigSnapshot::capture(&context, &swig);
+    assert_eq!(s.roles.len(), 4, "root + 3 roles");
+    assert_eq!(
+        s.rent_claimer,
+        Some(claimer.to_bytes()),
+        "rent claimer must be set"
+    );
+
+    // === 1) ADD AUTHORITY (grow): add role 4; no existing role changes. ===
+    let role4 = Keypair::new();
+    fund(&mut context, &role4);
+    add_authority_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        ed(&role4.pubkey()),
+        vec![ClientAction::SolLimit(SolLimit { amount: 5 })],
+    )
+    .unwrap();
+    let id_r4 = role4.pubkey().to_bytes();
+    let after = SwigSnapshot::capture(&context, &swig);
+    s.assert_others_stable(&after, &[]);
+    assert!(
+        after.role_by_identity(&id_r4).is_some(),
+        "role 4 should exist"
+    );
+    assert!(
+        after.account_len > s.account_len,
+        "add authority should grow the account"
+    );
+    let s = after;
+
+    // === 2) UPDATE AUTHORITY (grow role 4): replace 1 action with 3. ===
+    let r4_id = role_id(&context, &swig, &role4.pubkey());
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        r4_id,
+        vec![
+            ClientAction::SolLimit(SolLimit { amount: 5 }),
+            ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(300)),
+            ClientAction::SubAccountV2Toggle(SubAccountV2Toggle::new(301)),
+        ],
+    )
+    .unwrap();
+    let after = SwigSnapshot::capture(&context, &swig);
+    s.assert_others_stable(&after, &[id_r4]);
+    assert_eq!(
+        after.actions_of(&id_r4).len(),
+        3,
+        "role 4 should hold 3 actions"
+    );
+    let s = after;
+
+    // === 3) CREATE SUB-ACCOUNT V2 by the creator (MIDDLE role): appends
+    //         SubAccountV2All{0} and reallocs, shifting roles 2, 3, 4. ===
+    let creator_role = role_id(&context, &swig, &creator.pubkey());
+    create_v2(&mut context, &swig, &creator, creator_role, &id, 0);
+    let after = SwigSnapshot::capture(&context, &swig);
+    s.assert_others_stable(&after, &[id_creator]);
+    assert_eq!(after.counter, s.counter + 1, "counter must advance");
+    let mut expected_creator = s.actions_of(&id_creator).clone();
+    expected_creator.push((Permission::SubAccountV2All, scoped_v2_body(0)));
+    assert_eq!(
+        after.actions_of(&id_creator),
+        &expected_creator,
+        "creator must gain exactly SubAccountV2All{{0}}"
+    );
+    let s = after;
+
+    // === 4) UPDATE AUTHORITY (shrink role 3): 4 actions -> 1. ===
+    let r3_id = role_id(&context, &swig, &role3.pubkey());
+    update_authority_replace_with_ed25519_root(
+        &mut context,
+        &swig,
+        &root,
+        r3_id,
+        vec![ClientAction::SubAccountV2Create(SubAccountV2Create)],
+    )
+    .unwrap();
+    let after = SwigSnapshot::capture(&context, &swig);
+    s.assert_others_stable(&after, &[id_r3]);
+    assert_eq!(
+        after.actions_of(&id_r3).len(),
+        1,
+        "role 3 should shrink to 1 action"
+    );
+    assert!(
+        after.account_len < s.account_len,
+        "shrinking a role should shrink the account"
+    );
+    let s = after;
+
+    // === 5) REMOVE AUTHORITY (shrink): remove role 4 entirely. ===
+    let r4_id = role_id(&context, &swig, &role4.pubkey());
+    remove_authority_with_ed25519_root(&mut context, &swig, &root, r4_id).unwrap();
+    let after = SwigSnapshot::capture(&context, &swig);
+    s.assert_others_stable(&after, &[id_r4]);
+    assert!(
+        after.role_by_identity(&id_r4).is_none(),
+        "role 4 should be gone"
+    );
+    let s = after;
+
+    // === 6) CREATE another sub-account — the creator still works after all the
+    //         grows, shrinks, and the removal that shuffled the buffer. ===
+    let creator_role = role_id(&context, &swig, &creator.pubkey());
+    create_v2(&mut context, &swig, &creator, creator_role, &id, 1);
+    let after = SwigSnapshot::capture(&context, &swig);
+    s.assert_others_stable(&after, &[id_creator]);
+    assert_eq!(after.counter, 2, "second create advances the counter");
+
+    // The rent claimer survived every realloc, byte-for-byte.
+    assert_eq!(after.rent_claimer, Some(claimer.to_bytes()));
+}


### PR DESCRIPTION
## Summary

Program-crate implementation of **SubAccount V2**, plus the interface instruction builders and the program-level tests (the tests import the builders, so they live in the same PR).

### program
Four new instructions (discriminants 18–21; the historical gap at 8 is left unused) and their handlers. **Authorization is default-deny** — the runtime handlers consult only scoped V2 actions; wallet-level `All` / `ManageAuthority` / `AllButManageAuthority` never grant Sign/Withdraw/Toggle/Create.

- **CreateSubAccountV2**: draws a fresh id from the header counter, inits the program-owned state PDA + system-owned asset PDA, then auto-grants the creator `SubAccountV2All { id }` via a shared, tail-preserving append helper. Requires an explicit `SubAccountV2Create` action — `All` alone is denied.
- **SubAccountSignV2**: CPIs as the asset PDA (`invoke_signed`), gated by `SubAccountV2Sign` / `All`; keeps the no-CPI stack-height guard. Swig is writable because Secp authorities record their odometer in the swig account during auth.
- **WithdrawFromSubAccountV2**: SOL/SPL to `swig_wallet_address` only, gated by `SubAccountV2Withdraw` / `All`.
- **ToggleSubAccountV2**: flips the state account's enabled kill-switch, gated by `SubAccountV2Toggle` / `All`.
- All handlers require the wallet-address Swig generation (`wallet_bump != 0`). IDL regenerated.

### interface
Five `ClientAction` variants + instruction builders for all four V2 instructions with **Ed25519, Secp256k1, and Secp256r1** authority variants (mirrors the V1 builders).

### tests (litesvm)
- `sub_account_v2_test.rs` (7): create / multi-create / SOL withdraw / toggle-disable / CPI sign / All-denied-create.
- `sub_account_v2_matrix_test.rs` (13): the normative auth matrix — overrides denied for every runtime op; sign/withdraw/toggle-only scopes; id-scoping of the `All` umbrella; cross-role sharing; self-grant recovery; atomic role-deletion; V1/V2 seed non-collision; duplicate rejection.

## Test
```
cargo build-sbf --arch v1
cargo test -p swig --test sub_account_v2_test --test sub_account_v2_matrix_test   # 20
cargo test -p swig   # V1 regression stays green
```

## Stack
1. #187 — state data model (base `main`)
2. **this PR** — program + interface builders + program tests (base #187)
3. #189 — rust-sdk V2 + SDK integration tests (base this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
