### PR TITLE
SubAccount V2 (3/3): rust-sdk V2 + SDK integration tests

### DIFF
--- a/rust-sdk/src/client_role.rs
+++ b/rust-sdk/src/client_role.rs
@@ -1,9 +1,11 @@
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use swig_interface::{
     AddAuthorityInstruction, AuthorityConfig, ClientAction, CreateSessionInstruction,
-    CreateSubAccountInstruction, RemoveAuthorityInstruction, SetRentClaimerV1Instruction,
-    SignV2Instruction, SubAccountSignInstruction, ToggleSubAccountInstruction, UpdateAuthorityData,
-    UpdateAuthorityInstruction, WithdrawFromSubAccountInstruction,
+    CreateSubAccountInstruction, CreateSubAccountV2Instruction, RemoveAuthorityInstruction,
+    SetRentClaimerV1Instruction, SignV2Instruction, SubAccountSignInstruction,
+    SubAccountSignV2Instruction, ToggleSubAccountInstruction, ToggleSubAccountV2Instruction,
+    UpdateAuthorityData, UpdateAuthorityInstruction, WithdrawFromSubAccountInstruction,
+    WithdrawFromSubAccountV2Instruction,
 };
 use swig_state::{
     authority::{
@@ -129,6 +131,77 @@ pub trait ClientRole {
         rent_claimer: Pubkey,
         current_slot: Option<u64>,
     ) -> Result<Vec<Instruction>, SwigError>;
+
+    /// Creates a V2 create-sub-account instruction. `sub_account_state` and
+    /// `sub_account` are the (already derived) state and asset PDAs for the next
+    /// sub-account id.
+    ///
+    /// Defaults to unsupported; authority types that support V2 override this.
+    fn create_sub_account_v2_instruction(
+        &self,
+        _swig_account: Pubkey,
+        _payer: Pubkey,
+        _role_id: u32,
+        _sub_account_state: Pubkey,
+        _sub_account: Pubkey,
+        _state_bump: u8,
+        _asset_bump: u8,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Err(SwigError::InterfaceError(
+            "V2 sub-accounts not supported for this authority type".to_string(),
+        ))
+    }
+
+    /// Creates a V2 sub-account sign instruction.
+    fn sub_account_sign_v2_instruction(
+        &self,
+        _swig_account: Pubkey,
+        _sub_account_state: Pubkey,
+        _sub_account: Pubkey,
+        _role_id: u32,
+        _subacc_id: u32,
+        _instructions: Vec<Instruction>,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Err(SwigError::InterfaceError(
+            "V2 sub-accounts not supported for this authority type".to_string(),
+        ))
+    }
+
+    /// Creates a V2 withdraw-from-sub-account instruction (SOL, to the swig
+    /// wallet address).
+    fn withdraw_from_sub_account_v2_instruction(
+        &self,
+        _swig_account: Pubkey,
+        _payer: Pubkey,
+        _sub_account_state: Pubkey,
+        _sub_account: Pubkey,
+        _role_id: u32,
+        _subacc_id: u32,
+        _amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Err(SwigError::InterfaceError(
+            "V2 sub-accounts not supported for this authority type".to_string(),
+        ))
+    }
+
+    /// Creates a V2 toggle-sub-account instruction.
+    fn toggle_sub_account_v2_instruction(
+        &self,
+        _swig_account: Pubkey,
+        _payer: Pubkey,
+        _sub_account_state: Pubkey,
+        _auth_role_id: u32,
+        _subacc_id: u32,
+        _enabled: bool,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Err(SwigError::InterfaceError(
+            "V2 sub-accounts not supported for this authority type".to_string(),
+        ))
+    }
 
     /// Returns the authority type
     fn authority_type(&self) -> AuthorityType;
@@ -393,6 +466,107 @@ impl ClientRole for Ed25519ClientRole {
                 self.authority,
                 role_id,
                 rent_claimer.to_bytes(),
+            )?,
+        ])
+    }
+
+    fn create_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        state_bump: u8,
+        asset_bump: u8,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Ok(vec![
+            CreateSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                self.authority,
+                payer,
+                sub_account_state,
+                sub_account,
+                role_id,
+                state_bump,
+                asset_bump,
+            )?,
+        ])
+    }
+
+    fn sub_account_sign_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Ok(vec![
+            SubAccountSignV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                sub_account_state,
+                sub_account,
+                self.authority,
+                role_id,
+                subacc_id,
+                instructions,
+            )?,
+        ])
+    }
+
+    fn withdraw_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                self.authority,
+                payer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn toggle_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Ok(vec![
+            ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                self.authority,
+                payer,
+                sub_account_state,
+                auth_role_id,
+                subacc_id,
+                enabled,
             )?,
         ])
     }
@@ -736,6 +910,123 @@ impl ClientRole for Secp256k1ClientRole {
                 new_odometer,
                 role_id,
                 rent_claimer.to_bytes(),
+            )?,
+        ])
+    }
+
+    fn create_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        state_bump: u8,
+        asset_bump: u8,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        Ok(vec![
+            CreateSubAccountV2Instruction::new_with_secp256k1_authority(
+                swig_account,
+                payer,
+                &self.signing_fn,
+                current_slot,
+                new_odometer,
+                sub_account_state,
+                sub_account,
+                role_id,
+                state_bump,
+                asset_bump,
+            )?,
+        ])
+    }
+
+    fn sub_account_sign_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        Ok(vec![
+            SubAccountSignV2Instruction::new_with_secp256k1_authority(
+                swig_account,
+                sub_account_state,
+                sub_account,
+                &self.signing_fn,
+                current_slot,
+                new_odometer,
+                role_id,
+                subacc_id,
+                instructions,
+            )?,
+        ])
+    }
+
+    fn withdraw_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_with_secp256k1_authority(
+                swig_account,
+                payer,
+                &self.signing_fn,
+                current_slot,
+                new_odometer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn toggle_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        Ok(vec![
+            ToggleSubAccountV2Instruction::new_with_secp256k1_authority(
+                swig_account,
+                payer,
+                &self.signing_fn,
+                current_slot,
+                new_odometer,
+                sub_account_state,
+                auth_role_id,
+                subacc_id,
+                enabled,
             )?,
         ])
     }
@@ -1119,6 +1410,121 @@ impl ClientRole for Secp256r1ClientRole {
         )?)
     }
 
+    fn create_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        state_bump: u8,
+        asset_bump: u8,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        Ok(CreateSubAccountV2Instruction::new_with_secp256r1_authority(
+            swig_account,
+            payer,
+            &self.signing_fn,
+            current_slot,
+            new_odometer,
+            sub_account_state,
+            sub_account,
+            role_id,
+            state_bump,
+            asset_bump,
+            &self.authority,
+        )?)
+    }
+
+    fn sub_account_sign_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        Ok(SubAccountSignV2Instruction::new_with_secp256r1_authority(
+            swig_account,
+            sub_account_state,
+            sub_account,
+            &self.signing_fn,
+            current_slot,
+            new_odometer,
+            role_id,
+            subacc_id,
+            instructions,
+            &self.authority,
+        )?)
+    }
+
+    fn withdraw_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(
+            WithdrawFromSubAccountV2Instruction::new_with_secp256r1_authority(
+                swig_account,
+                payer,
+                &self.signing_fn,
+                current_slot,
+                new_odometer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+                &self.authority,
+            )?,
+        )
+    }
+
+    fn toggle_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        Ok(ToggleSubAccountV2Instruction::new_with_secp256r1_authority(
+            swig_account,
+            payer,
+            &self.signing_fn,
+            current_slot,
+            new_odometer,
+            sub_account_state,
+            auth_role_id,
+            subacc_id,
+            enabled,
+            &self.authority,
+        )?)
+    }
+
     fn authority_type(&self) -> AuthorityType {
         AuthorityType::Secp256r1
     }
@@ -1426,6 +1832,111 @@ impl ClientRole for Ed25519SessionClientRole {
                 session_key,
                 role_id,
                 rent_claimer.to_bytes(),
+            )?,
+        ])
+    }
+
+    fn create_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        state_bump: u8,
+        asset_bump: u8,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            CreateSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                role_id,
+                state_bump,
+                asset_bump,
+            )?,
+        ])
+    }
+
+    fn sub_account_sign_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            SubAccountSignV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                sub_account_state,
+                sub_account,
+                session_key,
+                role_id,
+                subacc_id,
+                instructions,
+            )?,
+        ])
+    }
+
+    fn withdraw_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn toggle_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                auth_role_id,
+                subacc_id,
+                enabled,
             )?,
         ])
     }
@@ -1764,6 +2275,111 @@ impl ClientRole for Secp256k1SessionClientRole {
                 session_key,
                 role_id,
                 rent_claimer.to_bytes(),
+            )?,
+        ])
+    }
+
+    fn create_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        state_bump: u8,
+        asset_bump: u8,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            CreateSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                role_id,
+                state_bump,
+                asset_bump,
+            )?,
+        ])
+    }
+
+    fn sub_account_sign_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            SubAccountSignV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                sub_account_state,
+                sub_account,
+                session_key,
+                role_id,
+                subacc_id,
+                instructions,
+            )?,
+        ])
+    }
+
+    fn withdraw_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn toggle_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                auth_role_id,
+                subacc_id,
+                enabled,
             )?,
         ])
     }
@@ -2107,6 +2723,111 @@ impl ClientRole for Secp256r1SessionClientRole {
                 session_key,
                 role_id,
                 rent_claimer.to_bytes(),
+            )?,
+        ])
+    }
+
+    fn create_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        role_id: u32,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        state_bump: u8,
+        asset_bump: u8,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            CreateSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                role_id,
+                state_bump,
+                asset_bump,
+            )?,
+        ])
+    }
+
+    fn sub_account_sign_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            SubAccountSignV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                sub_account_state,
+                sub_account,
+                session_key,
+                role_id,
+                subacc_id,
+                instructions,
+            )?,
+        ])
+    }
+
+    fn withdraw_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn toggle_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        auth_role_id: u32,
+        subacc_id: u32,
+        enabled: bool,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        Ok(vec![
+            ToggleSubAccountV2Instruction::new_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                auth_role_id,
+                subacc_id,
+                enabled,
             )?,
         ])
     }

--- a/rust-sdk/src/client_role.rs
+++ b/rust-sdk/src/client_role.rs
@@ -187,6 +187,28 @@ pub trait ClientRole {
         ))
     }
 
+    /// Creates a V2 token withdrawal with the token accounts included in the
+    /// authenticated account list.
+    #[allow(clippy::too_many_arguments)]
+    fn withdraw_token_from_sub_account_v2_instruction(
+        &self,
+        _swig_account: Pubkey,
+        _payer: Pubkey,
+        _sub_account_state: Pubkey,
+        _sub_account: Pubkey,
+        _source_token: Pubkey,
+        _destination_token: Pubkey,
+        _token_program: Pubkey,
+        _role_id: u32,
+        _subacc_id: u32,
+        _amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        Err(SwigError::InterfaceError(
+            "V2 sub-accounts not supported for this authority type".to_string(),
+        ))
+    }
+
     /// Creates a V2 toggle-sub-account instruction.
     fn toggle_sub_account_v2_instruction(
         &self,
@@ -541,6 +563,42 @@ impl ClientRole for Ed25519ClientRole {
                 sub_account_state,
                 sub_account,
                 swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn withdraw_token_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_token_with_ed25519_authority(
+                swig_account,
+                self.authority,
+                payer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                source_token,
+                destination_token,
+                token_program,
                 role_id,
                 subacc_id,
                 amount,
@@ -997,6 +1055,46 @@ impl ClientRole for Secp256k1ClientRole {
                 sub_account_state,
                 sub_account,
                 swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn withdraw_token_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_token_with_secp256k1_authority(
+                swig_account,
+                payer,
+                &self.signing_fn,
+                current_slot,
+                new_odometer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                source_token,
+                destination_token,
+                token_program,
                 role_id,
                 subacc_id,
                 amount,
@@ -1491,6 +1589,47 @@ impl ClientRole for Secp256r1ClientRole {
                 sub_account_state,
                 sub_account,
                 swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+                &self.authority,
+            )?,
+        )
+    }
+
+    fn withdraw_token_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let current_slot = current_slot.ok_or(SwigError::CurrentSlotNotSet)?;
+        let new_odometer = self.odometer.wrapping_add(1);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(
+            WithdrawFromSubAccountV2Instruction::new_token_with_secp256r1_authority(
+                swig_account,
+                payer,
+                &self.signing_fn,
+                current_slot,
+                new_odometer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                source_token,
+                destination_token,
+                token_program,
                 role_id,
                 subacc_id,
                 amount,

--- a/rust-sdk/src/client_role.rs
+++ b/rust-sdk/src/client_role.rs
@@ -133,8 +133,8 @@ pub trait ClientRole {
     ) -> Result<Vec<Instruction>, SwigError>;
 
     /// Creates a V2 create-sub-account instruction. `sub_account_state` and
-    /// `sub_account` are the (already derived) state and asset PDAs for the next
-    /// sub-account id.
+    /// `sub_account` are the (already derived) state and asset PDAs for the
+    /// next sub-account id.
     ///
     /// Defaults to unsupported; authority types that support V2 override this.
     fn create_sub_account_v2_instruction(
@@ -2056,6 +2056,43 @@ impl ClientRole for Ed25519SessionClientRole {
         ])
     }
 
+    fn withdraw_token_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_token_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                source_token,
+                destination_token,
+                token_program,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
     fn toggle_sub_account_v2_instruction(
         &self,
         swig_account: Pubkey,
@@ -2492,6 +2529,43 @@ impl ClientRole for Secp256k1SessionClientRole {
                 sub_account_state,
                 sub_account,
                 swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn withdraw_token_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_token_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                source_token,
+                destination_token,
+                token_program,
                 role_id,
                 subacc_id,
                 amount,
@@ -2940,6 +3014,43 @@ impl ClientRole for Secp256r1SessionClientRole {
                 sub_account_state,
                 sub_account,
                 swig_wallet_address,
+                role_id,
+                subacc_id,
+                amount,
+            )?,
+        ])
+    }
+
+    fn withdraw_token_from_sub_account_v2_instruction(
+        &self,
+        swig_account: Pubkey,
+        payer: Pubkey,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        role_id: u32,
+        subacc_id: u32,
+        amount: u64,
+        _current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let session_key = Pubkey::new_from_array(self.session_authority.session_key);
+        let (swig_wallet_address, _) = Pubkey::find_program_address(
+            &swig_state::swig::swig_wallet_address_seeds(swig_account.as_ref()),
+            &swig_interface::program_id(),
+        );
+        Ok(vec![
+            WithdrawFromSubAccountV2Instruction::new_token_with_ed25519_authority(
+                swig_account,
+                session_key,
+                payer,
+                sub_account_state,
+                sub_account,
+                swig_wallet_address,
+                source_token,
+                destination_token,
+                token_program,
                 role_id,
                 subacc_id,
                 amount,

--- a/rust-sdk/src/instruction_builder.rs
+++ b/rust-sdk/src/instruction_builder.rs
@@ -10,7 +10,10 @@ use swig_state::{
         ed25519::CreateEd25519SessionAuthority, secp256k1::CreateSecp256k1SessionAuthority,
         secp256r1::CreateSecp256r1SessionAuthority, AuthorityType,
     },
-    swig::{sub_account_seeds, swig_account_seeds, swig_wallet_address_seeds},
+    swig::{
+        sub_account_seeds, sub_account_v2_asset_seeds, sub_account_v2_state_seeds,
+        swig_account_seeds, swig_wallet_address_seeds,
+    },
     IntoBytes,
 };
 
@@ -542,6 +545,102 @@ impl SwigInstructionBuilder {
             sub_account,
             sub_account_role_id,
             auth_role_id,
+            enabled,
+            current_slot,
+        )
+    }
+
+    /// Derives the V2 state and asset PDAs for a sub-account id.
+    pub fn sub_account_v2_pdas(&self, subacc_id: u32) -> (Pubkey, Pubkey) {
+        let id_le = subacc_id.to_le_bytes();
+        let (state, _) = Pubkey::find_program_address(
+            &sub_account_v2_state_seeds(&self.swig_id, &id_le),
+            &swig_interface::program_id(),
+        );
+        let (asset, _) = Pubkey::find_program_address(
+            &sub_account_v2_asset_seeds(&self.swig_id, &id_le),
+            &swig_interface::program_id(),
+        );
+        (state, asset)
+    }
+
+    /// Creates instructions to create a V2 sub-account for the given id (the
+    /// next value of the on-chain counter). The caller supplies the derived
+    /// state/asset PDAs and their bumps.
+    pub fn create_sub_account_v2(
+        &self,
+        sub_account_state: Pubkey,
+        sub_account: Pubkey,
+        state_bump: u8,
+        asset_bump: u8,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        self.client_role.create_sub_account_v2_instruction(
+            self.swig_account,
+            self.payer,
+            self.role_id,
+            sub_account_state,
+            sub_account,
+            state_bump,
+            asset_bump,
+            current_slot,
+        )
+    }
+
+    /// Creates instructions to sign as a V2 sub-account.
+    pub fn sign_instruction_with_sub_account_v2(
+        &self,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let (sub_account_state, sub_account) = self.sub_account_v2_pdas(subacc_id);
+        self.client_role.sub_account_sign_v2_instruction(
+            self.swig_account,
+            sub_account_state,
+            sub_account,
+            self.role_id,
+            subacc_id,
+            instructions,
+            current_slot,
+        )
+    }
+
+    /// Creates instructions to withdraw SOL from a V2 sub-account to the swig
+    /// wallet address.
+    pub fn withdraw_from_sub_account_v2(
+        &self,
+        subacc_id: u32,
+        amount: u64,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let (sub_account_state, sub_account) = self.sub_account_v2_pdas(subacc_id);
+        self.client_role.withdraw_from_sub_account_v2_instruction(
+            self.swig_account,
+            self.payer,
+            sub_account_state,
+            sub_account,
+            self.role_id,
+            subacc_id,
+            amount,
+            current_slot,
+        )
+    }
+
+    /// Creates instructions to toggle a V2 sub-account's enabled kill-switch.
+    pub fn toggle_sub_account_v2(
+        &self,
+        subacc_id: u32,
+        enabled: bool,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let (sub_account_state, _) = self.sub_account_v2_pdas(subacc_id);
+        self.client_role.toggle_sub_account_v2_instruction(
+            self.swig_account,
+            self.payer,
+            sub_account_state,
+            self.role_id,
+            subacc_id,
             enabled,
             current_slot,
         )

--- a/rust-sdk/src/instruction_builder.rs
+++ b/rust-sdk/src/instruction_builder.rs
@@ -627,6 +627,34 @@ impl SwigInstructionBuilder {
         )
     }
 
+    /// Creates instructions to withdraw tokens from a V2 sub-account to a
+    /// token account owned by the swig wallet address.
+    pub fn withdraw_token_from_sub_account_v2(
+        &self,
+        subacc_id: u32,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        amount: u64,
+        current_slot: Option<u64>,
+    ) -> Result<Vec<Instruction>, SwigError> {
+        let (sub_account_state, sub_account) = self.sub_account_v2_pdas(subacc_id);
+        self.client_role
+            .withdraw_token_from_sub_account_v2_instruction(
+                self.swig_account,
+                self.payer,
+                sub_account_state,
+                sub_account,
+                source_token,
+                destination_token,
+                token_program,
+                self.role_id,
+                subacc_id,
+                amount,
+                current_slot,
+            )
+    }
+
     /// Creates instructions to toggle a V2 sub-account's enabled kill-switch.
     pub fn toggle_sub_account_v2(
         &self,

--- a/rust-sdk/src/tests/wallet/helper_tests.rs
+++ b/rust-sdk/src/tests/wallet/helper_tests.rs
@@ -139,7 +139,6 @@ fn should_get_current_slot() {
     let swig_wallet = create_test_wallet(litesvm, &main_authority);
 
     let slot = swig_wallet.get_current_slot().unwrap();
-    assert!(slot >= 0); // Slot can be 0 in test environment
     println!("Current slot: {}", slot);
 }
 

--- a/rust-sdk/src/tests/wallet/mod.rs
+++ b/rust-sdk/src/tests/wallet/mod.rs
@@ -10,6 +10,7 @@ pub mod secp_tests;
 pub mod session_tests;
 pub mod sign_v2_tests;
 pub mod sub_accounts_test;
+pub mod sub_accounts_v2_test;
 
 use alloy_primitives::B256;
 use alloy_signer::SignerSync;

--- a/rust-sdk/src/tests/wallet/sub_accounts_v2_test.rs
+++ b/rust-sdk/src/tests/wallet/sub_accounts_v2_test.rs
@@ -2,11 +2,18 @@
 use alloy_primitives::B256;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use solana_sdk::signature::{Keypair, Signer};
-use swig_state::{authority::AuthorityType, swig::sub_account_v2_asset_seeds};
+use solana_sdk::{
+    account::Account,
+    program_pack::Pack,
+    signature::{Keypair, Signer},
+};
+use swig_state::{
+    authority::AuthorityType,
+    swig::{sub_account_v2_asset_seeds, sub_account_v2_state_seeds},
+};
 
 use super::*;
-use crate::client_role::{Ed25519ClientRole, Secp256k1ClientRole};
+use crate::client_role::{Ed25519ClientRole, Secp256k1ClientRole, Secp256r1ClientRole};
 
 /// Adds a creator authority (SubAccountV2Create), switches to it, and creates a
 /// V2 sub-account. Returns (secondary_keypair, subacc_id, asset_pda).
@@ -33,6 +40,30 @@ fn create_v2_setup<'a>(swig_wallet: &mut SwigWallet<'a>, secondary: &'a Keypair)
     (subacc_id, asset)
 }
 
+fn setup_v2_tokens(
+    swig_wallet: &mut SwigWallet<'_>,
+    payer: &Keypair,
+    asset: &Pubkey,
+    amount: u64,
+) -> (Pubkey, Pubkey) {
+    use crate::tests::common::{mint_to, setup_ata, setup_mint};
+
+    let mint = setup_mint(swig_wallet.litesvm(), payer).unwrap();
+    let source_token = setup_ata(swig_wallet.litesvm(), &mint, asset, payer).unwrap();
+    let wallet_address = swig_wallet.get_swig_wallet_address().unwrap();
+    let destination_token =
+        setup_ata(swig_wallet.litesvm(), &mint, &wallet_address, payer).unwrap();
+    mint_to(swig_wallet.litesvm(), &mint, payer, &source_token, amount).unwrap();
+    (source_token, destination_token)
+}
+
+fn token_balance(swig_wallet: &mut SwigWallet<'_>, token_account: &Pubkey) -> u64 {
+    let account = swig_wallet.litesvm().get_account(token_account).unwrap();
+    spl_token::state::Account::unpack(&account.data)
+        .unwrap()
+        .amount
+}
+
 #[test_log::test]
 fn test_v2_creation_and_counter() {
     let (litesvm, main_authority) = setup_test_environment();
@@ -45,6 +76,35 @@ fn test_v2_creation_and_counter() {
     assert_eq!(swig_wallet.get_sub_account_v2_counter().unwrap(), 1);
     assert!(swig_wallet.get_sub_account_v2(0).unwrap().is_some());
     assert!(swig_wallet.get_sub_account_v2(5).unwrap().is_none());
+}
+
+#[test_log::test]
+fn test_v2_lookup_rejects_prefunded_uninitialized_state() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let id_le = 0u32.to_le_bytes();
+    let (state, _) = Pubkey::find_program_address(
+        &sub_account_v2_state_seeds(swig_wallet.get_swig_id(), &id_le),
+        &swig_interface::program_id(),
+    );
+    swig_wallet
+        .litesvm()
+        .set_account(
+            state,
+            Account {
+                lamports: 1,
+                data: Vec::new(),
+                owner: solana_system_interface::program::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+    assert!(matches!(
+        swig_wallet.get_sub_account_v2(0),
+        Err(SwigError::InvalidSwigData)
+    ));
 }
 
 #[test_log::test]
@@ -78,6 +138,28 @@ fn test_v2_sign_and_withdraw() {
         .unwrap();
     let after = swig_wallet.litesvm().get_balance(&asset).unwrap();
     assert_eq!(before - after, 500_000);
+}
+
+#[test_log::test]
+fn test_v2_ed25519_token_withdraw() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let creator = Keypair::new();
+    let (subacc_id, asset) = create_v2_setup(&mut swig_wallet, &creator);
+    let (source_token, destination_token) =
+        setup_v2_tokens(&mut swig_wallet, &main_authority, &asset, 10_000);
+
+    swig_wallet
+        .withdraw_token_from_sub_account_v2(
+            subacc_id,
+            source_token,
+            destination_token,
+            spl_token::ID,
+            4_000,
+        )
+        .unwrap();
+    assert_eq!(token_balance(&mut swig_wallet, &source_token), 6_000);
+    assert_eq!(token_balance(&mut swig_wallet, &destination_token), 4_000);
 }
 
 #[test_log::test]
@@ -201,10 +283,103 @@ fn test_v2_secp256k1_sign() {
     );
 }
 
-// NOTE: A Secp256k1/r1 `create_sub_account_v2` test is intentionally omitted.
-// The create instruction includes the fee payer as a signer account in the
-// Secp signature's account payload, and the on-chain reconstruction of that
-// payload for a signer account currently diverges from the client builder,
-// causing the recovered key to mismatch. Secp runtime ops that carry no signer
-// account (sign, above) verify correctly. Resolving Secp create is tracked as a
-// follow-up; Ed25519 create is fully covered above.
+#[test_log::test]
+fn test_v2_secp256k1_create_and_token_withdraw() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    let secp_wallet = PrivateKeySigner::random();
+    let secp_pubkey = secp_wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes()
+        .as_ref()[1..]
+        .to_vec();
+    swig_wallet
+        .add_authority(
+            AuthorityType::Secp256k1,
+            &secp_pubkey,
+            vec![Permission::SubAccountV2Create],
+        )
+        .unwrap();
+    let secp_role = swig_wallet.get_role_id(&secp_pubkey).unwrap();
+    let signing_fn = Box::new(move |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        secp_wallet
+            .sign_hash_sync(&B256::from(hash))
+            .unwrap()
+            .as_bytes()
+    });
+    swig_wallet
+        .switch_authority(
+            secp_role,
+            Box::new(Secp256k1ClientRole::new(
+                secp_pubkey.clone().into(),
+                signing_fn,
+            )),
+            None,
+        )
+        .unwrap();
+
+    let (_signature, subacc_id) = swig_wallet.create_sub_account_v2().unwrap();
+    let asset = swig_wallet.get_sub_account_v2(subacc_id).unwrap().unwrap();
+    let (source_token, destination_token) =
+        setup_v2_tokens(&mut swig_wallet, &main_authority, &asset, 10_000);
+    swig_wallet
+        .withdraw_token_from_sub_account_v2(
+            subacc_id,
+            source_token,
+            destination_token,
+            spl_token::ID,
+            4_000,
+        )
+        .unwrap();
+    assert_eq!(token_balance(&mut swig_wallet, &source_token), 6_000);
+    assert_eq!(token_balance(&mut swig_wallet, &destination_token), 4_000);
+}
+
+#[test_log::test]
+fn test_v2_secp256r1_create_and_token_withdraw() {
+    use crate::tests::common::create_test_secp256r1_keypair;
+    use solana_secp256r1_program::sign_message;
+
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let (signing_key, public_key) = create_test_secp256r1_keypair();
+    swig_wallet
+        .add_authority(
+            AuthorityType::Secp256r1,
+            &public_key,
+            vec![Permission::SubAccountV2Create],
+        )
+        .unwrap();
+    let role_id = swig_wallet.get_role_id(&public_key).unwrap();
+    let signing_fn = Box::new(move |message_hash: &[u8]| -> [u8; 64] {
+        sign_message(message_hash, &signing_key.private_key_to_der().unwrap()).unwrap()
+    });
+    swig_wallet
+        .switch_authority(
+            role_id,
+            Box::new(Secp256r1ClientRole::new(public_key, signing_fn)),
+            None,
+        )
+        .unwrap();
+
+    let (_signature, subacc_id) = swig_wallet.create_sub_account_v2().unwrap();
+    let asset = swig_wallet.get_sub_account_v2(subacc_id).unwrap().unwrap();
+    let (source_token, destination_token) =
+        setup_v2_tokens(&mut swig_wallet, &main_authority, &asset, 10_000);
+    swig_wallet
+        .withdraw_token_from_sub_account_v2(
+            subacc_id,
+            source_token,
+            destination_token,
+            spl_token::ID,
+            4_000,
+        )
+        .unwrap();
+    assert_eq!(token_balance(&mut swig_wallet, &source_token), 6_000);
+    assert_eq!(token_balance(&mut swig_wallet, &destination_token), 4_000);
+}

--- a/rust-sdk/src/tests/wallet/sub_accounts_v2_test.rs
+++ b/rust-sdk/src/tests/wallet/sub_accounts_v2_test.rs
@@ -1,0 +1,210 @@
+//! SDK-level integration tests for V2 sub-accounts via the `SwigWallet` API.
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use solana_sdk::signature::{Keypair, Signer};
+use swig_state::{authority::AuthorityType, swig::sub_account_v2_asset_seeds};
+
+use super::*;
+use crate::client_role::{Ed25519ClientRole, Secp256k1ClientRole};
+
+/// Adds a creator authority (SubAccountV2Create), switches to it, and creates a
+/// V2 sub-account. Returns (secondary_keypair, subacc_id, asset_pda).
+fn create_v2_setup<'a>(swig_wallet: &mut SwigWallet<'a>, secondary: &'a Keypair) -> (u32, Pubkey) {
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary.pubkey().to_bytes(),
+            vec![Permission::SubAccountV2Create],
+        )
+        .unwrap();
+    swig_wallet
+        .switch_authority(
+            1,
+            Box::new(Ed25519ClientRole::new(secondary.pubkey())),
+            Some(secondary),
+        )
+        .unwrap();
+    let (_sig, subacc_id) = swig_wallet.create_sub_account_v2().unwrap();
+    let (asset, _) = Pubkey::find_program_address(
+        &sub_account_v2_asset_seeds(swig_wallet.get_swig_id(), &subacc_id.to_le_bytes()),
+        &swig_interface::program_id(),
+    );
+    (subacc_id, asset)
+}
+
+#[test_log::test]
+fn test_v2_creation_and_counter() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let secondary = Keypair::new();
+
+    assert_eq!(swig_wallet.get_sub_account_v2_counter().unwrap(), 0);
+    let (subacc_id, _asset) = create_v2_setup(&mut swig_wallet, &secondary);
+    assert_eq!(subacc_id, 0);
+    assert_eq!(swig_wallet.get_sub_account_v2_counter().unwrap(), 1);
+    assert!(swig_wallet.get_sub_account_v2(0).unwrap().is_some());
+    assert!(swig_wallet.get_sub_account_v2(5).unwrap().is_none());
+}
+
+#[test_log::test]
+fn test_v2_sign_and_withdraw() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let secondary = Keypair::new();
+    let (subacc_id, asset) = create_v2_setup(&mut swig_wallet, &secondary);
+
+    swig_wallet.litesvm().airdrop(&asset, 100_000_000).unwrap();
+    let recipient = Keypair::new();
+
+    // Sign a transfer out of the asset PDA.
+    let transfer =
+        solana_system_interface::instruction::transfer(&asset, &recipient.pubkey(), 1_000_000);
+    swig_wallet
+        .sign_with_sub_account_v2(subacc_id, vec![transfer], None)
+        .unwrap();
+    assert_eq!(
+        swig_wallet
+            .litesvm()
+            .get_balance(&recipient.pubkey())
+            .unwrap(),
+        1_000_000
+    );
+
+    // Withdraw SOL back to the swig wallet address.
+    let before = swig_wallet.litesvm().get_balance(&asset).unwrap();
+    swig_wallet
+        .withdraw_from_sub_account_v2(subacc_id, 500_000)
+        .unwrap();
+    let after = swig_wallet.litesvm().get_balance(&asset).unwrap();
+    assert_eq!(before - after, 500_000);
+}
+
+#[test_log::test]
+fn test_v2_toggle_blocks_ops() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let secondary = Keypair::new();
+    let (subacc_id, asset) = create_v2_setup(&mut swig_wallet, &secondary);
+    swig_wallet.litesvm().airdrop(&asset, 100_000_000).unwrap();
+
+    // Disable the sub-account.
+    swig_wallet.toggle_sub_account_v2(subacc_id, false).unwrap();
+
+    // Withdrawing from a disabled sub-account must fail.
+    assert!(swig_wallet
+        .withdraw_from_sub_account_v2(subacc_id, 1_000)
+        .is_err());
+
+    // Re-enable and withdraw succeeds (distinct amount to avoid a duplicate tx).
+    swig_wallet.toggle_sub_account_v2(subacc_id, true).unwrap();
+    assert!(swig_wallet
+        .withdraw_from_sub_account_v2(subacc_id, 2_000)
+        .is_ok());
+}
+
+#[test_log::test]
+fn test_v2_all_authority_cannot_create() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let secondary = Keypair::new();
+
+    // Grant only All — not SubAccountV2Create.
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519,
+            &secondary.pubkey().to_bytes(),
+            vec![Permission::All],
+        )
+        .unwrap();
+    swig_wallet
+        .switch_authority(
+            1,
+            Box::new(Ed25519ClientRole::new(secondary.pubkey())),
+            Some(&secondary),
+        )
+        .unwrap();
+
+    assert!(
+        swig_wallet.create_sub_account_v2().is_err(),
+        "All alone must not create a V2 sub-account"
+    );
+}
+
+#[test_log::test]
+fn test_v2_secp256k1_sign() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    // An ed25519 creator makes sub-account 0.
+    let creator = Keypair::new();
+    let (subacc_id, asset) = create_v2_setup(&mut swig_wallet, &creator);
+
+    // Grant a Secp256k1 authority scoped Sign{0} (sharing, done by root).
+    swig_wallet
+        .switch_authority(
+            0,
+            Box::new(Ed25519ClientRole::new(main_authority.pubkey())),
+            Some(&main_authority),
+        )
+        .unwrap();
+    let secp_wallet = PrivateKeySigner::random();
+    let secp_pubkey = secp_wallet
+        .credential()
+        .verifying_key()
+        .to_encoded_point(false)
+        .to_bytes()
+        .as_ref()[1..]
+        .to_vec();
+    swig_wallet
+        .add_authority(
+            AuthorityType::Secp256k1,
+            &secp_pubkey,
+            vec![Permission::SubAccountV2Sign { subacc_id }],
+        )
+        .unwrap();
+
+    // Switch to the Secp256k1 authority (role 2) and sign.
+    let secp_role = swig_wallet.get_role_id(&secp_pubkey).unwrap();
+    let signing_fn = Box::new(move |payload: &[u8]| -> [u8; 65] {
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&payload[..32]);
+        secp_wallet
+            .sign_hash_sync(&B256::from(hash))
+            .unwrap()
+            .as_bytes()
+    });
+    swig_wallet
+        .switch_authority(
+            secp_role,
+            Box::new(Secp256k1ClientRole::new(
+                secp_pubkey.clone().into(),
+                signing_fn,
+            )),
+            None,
+        )
+        .unwrap();
+
+    swig_wallet.litesvm().airdrop(&asset, 100_000_000).unwrap();
+    let recipient = Keypair::new();
+    let transfer =
+        solana_system_interface::instruction::transfer(&asset, &recipient.pubkey(), 1_000_000);
+    swig_wallet
+        .sign_with_sub_account_v2(subacc_id, vec![transfer], None)
+        .unwrap();
+    assert_eq!(
+        swig_wallet
+            .litesvm()
+            .get_balance(&recipient.pubkey())
+            .unwrap(),
+        1_000_000
+    );
+}
+
+// NOTE: A Secp256k1/r1 `create_sub_account_v2` test is intentionally omitted.
+// The create instruction includes the fee payer as a signer account in the
+// Secp signature's account payload, and the on-chain reconstruction of that
+// payload for a signer account currently diverges from the client builder,
+// causing the recovered key to mismatch. Secp runtime ops that carry no signer
+// account (sign, above) verify correctly. Resolving Secp create is tracked as a
+// follow-up; Ed25519 create is fully covered above.

--- a/rust-sdk/src/tests/wallet/sub_accounts_v2_test.rs
+++ b/rust-sdk/src/tests/wallet/sub_accounts_v2_test.rs
@@ -366,8 +366,9 @@ fn test_v2_secp256k1_create_and_token_withdraw() {
 
 #[test_log::test]
 fn test_v2_secp256r1_create_and_token_withdraw() {
-    use crate::tests::common::create_test_secp256r1_keypair;
     use solana_secp256r1_program::sign_message;
+
+    use crate::tests::common::create_test_secp256r1_keypair;
 
     let (litesvm, main_authority) = setup_test_environment();
     let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
@@ -406,4 +407,184 @@ fn test_v2_secp256r1_create_and_token_withdraw() {
         .unwrap();
     assert_eq!(token_balance(&mut swig_wallet, &source_token), 6_000);
     assert_eq!(token_balance(&mut swig_wallet, &destination_token), 4_000);
+}
+
+// ------------------------------------------------------------ session roles
+
+/// Adds an Ed25519 session authority holding `permissions`, opens a session on
+/// it, and leaves the wallet acting as that session. Returns the role id.
+///
+/// Session roles build their V2 instructions with the Ed25519 builders using
+/// the session key as the authority, so the wallet has to sign as the session
+/// key once the session is live.
+fn start_ed25519_session<'a>(
+    swig_wallet: &mut SwigWallet<'a>,
+    main_payer: &'a Keypair,
+    session_root: &'a Keypair,
+    session_key: &'a Keypair,
+    permissions: Vec<Permission>,
+) -> u32 {
+    let create_authority =
+        CreateEd25519SessionAuthority::new(session_root.pubkey().to_bytes(), [0; 32], 100);
+    swig_wallet
+        .add_authority(
+            AuthorityType::Ed25519Session,
+            create_authority.into_bytes().unwrap(),
+            permissions,
+        )
+        .unwrap();
+
+    let role_id = swig_wallet
+        .get_role_id(&session_root.pubkey().to_bytes())
+        .unwrap();
+
+    // Act as the session role with the root key to open the session.
+    swig_wallet
+        .switch_authority(
+            role_id,
+            Box::new(Ed25519SessionClientRole::new(create_authority)),
+            Some(session_root),
+        )
+        .unwrap();
+    // `create_session` signs with the fee payer alone rather than
+    // fee_payer + authority, so the session root has to be the payer for it.
+    swig_wallet
+        .litesvm()
+        .airdrop(&session_root.pubkey(), 10_000_000_000)
+        .unwrap();
+    let original_payer = main_payer;
+    swig_wallet.switch_payer(session_root).unwrap();
+    swig_wallet
+        .create_session(session_key.pubkey(), 100)
+        .unwrap();
+    swig_wallet.switch_payer(original_payer).unwrap();
+
+    // Re-point the client role at the now-live session key and sign as it.
+    swig_wallet
+        .switch_authority(
+            role_id,
+            Box::new(Ed25519SessionClientRole::new(
+                CreateEd25519SessionAuthority::new(
+                    session_root.pubkey().to_bytes(),
+                    session_key.pubkey().to_bytes(),
+                    100,
+                ),
+            )),
+            Some(session_key),
+        )
+        .unwrap();
+    role_id
+}
+
+#[test_log::test]
+fn test_v2_ed25519_session_create_and_sol_withdraw() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let session_root = Keypair::new();
+    let session_key = Keypair::new();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    start_ed25519_session(
+        &mut swig_wallet,
+        &main_authority,
+        &session_root,
+        &session_key,
+        vec![Permission::SubAccountV2Create],
+    );
+
+    let (_signature, subacc_id) = swig_wallet.create_sub_account_v2().unwrap();
+    let asset = swig_wallet.get_sub_account_v2(subacc_id).unwrap().unwrap();
+    swig_wallet
+        .litesvm()
+        .airdrop(&asset, 1_000_000_000)
+        .unwrap();
+
+    let wallet_address = swig_wallet.get_swig_wallet_address().unwrap();
+    let before = swig_wallet
+        .litesvm()
+        .get_account(&wallet_address)
+        .unwrap()
+        .lamports;
+    swig_wallet
+        .withdraw_from_sub_account_v2(subacc_id, 250_000_000)
+        .unwrap();
+    assert_eq!(
+        swig_wallet
+            .litesvm()
+            .get_account(&wallet_address)
+            .unwrap()
+            .lamports,
+        before + 250_000_000
+    );
+}
+
+/// Regression for the session roles missing a token-withdraw impl: they used to
+/// fall through to the trait default and return "unsupported".
+#[test_log::test]
+fn test_v2_ed25519_session_token_withdraw() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let session_root = Keypair::new();
+    let session_key = Keypair::new();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    start_ed25519_session(
+        &mut swig_wallet,
+        &main_authority,
+        &session_root,
+        &session_key,
+        vec![Permission::SubAccountV2Create],
+    );
+
+    let (_signature, subacc_id) = swig_wallet.create_sub_account_v2().unwrap();
+    let asset = swig_wallet.get_sub_account_v2(subacc_id).unwrap().unwrap();
+    let (source_token, destination_token) =
+        setup_v2_tokens(&mut swig_wallet, &main_authority, &asset, 10_000);
+
+    swig_wallet
+        .withdraw_token_from_sub_account_v2(
+            subacc_id,
+            source_token,
+            destination_token,
+            spl_token::ID,
+            4_000,
+        )
+        .unwrap();
+    assert_eq!(token_balance(&mut swig_wallet, &source_token), 6_000);
+    assert_eq!(token_balance(&mut swig_wallet, &destination_token), 4_000);
+}
+
+#[test_log::test]
+fn test_v2_ed25519_session_toggle_blocks_ops() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let session_root = Keypair::new();
+    let session_key = Keypair::new();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+
+    start_ed25519_session(
+        &mut swig_wallet,
+        &main_authority,
+        &session_root,
+        &session_key,
+        vec![Permission::SubAccountV2Create],
+    );
+
+    let (_signature, subacc_id) = swig_wallet.create_sub_account_v2().unwrap();
+    let asset = swig_wallet.get_sub_account_v2(subacc_id).unwrap().unwrap();
+    swig_wallet
+        .litesvm()
+        .airdrop(&asset, 1_000_000_000)
+        .unwrap();
+
+    swig_wallet.toggle_sub_account_v2(subacc_id, false).unwrap();
+    assert!(
+        swig_wallet
+            .withdraw_from_sub_account_v2(subacc_id, 1_000)
+            .is_err(),
+        "a disabled sub-account must reject withdrawals from a session role"
+    );
+
+    // Distinct amount so the retry is not a byte-identical, already-processed tx.
+    swig_wallet.toggle_sub_account_v2(subacc_id, true).unwrap();
+    swig_wallet
+        .withdraw_from_sub_account_v2(subacc_id, 2_000)
+        .unwrap();
 }

--- a/rust-sdk/src/tests/wallet/sub_accounts_v2_test.rs
+++ b/rust-sdk/src/tests/wallet/sub_accounts_v2_test.rs
@@ -108,6 +108,30 @@ fn test_v2_lookup_rejects_prefunded_uninitialized_state() {
 }
 
 #[test_log::test]
+fn test_v2_lookup_rejects_invalid_enabled_byte() {
+    let (litesvm, main_authority) = setup_test_environment();
+    let mut swig_wallet = create_test_wallet(litesvm, &main_authority);
+    let secondary = Keypair::new();
+    let (subacc_id, _asset) = create_v2_setup(&mut swig_wallet, &secondary);
+    let (state, _) = Pubkey::find_program_address(
+        &sub_account_v2_state_seeds(swig_wallet.get_swig_id(), &subacc_id.to_le_bytes()),
+        &swig_interface::program_id(),
+    );
+
+    let mut state_account = swig_wallet.litesvm().get_account(&state).unwrap();
+    state_account.data[3] = 2;
+    swig_wallet
+        .litesvm()
+        .set_account(state, state_account)
+        .unwrap();
+
+    assert!(matches!(
+        swig_wallet.get_sub_account_v2(subacc_id),
+        Err(SwigError::InvalidSwigData)
+    ));
+}
+
+#[test_log::test]
 fn test_v2_sign_and_withdraw() {
     let (litesvm, main_authority) = setup_test_environment();
     let mut swig_wallet = create_test_wallet(litesvm, &main_authority);

--- a/rust-sdk/src/types.rs
+++ b/rust-sdk/src/types.rs
@@ -18,6 +18,10 @@ use swig_state::{
         stake_limit::StakeLimit,
         stake_recurring_limit::StakeRecurringLimit,
         sub_account::SubAccount,
+        sub_account_v2::{
+            SubAccountV2All, SubAccountV2Create, SubAccountV2Sign, SubAccountV2Toggle,
+            SubAccountV2Withdraw,
+        },
         token_destination_limit::TokenDestinationLimit,
         token_limit::TokenLimit,
         token_recurring_destination_limit::TokenRecurringDestinationLimit,
@@ -168,6 +172,22 @@ pub enum Permission {
     /// This grants access to all wallet operations but excludes the ability
     /// to add, remove, or modify authorities/subaccounts.
     AllButManageAuthority,
+
+    /// Permission to create V2 sub-accounts (non-repeatable marker).
+    SubAccountV2Create,
+
+    /// Scoped umbrella permission for V2 sub-account runtime operations
+    /// (sign/withdraw/toggle) on a single sub-account id.
+    SubAccountV2All { subacc_id: u32 },
+
+    /// Scoped permission to sign as a single V2 sub-account.
+    SubAccountV2Sign { subacc_id: u32 },
+
+    /// Scoped permission to withdraw from a single V2 sub-account.
+    SubAccountV2Withdraw { subacc_id: u32 },
+
+    /// Scoped permission to toggle a single V2 sub-account.
+    SubAccountV2Toggle { subacc_id: u32 },
 }
 
 impl Permission {
@@ -339,6 +359,29 @@ impl Permission {
                     actions.push(ClientAction::AllButManageAuthority(
                         AllButManageAuthority {},
                     ));
+                },
+                Permission::SubAccountV2Create => {
+                    actions.push(ClientAction::SubAccountV2Create(SubAccountV2Create));
+                },
+                Permission::SubAccountV2All { subacc_id } => {
+                    actions.push(ClientAction::SubAccountV2All(SubAccountV2All::new(
+                        subacc_id,
+                    )));
+                },
+                Permission::SubAccountV2Sign { subacc_id } => {
+                    actions.push(ClientAction::SubAccountV2Sign(SubAccountV2Sign::new(
+                        subacc_id,
+                    )));
+                },
+                Permission::SubAccountV2Withdraw { subacc_id } => {
+                    actions.push(ClientAction::SubAccountV2Withdraw(
+                        SubAccountV2Withdraw::new(subacc_id),
+                    ));
+                },
+                Permission::SubAccountV2Toggle { subacc_id } => {
+                    actions.push(ClientAction::SubAccountV2Toggle(SubAccountV2Toggle::new(
+                        subacc_id,
+                    )));
                 },
             }
         }
@@ -547,6 +590,43 @@ impl Permission {
             });
         }
 
+        // Check for V2 sub-account permissions. The create marker is single; the
+        // scoped permissions are repeatable (one per sub-account id).
+        if swig_state::role::Role::get_action::<SubAccountV2Create>(role, &[])
+            .map_err(|_| SwigError::InvalidSwigData)?
+            .is_some()
+        {
+            permissions.push(Permission::SubAccountV2Create);
+        }
+        for action in swig_state::role::Role::get_all_actions_of_type::<SubAccountV2All>(role)
+            .map_err(|_| SwigError::InvalidSwigData)?
+        {
+            permissions.push(Permission::SubAccountV2All {
+                subacc_id: action.subacc_id,
+            });
+        }
+        for action in swig_state::role::Role::get_all_actions_of_type::<SubAccountV2Sign>(role)
+            .map_err(|_| SwigError::InvalidSwigData)?
+        {
+            permissions.push(Permission::SubAccountV2Sign {
+                subacc_id: action.subacc_id,
+            });
+        }
+        for action in swig_state::role::Role::get_all_actions_of_type::<SubAccountV2Withdraw>(role)
+            .map_err(|_| SwigError::InvalidSwigData)?
+        {
+            permissions.push(Permission::SubAccountV2Withdraw {
+                subacc_id: action.subacc_id,
+            });
+        }
+        for action in swig_state::role::Role::get_all_actions_of_type::<SubAccountV2Toggle>(role)
+            .map_err(|_| SwigError::InvalidSwigData)?
+        {
+            permissions.push(Permission::SubAccountV2Toggle {
+                subacc_id: action.subacc_id,
+            });
+        }
+
         // Check for StakeLimit permission
         if let Some(action) = swig_state::role::Role::get_action::<StakeLimit>(role, &[])
             .map_err(|_| SwigError::InvalidSwigData)?
@@ -652,6 +732,11 @@ impl Permission {
                 balance_field_end: _,
             } => 4,
             Permission::SubAccount { sub_account: _ } => 9,
+            Permission::SubAccountV2Create => 22,
+            Permission::SubAccountV2All { subacc_id: _ } => 23,
+            Permission::SubAccountV2Sign { subacc_id: _ } => 24,
+            Permission::SubAccountV2Withdraw { subacc_id: _ } => 25,
+            Permission::SubAccountV2Toggle { subacc_id: _ } => 26,
             Permission::Stake {
                 amount: _,
                 recurring,

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -777,7 +777,6 @@ impl<'c> SwigWallet<'c> {
 
         if state_account.owner != swig_interface::program_id()
             || state_account.data.len() != SubAccountV2::LEN
-            || state_account.data[3] > 1
         {
             return Err(SwigError::InvalidSwigData);
         }
@@ -788,6 +787,7 @@ impl<'c> SwigWallet<'c> {
         state
             .check_discriminator()
             .map_err(|_| SwigError::InvalidSwigData)?;
+        state.is_enabled().map_err(|_| SwigError::InvalidSwigData)?;
         if state.bump != state_bump
             || state.asset_bump != asset_bump
             || state.subacc_id != subacc_id

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -36,10 +36,12 @@ use swig_state::{
     },
     authority::{self, secp256k1::Secp256k1Authority, AuthorityType},
     role::Role,
+    sub_account_v2::SubAccountV2,
     swig::{
         sub_account_seeds, sub_account_v2_asset_seeds, sub_account_v2_state_seeds, Swig,
         SwigWithRoles,
     },
+    Transmutable,
 };
 const TOKEN_22_PROGRAM_ID: Pubkey = pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 
@@ -686,6 +688,42 @@ impl<'c> SwigWallet<'c> {
         tx_result
     }
 
+    /// Withdraws tokens from a V2 sub-account to a token account owned by the
+    /// swig wallet address.
+    pub fn withdraw_token_from_sub_account_v2(
+        &mut self,
+        subacc_id: u32,
+        source_token: Pubkey,
+        destination_token: Pubkey,
+        token_program: Pubkey,
+        amount: u64,
+    ) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let withdraw_instructions = self
+            .instruction_builder
+            .withdraw_token_from_sub_account_v2(
+                subacc_id,
+                source_token,
+                destination_token,
+                token_program,
+                amount,
+                Some(current_slot),
+            )?;
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &withdraw_instructions,
+            &[],
+            self.get_current_blockhash()?,
+        )?;
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+        let tx_result = self.send_and_confirm_transaction(tx);
+        if tx_result.is_ok() {
+            self.refresh_permissions()?;
+            self.instruction_builder.increment_odometer()?;
+        }
+        tx_result
+    }
+
     /// Toggles a V2 sub-account's enabled kill-switch.
     pub fn toggle_sub_account_v2(
         &mut self,
@@ -714,27 +752,52 @@ impl<'c> SwigWallet<'c> {
     }
 
     /// Returns the V2 sub-account asset PDA for `subacc_id` if its state account
-    /// exists on-chain.
+    /// is a valid, canonical program-owned V2 state account.
     pub fn get_sub_account_v2(&self, subacc_id: u32) -> Result<Option<Pubkey>, SwigError> {
         let swig_id = *self.instruction_builder.get_swig_id();
         let id_le = subacc_id.to_le_bytes();
-        let (sub_account_state, _) = Pubkey::find_program_address(
+        let (sub_account_state, state_bump) = Pubkey::find_program_address(
             &sub_account_v2_state_seeds(&swig_id, &id_le),
             &swig_interface::program_id(),
         );
-        let (asset, _) = Pubkey::find_program_address(
+        let (asset, asset_bump) = Pubkey::find_program_address(
             &sub_account_v2_asset_seeds(&swig_id, &id_le),
             &swig_interface::program_id(),
         );
         #[cfg(not(all(feature = "rust_sdk_test", test)))]
-        let exists = self.rpc_client.get_account(&sub_account_state).is_ok();
+        let state_account = self
+            .rpc_client
+            .get_account_with_commitment(&sub_account_state, CommitmentConfig::confirmed())?
+            .value;
         #[cfg(all(feature = "rust_sdk_test", test))]
-        let exists = self.litesvm.get_account(&sub_account_state).is_some();
-        if exists {
-            Ok(Some(asset))
-        } else {
-            Ok(None)
+        let state_account = self.litesvm.get_account(&sub_account_state);
+        let Some(state_account) = state_account else {
+            return Ok(None);
+        };
+
+        if state_account.owner != swig_interface::program_id()
+            || state_account.data.len() != SubAccountV2::LEN
+            || state_account.data[3] > 1
+        {
+            return Err(SwigError::InvalidSwigData);
         }
+        let state = unsafe {
+            SubAccountV2::load_unchecked(&state_account.data)
+                .map_err(|_| SwigError::InvalidSwigData)?
+        };
+        state
+            .check_discriminator()
+            .map_err(|_| SwigError::InvalidSwigData)?;
+        if state.bump != state_bump
+            || state.asset_bump != asset_bump
+            || state.subacc_id != subacc_id
+            || state.swig_id != swig_id
+            || state.sub_account != asset.to_bytes()
+        {
+            return Err(SwigError::InvalidSwigData);
+        }
+
+        Ok(Some(asset))
     }
 
     /// Sends and confirms a transaction on the Solana network

--- a/rust-sdk/src/wallet.rs
+++ b/rust-sdk/src/wallet.rs
@@ -36,7 +36,10 @@ use swig_state::{
     },
     authority::{self, secp256k1::Secp256k1Authority, AuthorityType},
     role::Role,
-    swig::{sub_account_seeds, Swig, SwigWithRoles},
+    swig::{
+        sub_account_seeds, sub_account_v2_asset_seeds, sub_account_v2_state_seeds, Swig,
+        SwigWithRoles,
+    },
 };
 const TOKEN_22_PROGRAM_ID: Pubkey = pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 
@@ -575,6 +578,163 @@ impl<'c> SwigWallet<'c> {
             self.instruction_builder.increment_odometer()?;
         }
         tx_result
+    }
+
+    /// Reads the on-chain V2 sub-account counter (the id the next
+    /// `create_sub_account_v2` will assign).
+    pub fn get_sub_account_v2_counter(&self) -> Result<u32, SwigError> {
+        let swig_pubkey = self.get_swig_account()?;
+        #[cfg(not(all(feature = "rust_sdk_test", test)))]
+        let swig_data = self.rpc_client.get_account_data(&swig_pubkey)?;
+        #[cfg(all(feature = "rust_sdk_test", test))]
+        let swig_data = self.litesvm.get_account(&swig_pubkey).unwrap().data;
+        let swig_with_roles =
+            SwigWithRoles::from_bytes(&swig_data).map_err(|_| SwigError::InvalidSwigData)?;
+        Ok(swig_with_roles.state.sub_account_counter)
+    }
+
+    /// Creates a V2 sub-account with the current authority. Returns the
+    /// transaction signature and the assigned sub-account id.
+    pub fn create_sub_account_v2(&mut self) -> Result<(Signature, u32), SwigError> {
+        let subacc_id = self.get_sub_account_v2_counter()?;
+        let swig_id = *self.instruction_builder.get_swig_id();
+        let id_le = subacc_id.to_le_bytes();
+        let (sub_account_state, state_bump) = Pubkey::find_program_address(
+            &sub_account_v2_state_seeds(&swig_id, &id_le),
+            &swig_interface::program_id(),
+        );
+        let (sub_account, asset_bump) = Pubkey::find_program_address(
+            &sub_account_v2_asset_seeds(&swig_id, &id_le),
+            &swig_interface::program_id(),
+        );
+        let current_slot = self.get_current_slot()?;
+        let instructions = self.instruction_builder.create_sub_account_v2(
+            sub_account_state,
+            sub_account,
+            state_bump,
+            asset_bump,
+            Some(current_slot),
+        )?;
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &instructions,
+            &[],
+            self.get_current_blockhash()?,
+        )?;
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+        match self.send_and_confirm_transaction(tx) {
+            Ok(sig) => {
+                self.refresh_permissions()?;
+                self.instruction_builder.increment_odometer()?;
+                Ok((sig, subacc_id))
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Signs and executes instructions as a V2 sub-account's asset PDA.
+    pub fn sign_with_sub_account_v2(
+        &mut self,
+        subacc_id: u32,
+        instructions: Vec<Instruction>,
+        alt: Option<&[AddressLookupTableAccount]>,
+    ) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let sign_instructions = self
+            .instruction_builder
+            .sign_instruction_with_sub_account_v2(subacc_id, instructions, Some(current_slot))?;
+        let alt = alt.unwrap_or(&[]);
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &sign_instructions,
+            alt,
+            self.get_current_blockhash()?,
+        )?;
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+        let tx_result = self.send_and_confirm_transaction(tx);
+        if tx_result.is_ok() {
+            self.refresh_permissions()?;
+            self.instruction_builder.increment_odometer()?;
+        }
+        tx_result
+    }
+
+    /// Withdraws SOL from a V2 sub-account to the swig wallet address.
+    pub fn withdraw_from_sub_account_v2(
+        &mut self,
+        subacc_id: u32,
+        amount: u64,
+    ) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let withdraw_instructions = self.instruction_builder.withdraw_from_sub_account_v2(
+            subacc_id,
+            amount,
+            Some(current_slot),
+        )?;
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &withdraw_instructions,
+            &[],
+            self.get_current_blockhash()?,
+        )?;
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+        let tx_result = self.send_and_confirm_transaction(tx);
+        if tx_result.is_ok() {
+            self.refresh_permissions()?;
+            self.instruction_builder.increment_odometer()?;
+        }
+        tx_result
+    }
+
+    /// Toggles a V2 sub-account's enabled kill-switch.
+    pub fn toggle_sub_account_v2(
+        &mut self,
+        subacc_id: u32,
+        enabled: bool,
+    ) -> Result<Signature, SwigError> {
+        let current_slot = self.get_current_slot()?;
+        let toggle_instructions = self.instruction_builder.toggle_sub_account_v2(
+            subacc_id,
+            enabled,
+            Some(current_slot),
+        )?;
+        let msg = v0::Message::try_compile(
+            &self.fee_payer.pubkey(),
+            &toggle_instructions,
+            &[],
+            self.get_current_blockhash()?,
+        )?;
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(msg), &self.get_keypairs()?)?;
+        let tx_result = self.send_and_confirm_transaction(tx);
+        if tx_result.is_ok() {
+            self.refresh_permissions()?;
+            self.instruction_builder.increment_odometer()?;
+        }
+        tx_result
+    }
+
+    /// Returns the V2 sub-account asset PDA for `subacc_id` if its state account
+    /// exists on-chain.
+    pub fn get_sub_account_v2(&self, subacc_id: u32) -> Result<Option<Pubkey>, SwigError> {
+        let swig_id = *self.instruction_builder.get_swig_id();
+        let id_le = subacc_id.to_le_bytes();
+        let (sub_account_state, _) = Pubkey::find_program_address(
+            &sub_account_v2_state_seeds(&swig_id, &id_le),
+            &swig_interface::program_id(),
+        );
+        let (asset, _) = Pubkey::find_program_address(
+            &sub_account_v2_asset_seeds(&swig_id, &id_le),
+            &swig_interface::program_id(),
+        );
+        #[cfg(not(all(feature = "rust_sdk_test", test)))]
+        let exists = self.rpc_client.get_account(&sub_account_state).is_ok();
+        #[cfg(all(feature = "rust_sdk_test", test))]
+        let exists = self.litesvm.get_account(&sub_account_state).is_some();
+        if exists {
+            Ok(Some(asset))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Sends and confirms a transaction on the Solana network


### PR DESCRIPTION
## Summary

The **rust-sdk** V2 sub-account API and its SDK-level integration tests. (The interface builders these depend on live in #188.)

### rust-sdk
- `types::Permission`: five V2 variants (Create + scoped All/Sign/Withdraw/Toggle) with `to_client_actions` / `from_role` / `to_action_type`.
- `ClientRole`: four V2 methods (create/sign/withdraw/toggle) with default "unsupported" impls, overridden for Ed25519, Secp256k1, Secp256r1, and the three session variants (which delegate to the Ed25519 builders via the session key). Secp256k1/r1 thread the odometer as the replay counter. ProgramExec uses the default impl.
- `SwigInstructionBuilder` + `SwigWallet`: V2 create/sign/withdraw/toggle, a counter reader, and `get_sub_account_v2`. Create reads the on-chain counter to derive the next sub-account's PDAs.

### tests (rust_sdk_test)
Thirteen SDK integration tests via the `SwigWallet` API:

- **lifecycle** — create/counter, sign + SOL withdraw, Ed25519 token withdraw, toggle kill-switch
- **validation** — state account pre-funded but uninitialized, invalid `enabled` wire byte
- **authorization** — `All` alone cannot create (default-deny)
- **Secp256k1 / Secp256r1** — k1 sign, and k1 + r1 create followed by token withdraw
- **sessions** — Ed25519 session create + SOL withdraw, token withdraw, and toggle

## Test
```
cargo build-sbf --arch v1
cargo test -p swig-sdk --features rust_sdk_test sub_accounts_v2_test   # 13
cargo test -p swig-sdk --features rust_sdk_test                        # 135
```

## Stack
1. #187 — state data model (base `main`)
2. #188 — program + interface builders + program tests (base #187)
3. **this PR** — rust-sdk V2 + SDK integration tests (base #188)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
