### PR TITLE
Correct stake account classification for stake accounts held by the Swig wallet PDA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,6 +83,50 @@ jobs:
           mkdir -p target/nextest/reports
           cp target/nextest/ci/output.xml target/nextest/reports/rust-sdk-tests.xml
 
+      # Stake tests are gated behind the `stake_tests` feature and talk to a real
+      # validator over RPC, so they need both the feature flag and a running
+      # validator. Without this step they are silently compiled out.
+      - name: Build Solana Program for stake tests
+        run: |
+          cargo build-sbf --arch v1
+
+      - name: Start test validator for stake tests
+        run: |
+          solana-test-validator \
+            --limit-ledger-size 0 \
+            --bind-address 127.0.0.1 \
+            --bpf-program swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB target/deploy/swig.so \
+            --reset \
+            --ticks-per-slot 10 \
+            --slots-per-epoch 64 \
+            --ledger /tmp/stake-test-ledger \
+            > /tmp/stake-validator.log 2>&1 &
+          echo "waiting for validator RPC"
+          for i in $(seq 1 60); do
+            if curl -s -m 3 http://127.0.0.1:8899 -X POST \
+                -H 'content-type: application/json' \
+                -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' | grep -q ok; then
+              echo "validator healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "validator failed to start" >&2
+          tail -50 /tmp/stake-validator.log >&2
+          exit 1
+
+      # Run serially: the tests share one validator, and the delegation test
+      # waits on epoch boundaries.
+      - name: Run Stake Tests with nextest
+        run: |
+          cargo nextest run --config-file nextest.toml --profile ci --all --workspace --no-fail-fast --exclude test-program-authority --features=stake_tests --test-threads=1
+          mkdir -p target/nextest/reports
+          cp target/nextest/ci/output.xml target/nextest/reports/stake-tests.xml
+
+      - name: Stop test validator
+        if: always()
+        run: pkill -f "[s]olana-test-validator" || true
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "solana-svm-measure",
  "solana-svm-timings",
  "solana-svm-type-overrides",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
@@ -3904,7 +3904,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-interface 2.0.0",
  "solana-system-program",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-sysvar-id",
  "solana-transaction",
  "solana-transaction-context",
@@ -5987,7 +5987,7 @@ dependencies = [
  "solana-instruction-error",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
 ]
 
 [[package]]
@@ -6021,7 +6021,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stake-interface 2.0.2",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-vote-interface",
  "spl-generic-token",
  "spl-token-2022-interface",
@@ -6119,7 +6119,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-svm-transaction",
  "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-context",
@@ -6218,7 +6218,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rent 3.1.0",
  "solana-signature",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -7417,7 +7417,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-sysvar-id",
 ]
 
@@ -7558,7 +7558,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-svm-type-overrides",
  "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
@@ -7618,7 +7618,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-svm-timings",
  "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-sysvar-id",
  "solana-transaction",
  "solana-transaction-context",
@@ -7761,7 +7761,11 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1771d726d4854f1818c750e14aff40b19d84720d0b1b6d53e50e8f16cb6bd62"
 dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
  "solana-sdk-macro",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -7995,7 +7999,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-interface 2.0.0",
  "solana-system-transaction",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-sysvar-id",
  "solana-time-utils",
  "solana-transaction",
@@ -8366,7 +8370,7 @@ dependencies = [
  "solana-program-error 3.0.1",
  "solana-pubkey 3.0.0",
  "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-sysvar-id",
 ]
 
@@ -8377,11 +8381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
 dependencies = [
  "num-traits",
+ "serde",
+ "serde_derive",
  "solana-clock",
+ "solana-cpi",
  "solana-instruction 3.3.0",
  "solana-program-error 3.0.1",
  "solana-pubkey 4.1.0",
  "solana-system-interface 3.1.0",
+ "solana-sysvar 4.0.0",
 ]
 
 [[package]]
@@ -8594,7 +8602,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-svm-type-overrides",
  "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "solana-transaction-context",
 ]
 
@@ -8640,6 +8648,38 @@ dependencies = [
  "solana-program-memory 3.1.0",
  "solana-pubkey 4.1.0",
  "solana-rent 3.1.0",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1632b69b4f72489db5949a10e8308c229dfa003f99ecaa7477b376807c7b81f4"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info 3.1.1",
+ "solana-clock",
+ "solana-define-syscall 5.0.0",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash 4.2.0",
+ "solana-instruction 3.3.0",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint 3.1.1",
+ "solana-program-error 3.0.1",
+ "solana-program-memory 3.1.0",
+ "solana-pubkey 4.1.0",
+ "solana-rent 4.1.0",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-slot-hashes",
@@ -9110,7 +9150,7 @@ dependencies = [
  "solana-rent 3.1.0",
  "solana-sdk-ids",
  "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "spl-associated-token-account-interface",
  "spl-token-2022-interface",
  "spl-token-interface",
@@ -9230,7 +9270,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rent 3.1.0",
  "solana-sdk-ids",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "spl-token-interface",
  "thiserror 2.0.18",
 ]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -40,7 +40,7 @@ ecdsa = "0.16.9"
 alloy-primitives = { version = "=1.5.7", features = ["k256"] }
 alloy-signer = { version = "=1.6.3" }
 alloy-signer-local = { version = "=1.6.3" }
-solana-stake-interface = "3.1.0"
+solana-stake-interface = { version = "3.1.0", features = ["bincode"] }
 solana-clock = "3.0.1"
 bincode = "=1.3.3"
 solana-client = "3.1.11"

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -458,11 +458,11 @@ pub fn sign_v2(
                                     .unwrap_or([0; 8])
                             });
 
-                            let stake_spent = if current < *balance {
-                                *balance - current
-                            } else {
-                                0
-                            };
+                            // Absolute difference: StakeLimit is documented to
+                            // apply to staking and unstaking alike, and its
+                            // `run` takes |new - old|. Counting only decreases
+                            // let a bounded role delegate without limit.
+                            let stake_spent = current.abs_diff(*balance);
 
                             *balance = current;
                             stake_spent
@@ -737,7 +737,8 @@ pub fn sign_v2(
 
                 if account_info.is_writable() {
                     let data = unsafe { &account_info.borrow_data_unchecked() };
-                    let exclude_ranges = [STAKE_STATE_EXCLUDE_RANGE, STAKE_DELEGATION_EXCLUDE_RANGE];
+                    let exclude_ranges =
+                        [STAKE_STATE_EXCLUDE_RANGE, STAKE_DELEGATION_EXCLUDE_RANGE];
                     let current_hash = hash_except(&data, account_info.owner(), &exclude_ranges);
                     let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
                     if *snapshot_hash != current_hash {

--- a/program/src/actions/sign_v2.rs
+++ b/program/src/actions/sign_v2.rs
@@ -59,8 +59,30 @@ pub const INSTRUCTION_SYSVAR_ACCOUNT: Pubkey =
 /// Exclude range for token account balance field (bytes 64-72)
 const TOKEN_BALANCE_EXCLUDE_RANGE: core::ops::Range<usize> = 64..72;
 
-/// Exclude range for stake account balance field (bytes 184-192)
-const STAKE_BALANCE_EXCLUDE_RANGE: core::ops::Range<usize> = 184..192;
+/// Exclude ranges for the mutable portion of a stake account.
+///
+/// A stake account is bincode `StakeStateV2` (200 bytes):
+///   0..4    state discriminant   (0 Uninitialized, 1 Initialized, 2 Stake,
+///                                 3 RewardsPool)
+///   4..12   rent_exempt_reserve
+///   12..44  authorized staker
+///   44..76  authorized withdrawer
+///   76..124 lockup (timestamp, epoch, custodian)
+///   124..156 voter_pubkey
+///   156..164 delegated stake
+///   164..172 activation_epoch
+///   172..180 deactivation_epoch
+///   180..188 warmup_cooldown_rate
+///   188..196 credits_observed
+///   196..200 padding
+///
+/// Legitimate stake operations (delegate, deactivate, withdraw) rewrite the
+/// discriminant and the whole delegation region, so those are excluded from the
+/// integrity hash. The Meta at 4..124 — crucially the authorized staker and
+/// withdrawer, and the lockup — stays covered, so a CPI cannot re-authorize the
+/// account away from the wallet without tripping the check.
+const STAKE_STATE_EXCLUDE_RANGE: core::ops::Range<usize> = 0..4;
+const STAKE_DELEGATION_EXCLUDE_RANGE: core::ops::Range<usize> = 124..200;
 
 /// Token account field ranges
 const TOKEN_ACCOUNT_BASE_DATA_LEN: usize = 165;
@@ -70,7 +92,7 @@ const TOKEN_BALANCE_RANGE: core::ops::Range<usize> = 64..72;
 const TOKEN_STATE_INDEX: usize = 108;
 
 /// Stake account field ranges
-const STAKE_BALANCE_RANGE: core::ops::Range<usize> = 184..192;
+const STAKE_BALANCE_RANGE: core::ops::Range<usize> = 156..164;
 
 /// Account state constants
 const TOKEN_ACCOUNT_INITIALIZED_STATE: u8 = 1;
@@ -312,7 +334,7 @@ pub fn sign_v2(
             AccountClassification::SwigStakeAccount { .. } => {
                 let data = unsafe { account.borrow_data_unchecked() };
                 // Exclude stake balance field (bytes 184-192) but include owner
-                let exclude_ranges = [STAKE_BALANCE_EXCLUDE_RANGE];
+                let exclude_ranges = [STAKE_STATE_EXCLUDE_RANGE, STAKE_DELEGATION_EXCLUDE_RANGE];
                 let hash = hash_except(&data, account.owner(), &exclude_ranges);
                 Some(hash)
             },
@@ -410,25 +432,46 @@ pub fn sign_v2(
                     AccountClassification::SwigStakeAccount {
                         state: _,
                         balance,
+                        lamports,
                         spent,
                     } => {
+                        // Lamports are checked independently of the delegated
+                        // stake amount: an undelegated stake account can be
+                        // drained by a withdrawal while the delegated amount at
+                        // STAKE_BALANCE_RANGE stays zero.
+                        let current_lamports = account.lamports();
+                        let lamports_spent = if current_lamports < *lamports {
+                            *lamports - current_lamports
+                        } else {
+                            0
+                        };
+                        *lamports = current_lamports;
+
                         let data = unsafe { account.borrow_data_unchecked() };
 
-                        if data.len() < STAKE_BALANCE_RANGE.end {
-                            continue;
-                        }
+                        let stake_spent = if data.len() < STAKE_BALANCE_RANGE.end {
+                            0
+                        } else {
+                            let current = u64::from_le_bytes(unsafe {
+                                data.get_unchecked(STAKE_BALANCE_RANGE)
+                                    .try_into()
+                                    .unwrap_or([0; 8])
+                            });
 
-                        let current = u64::from_le_bytes(unsafe {
-                            data.get_unchecked(STAKE_BALANCE_RANGE)
-                                .try_into()
-                                .unwrap_or([0; 8])
-                        });
+                            let stake_spent = if current < *balance {
+                                *balance - current
+                            } else {
+                                0
+                            };
 
-                        if current < *balance {
-                            *spent = spent.saturating_add(*balance - current);
-                        }
+                            *balance = current;
+                            stake_spent
+                        };
 
-                        *balance = current;
+                        // Take the larger of the two rather than the sum: a
+                        // withdrawal from a delegated account reduces both, and
+                        // summing would double-count it against the limit.
+                        *spent = spent.saturating_add(lamports_spent.max(stake_spent));
                     },
                     AccountClassification::ProgramScope {
                         role_index: _,
@@ -694,7 +737,7 @@ pub fn sign_v2(
 
                 if account_info.is_writable() {
                     let data = unsafe { &account_info.borrow_data_unchecked() };
-                    let exclude_ranges = [STAKE_BALANCE_EXCLUDE_RANGE];
+                    let exclude_ranges = [STAKE_STATE_EXCLUDE_RANGE, STAKE_DELEGATION_EXCLUDE_RANGE];
                     let current_hash = hash_except(&data, account_info.owner(), &exclude_ranges);
                     let snapshot_hash = unsafe { account_snapshots[index].assume_init_ref() };
                     if *snapshot_hash != current_hash {
@@ -704,6 +747,12 @@ pub fn sign_v2(
 
                 let total_stake_spent = *spent;
                 if total_stake_spent == 0 {
+                    continue;
+                }
+
+                // StakeAll grants uncapped stake authority, so it short-circuits
+                // the limit actions and needs no accounting.
+                if RoleMut::get_action_mut::<StakeAll>(actions, &[])?.is_some() {
                     continue;
                 }
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -377,19 +377,37 @@ unsafe fn classify_account(
             }
 
             // Stake account authorized withdrawer is at offset 44 for 32 bytes.
+            // The withdrawer may be either the Swig config account (index 0) or
+            // the Swig wallet address (index 1), which is the CPI signer for
+            // SignV2. Both must classify so stake spending is accounted for.
             let authorized_withdrawer = data.get_unchecked(44..76);
-            if sol_memcmp(
+
+            let matches_swig_account = sol_memcmp(
                 accounts.get_unchecked(0).assume_init_ref().key(),
                 authorized_withdrawer,
                 32,
-            ) != 0
-            {
+            ) == 0;
+
+            let matches_swig_wallet_address = index > 1
+                && matches!(
+                    account_classifications.get_unchecked(1).assume_init_ref(),
+                    AccountClassification::SwigWalletAddress
+                )
+                && sol_memcmp(
+                    accounts.get_unchecked(1).assume_init_ref().key(),
+                    authorized_withdrawer,
+                    32,
+                ) == 0;
+
+            if !matches_swig_account && !matches_swig_wallet_address {
                 return Ok(AccountClassification::None);
             }
 
-            // Stake state is at offset 196; delegated stake amount is at 184.
+            // `StakeStateV2` is bincode: the state discriminant is the leading
+            // u32 and the delegated stake amount sits at 156..164, inside the
+            // Delegation struct.
             let state_value = u32::from_le_bytes(
-                data.get_unchecked(196..200)
+                data.get_unchecked(0..4)
                     .try_into()
                     .map_err(|_| ProgramError::InvalidAccountData)?,
             );
@@ -401,7 +419,7 @@ unsafe fn classify_account(
                 _ => return Err(ProgramError::InvalidAccountData),
             };
             let stake_amount = u64::from_le_bytes(
-                data.get_unchecked(184..192)
+                data.get_unchecked(156..164)
                     .try_into()
                     .map_err(|_| ProgramError::InvalidAccountData)?,
             );
@@ -409,6 +427,7 @@ unsafe fn classify_account(
             Ok(AccountClassification::SwigStakeAccount {
                 state,
                 balance: stake_amount,
+                lamports: account.lamports(),
                 spent: 0,
             })
         },

--- a/program/tests/stake_account_test_v2.rs
+++ b/program/tests/stake_account_test_v2.rs
@@ -20,20 +20,18 @@ use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     message::{v0, Message, VersionedMessage},
     signature::{Keypair, Signature, Signer},
-    stake::{
-        instruction::{deactivate_stake, delegate_stake, initialize as stake_initialize, withdraw},
-        state::{Authorized, Lockup},
-    },
     transaction::{Transaction, VersionedTransaction},
-    vote::{
-        instruction as vote_instruction,
-        state::{VoteInit, VoteState},
+};
+use solana_stake_interface::{
+    instruction::{
+        deactivate_stake, delegate_stake, initialize as stake_initialize, withdraw,
     },
+    state::{Authorized, Lockup},
 };
 use swig_interface::{AuthorityConfig, ClientAction, SignV2Instruction};
 use swig_state::{
     action::{
-        all::All, stake_all::StakeAll, stake_limit::StakeLimit,
+        all::All, program::Program, stake_all::StakeAll, stake_limit::StakeLimit,
         stake_recurring_limit::StakeRecurringLimit,
     },
     authority::AuthorityType,
@@ -42,9 +40,8 @@ use swig_state::{
 };
 
 // Constants
-const LOCALHOST: &str = "http://localhost:8899";
-const STAKE_PROGRAM_ID: SolanaPubkey = solana_sdk::stake::program::id();
-const VOTE_PROGRAM_ID: SolanaPubkey = solana_sdk::vote::program::id();
+const LOCALHOST: &str = "http://127.0.0.1:8899";
+const STAKE_PROGRAM_ID: SolanaPubkey = solana_stake_interface::program::id();
 
 // Global static validator process that will be shared across all tests
 static GLOBAL_VALIDATOR: Lazy<Mutex<ValidatorProcess>> = Lazy::new(|| {
@@ -112,11 +109,16 @@ impl TestContext {
         let payer = Keypair::new();
 
         // Try to airdrop funds to payer
-        for _ in 0..5 {
+        'airdrop: for _ in 0..5 {
             match client.request_airdrop(&payer.pubkey(), 10_000_000_000) {
                 Ok(signature) => {
-                    if let Ok(_) = client.confirm_transaction(&signature) {
-                        break;
+                    // confirm_transaction can return Ok(false) immediately without
+                    // waiting; poll the same signature until it actually confirms.
+                    for _ in 0..30 {
+                        match client.confirm_transaction(&signature) {
+                            Ok(true) => break 'airdrop,
+                            _ => thread::sleep(Duration::from_millis(500)),
+                        }
                     }
                 },
                 Err(_) => {
@@ -179,6 +181,38 @@ fn create_swig_ed25519_v2(
     Ok(swig_wallet_address)
 }
 
+/// Helper function to add a second Ed25519 authority to an existing Swig
+/// wallet, signed by the current root authority (acting_role_id 0) over RPC.
+fn add_swig_ed25519_authority_v2(
+    context: &TestContext,
+    swig_account: &SolanaPubkey,
+    root_authority: &Keypair,
+    new_authority: &SolanaPubkey,
+    actions: Vec<ClientAction>,
+) -> anyhow::Result<()> {
+    let add_ix = swig_interface::AddAuthorityInstruction::new_with_ed25519_authority(
+        *swig_account,
+        context.payer.pubkey(),
+        root_authority.pubkey(),
+        0, // acting_role_id: root
+        AuthorityConfig {
+            authority_type: AuthorityType::Ed25519,
+            authority: new_authority.as_ref(),
+        },
+        actions,
+    )?;
+
+    let recent_blockhash = context.client.get_latest_blockhash()?;
+    let transaction = Transaction::new_signed_with_payer(
+        &[add_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, root_authority],
+        recent_blockhash,
+    );
+    context.client.send_and_confirm_transaction(&transaction)?;
+    Ok(())
+}
+
 /// Helper function to sign transaction using SignV2
 fn sign_with_swig_v2(
     context: &TestContext,
@@ -212,372 +246,781 @@ fn sign_with_swig_v2(
     Ok(signature.to_string())
 }
 
+/// Helper function to sign transaction using SignV2 with an explicit role_id.
+/// Same behavior as `sign_with_swig_v2` but for non-root roles.
+fn sign_with_swig_v2_role(
+    context: &TestContext,
+    swig_account: &SolanaPubkey,
+    swig_wallet_address: &SolanaPubkey,
+    authority: &Keypair,
+    role_id: u32,
+    instruction: Instruction,
+) -> anyhow::Result<String> {
+    let sign_v2_ix = SignV2Instruction::new_ed25519(
+        *swig_account,
+        *swig_wallet_address,
+        authority.pubkey(),
+        instruction,
+        role_id,
+    )?;
+
+    let recent_blockhash = context.client.get_latest_blockhash()?;
+    let transaction = Transaction::new_signed_with_payer(
+        &[sign_v2_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, authority],
+        recent_blockhash,
+    );
+
+    let signature = context.client.send_and_confirm_transaction(&transaction)?;
+    Ok(signature.to_string())
+}
+
+/// Returns the local validator's vote account, used by delegation tests.
+fn local_vote_account(context: &TestContext) -> anyhow::Result<SolanaPubkey> {
+    let accounts = context.client.get_vote_accounts()?;
+    let vote: &RpcVoteAccountInfo = accounts
+        .current
+        .first()
+        .or_else(|| accounts.delinquent.first())
+        .ok_or_else(|| anyhow::anyhow!("no vote account on local validator"))?;
+    Ok(SolanaPubkey::from_str(&vote.vote_pubkey)?)
+}
+
+/// Blocks until the validator has advanced at least `slots` slots.
+fn wait_for_slots(context: &TestContext, slots: u64) {
+    let start = context.client.get_slot().unwrap_or(0);
+    for _ in 0..600 {
+        thread::sleep(Duration::from_millis(100));
+        if let Ok(now) = context.client.get_slot() {
+            if now >= start + slots {
+                return;
+            }
+        }
+    }
+}
+
+/// Swig's `PermissionDeniedInsufficientBalance` (3011), the error a stake limit
+/// raises when exceeded.
+const SWIG_LIMIT_EXCEEDED_ERROR: &str = "0xbc3";
+
+/// Stake program `EpochRewardsActive` (16). The local validator runs 64-slot
+/// epochs, so the rewards window is frequently active and briefly rejects stake
+/// operations. Transient — retry rather than fail.
+const STAKE_EPOCH_REWARDS_ACTIVE_ERROR: &str = "0x10";
+
+/// Retries a signing operation while it fails with the transient epoch-rewards
+/// error.
+fn retry_while_epoch_rewards_active<F>(mut attempt: F) -> anyhow::Result<String>
+where
+    F: FnMut() -> anyhow::Result<String>,
+{
+    for _ in 0..30 {
+        let result = attempt();
+        match &result {
+            Err(e) if format!("{:?}", e).contains(STAKE_EPOCH_REWARDS_ACTIVE_ERROR) => {
+                thread::sleep(Duration::from_millis(500));
+            },
+            _ => return result,
+        }
+    }
+    attempt()
+}
+
+/// Blocks until the validator crosses into a new epoch, which is when a
+/// deactivation takes effect.
+fn wait_for_epoch_change(context: &TestContext) {
+    let start = match context.client.get_epoch_info() {
+        Ok(info) => info.epoch,
+        Err(_) => return,
+    };
+    for _ in 0..900 {
+        thread::sleep(Duration::from_millis(100));
+        if let Ok(info) = context.client.get_epoch_info() {
+            if info.epoch > start {
+                return;
+            }
+        }
+    }
+}
+
+/// Creates a Swig wallet whose root role (role_id 0) holds `All`, plus a
+/// bounded second role (role_id 1) holding exactly `bounded_actions`.
+///
+/// The root role must hold `All` or `ManageAuthority` — the program rejects
+/// creation otherwise — so a genuinely capped role has to be a *second*
+/// authority. That is also the real threat model: an owner delegating a
+/// limited role to someone else.
+///
+/// Returns `(swig_account, swig_wallet_address)`.
+fn setup_bounded_role_wallet(
+    context: &TestContext,
+    root_authority: &Keypair,
+    bounded_authority: &Keypair,
+    bounded_actions: Vec<ClientAction>,
+    id: [u8; 32],
+) -> anyhow::Result<(SolanaPubkey, SolanaPubkey)> {
+    let swig_wallet_address =
+        create_swig_ed25519_v2(context, root_authority, vec![ClientAction::All(All {})], id)?;
+
+    let program_id = SolanaPubkey::from_str("swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB")?;
+    let (swig_account, _) =
+        SolanaPubkey::find_program_address(&swig_account_seeds(&id), &program_id);
+
+    add_swig_ed25519_authority_v2(
+        context,
+        &swig_account,
+        root_authority,
+        &bounded_authority.pubkey(),
+        bounded_actions,
+    )?;
+
+    Ok((swig_account, swig_wallet_address))
+}
+
+/// Creates and initializes a stake account holding `principal` lamports above
+/// rent, with `authority` as BOTH staker and withdrawer.
+///
+/// Funding real principal matters: a rent-only stake account cannot satisfy any
+/// meaningful withdrawal, so the stake program rejects it before Swig's limit
+/// logic is ever consulted, and the test proves nothing.
+fn create_initialized_stake_account(
+    context: &TestContext,
+    stake_account: &Keypair,
+    authority: &SolanaPubkey,
+    principal: u64,
+) -> anyhow::Result<()> {
+    let rent = context.client.get_minimum_balance_for_rent_exemption(200)?;
+    let create_tx = Transaction::new_signed_with_payer(
+        &[solana_system_interface::instruction::create_account(
+            &context.payer.pubkey(),
+            &stake_account.pubkey(),
+            rent + principal,
+            200,
+            &STAKE_PROGRAM_ID,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, stake_account],
+        context.client.get_latest_blockhash()?,
+    );
+    context.client.send_and_confirm_transaction(&create_tx)?;
+
+    let authorized = Authorized {
+        staker: *authority,
+        withdrawer: *authority,
+    };
+    let initialize_ix = stake_initialize(&stake_account.pubkey(), &authorized, &Lockup::default());
+    let initialize_tx = Transaction::new_signed_with_payer(
+        &[initialize_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.client.get_latest_blockhash()?,
+    );
+    context.client.send_and_confirm_transaction(&initialize_tx)?;
+    Ok(())
+}
+
+/// Withdraws `amount` from `stake_account` through SignV2 as the bounded role,
+/// returning `(result, destination_balance_delta)`.
+///
+/// Retries while the stake program reports `EpochRewardsActive`, which the
+/// local validator's 64-slot epochs trigger often. Only that specific transient
+/// error is retried, so genuine rejections still surface immediately.
+fn withdraw_through_swig(
+    context: &TestContext,
+    swig_account: &SolanaPubkey,
+    swig_wallet_address: &SolanaPubkey,
+    bounded_authority: &Keypair,
+    stake_account: &SolanaPubkey,
+    destination: &SolanaPubkey,
+    amount: u64,
+) -> (anyhow::Result<String>, u64) {
+    for _ in 0..30 {
+        let (result, delta) = withdraw_through_swig_once(
+            context,
+            swig_account,
+            swig_wallet_address,
+            bounded_authority,
+            stake_account,
+            destination,
+            amount,
+        );
+        match &result {
+            Err(e) if format!("{:?}", e).contains(STAKE_EPOCH_REWARDS_ACTIVE_ERROR) => {
+                thread::sleep(Duration::from_millis(500));
+            },
+            _ => return (result, delta),
+        }
+    }
+    withdraw_through_swig_once(
+        context,
+        swig_account,
+        swig_wallet_address,
+        bounded_authority,
+        stake_account,
+        destination,
+        amount,
+    )
+}
+
+/// Single withdrawal attempt without retry.
+fn withdraw_through_swig_once(
+    context: &TestContext,
+    swig_account: &SolanaPubkey,
+    swig_wallet_address: &SolanaPubkey,
+    bounded_authority: &Keypair,
+    stake_account: &SolanaPubkey,
+    destination: &SolanaPubkey,
+    amount: u64,
+) -> (anyhow::Result<String>, u64) {
+    let withdraw_ix = withdraw(
+        stake_account,
+        swig_wallet_address,
+        destination,
+        amount,
+        None,
+    );
+
+    let before = context.client.get_balance(destination).unwrap_or(0);
+    let result = sign_with_swig_v2_role(
+        context,
+        swig_account,
+        swig_wallet_address,
+        bounded_authority,
+        1,
+        withdraw_ix,
+    );
+    let after = context.client.get_balance(destination).unwrap_or(0);
+    (result, after.saturating_sub(before))
+}
+
+/// `StakeAll` grants uncapped stake authority, so a large withdrawal succeeds.
 #[test]
 fn test_stake_with_unlimited_permission_v2() {
     let context = TestContext::new();
-    let owner = Keypair::new();
-    let delegate = Keypair::new();
     let stake_account = Keypair::new();
-    let swig_authority = Keypair::new();
-
-    // Airdrop funds
-    for keypair in [&owner, &delegate, &swig_authority] {
-        for _ in 0..5 {
-            match context
-                .client
-                .request_airdrop(&keypair.pubkey(), 10_000_000_000)
-            {
-                Ok(signature) => {
-                    if context.client.confirm_transaction(&signature).is_ok() {
-                        break;
-                    }
-                },
-                Err(_) => thread::sleep(Duration::from_millis(500)),
-            }
-        }
-    }
-
+    let destination = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
     let id = rand::random::<[u8; 32]>();
 
-    // Create Swig account with StakeAll permission
-    let swig_wallet_address = create_swig_ed25519_v2(
+    let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
         &context,
-        &swig_authority,
-        vec![ClientAction::StakeAll(StakeAll {})],
+        &root_authority,
+        &bounded_authority,
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeAll(StakeAll {}),
+        ],
         id,
     )
-    .expect("Failed to create swig account");
+    .expect("Failed to set up bounded role wallet");
 
-    let program_id = SolanaPubkey::from_str("swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB").unwrap();
-    let (swig_account, _) =
-        SolanaPubkey::find_program_address(&swig_account_seeds(&id), &program_id);
+    create_initialized_stake_account(&context, &stake_account, &swig_wallet_address, 100_000_000)
+        .expect("Failed to create stake account");
 
-    // Create stake account
-    let rent = context
-        .client
-        .get_minimum_balance_for_rent_exemption(200)
-        .unwrap();
-    let create_tx = Transaction::new_signed_with_payer(
-        &[solana_system_interface::instruction::create_account(
-            &context.payer.pubkey(),
-            &stake_account.pubkey(),
-            rent,
-            200,
-            &STAKE_PROGRAM_ID,
-        )],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &stake_account],
-        context.client.get_latest_blockhash().unwrap(),
-    );
-    context
-        .client
-        .send_and_confirm_transaction(&create_tx)
-        .unwrap();
-
-    // Initialize stake account
-    let authorized = Authorized {
-        staker: swig_wallet_address,
-        withdrawer: owner.pubkey(),
-    };
-
-    let initialize_ix = stake_initialize(&stake_account.pubkey(), &authorized, &Lockup::default());
-
-    let initialize_tx = Transaction::new_signed_with_payer(
-        &[initialize_ix],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.client.get_latest_blockhash().unwrap(),
-    );
-    context
-        .client
-        .send_and_confirm_transaction(&initialize_tx)
-        .unwrap();
-
-    // Create delegate instruction
-    let delegate_ix = delegate_stake(
-        &stake_account.pubkey(),
-        &swig_wallet_address,
-        &delegate.pubkey(),
-    );
-
-    // Sign with Swig V2
-    let signature = sign_with_swig_v2(
+    let (result, delta) = withdraw_through_swig(
         &context,
         &swig_account,
         &swig_wallet_address,
-        &swig_authority,
-        delegate_ix,
-    )
-    .expect("Failed to sign with swig v2");
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        60_000_000,
+    );
 
-    println!("Stake delegation successful: {}", signature);
+    assert!(
+        result.is_ok(),
+        "StakeAll should permit an uncapped withdrawal, got: {:?}",
+        result.err()
+    );
+    assert_eq!(
+        delta, 60_000_000,
+        "destination should receive the full withdrawal"
+    );
 }
 
+/// `StakeLimit` caps total stake movement: within-limit succeeds, over-limit is
+/// rejected and moves no lamports.
 #[test]
 fn test_stake_with_fixed_limit_v2() {
     let context = TestContext::new();
-    let owner = Keypair::new();
-    let delegate = Keypair::new();
     let stake_account = Keypair::new();
-    let swig_authority = Keypair::new();
-
-    // Airdrop funds
-    for keypair in [&owner, &delegate, &swig_authority] {
-        for _ in 0..5 {
-            match context
-                .client
-                .request_airdrop(&keypair.pubkey(), 10_000_000_000)
-            {
-                Ok(signature) => {
-                    if context.client.confirm_transaction(&signature).is_ok() {
-                        break;
-                    }
-                },
-                Err(_) => thread::sleep(Duration::from_millis(500)),
-            }
-        }
-    }
-
+    let destination = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
     let id = rand::random::<[u8; 32]>();
 
-    // Create Swig account with StakeLimit permission
-    let swig_wallet_address = create_swig_ed25519_v2(
+    let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
         &context,
-        &swig_authority,
-        vec![ClientAction::StakeLimit(StakeLimit {
-            amount: 500_000_000,
-        })],
+        &root_authority,
+        &bounded_authority,
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeLimit(StakeLimit {
+                amount: 50_000_000,
+            }),
+        ],
         id,
     )
-    .expect("Failed to create swig account");
+    .expect("Failed to set up bounded role wallet");
 
-    let program_id = SolanaPubkey::from_str("swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB").unwrap();
-    let (swig_account, _) =
-        SolanaPubkey::find_program_address(&swig_account_seeds(&id), &program_id);
+    create_initialized_stake_account(&context, &stake_account, &swig_wallet_address, 200_000_000)
+        .expect("Failed to create stake account");
 
-    // Create stake account
-    let rent = context
-        .client
-        .get_minimum_balance_for_rent_exemption(200)
-        .unwrap();
-    let create_tx = Transaction::new_signed_with_payer(
-        &[solana_system_interface::instruction::create_account(
-            &context.payer.pubkey(),
-            &stake_account.pubkey(),
-            rent,
-            200,
-            &STAKE_PROGRAM_ID,
-        )],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &stake_account],
-        context.client.get_latest_blockhash().unwrap(),
-    );
-    context
-        .client
-        .send_and_confirm_transaction(&create_tx)
-        .unwrap();
-
-    // Initialize stake account
-    let authorized = Authorized {
-        staker: swig_wallet_address,
-        withdrawer: owner.pubkey(),
-    };
-
-    let initialize_ix = stake_initialize(&stake_account.pubkey(), &authorized, &Lockup::default());
-
-    let initialize_tx = Transaction::new_signed_with_payer(
-        &[initialize_ix],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.client.get_latest_blockhash().unwrap(),
-    );
-    context
-        .client
-        .send_and_confirm_transaction(&initialize_tx)
-        .unwrap();
-
-    // Test successful delegation within limit
-    let delegate_ix = delegate_stake(
-        &stake_account.pubkey(),
-        &swig_wallet_address,
-        &delegate.pubkey(),
-    );
-
-    let signature = sign_with_swig_v2(
+    // Within the 50_000_000 cap.
+    let (ok_result, ok_delta) = withdraw_through_swig(
         &context,
         &swig_account,
         &swig_wallet_address,
-        &swig_authority,
-        delegate_ix,
-    )
-    .expect("Failed to sign with swig v2");
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        10_000_000,
+    );
+    assert!(
+        ok_result.is_ok(),
+        "withdrawal within StakeLimit should succeed, got: {:?}",
+        ok_result.err()
+    );
+    assert_eq!(ok_delta, 10_000_000, "within-limit delta mismatch");
 
-    println!("Stake delegation within limit successful: {}", signature);
+    // 60_000_000 exceeds the 40_000_000 remaining.
+    let (err_result, err_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        60_000_000,
+    );
+    assert!(
+        err_result.is_err(),
+        "withdrawal above StakeLimit must be rejected, but it succeeded"
+    );
+    assert_eq!(
+        err_delta, 0,
+        "rejected withdrawal must not move any lamports"
+    );
 }
 
+/// A withdrawal of exactly the remaining limit is allowed; one lamport more is
+/// not. Guards the boundary condition in `StakeLimit::run`.
+#[test]
+fn test_stake_withdraw_at_exact_limit_boundary_v2() {
+    let context = TestContext::new();
+    let stake_account = Keypair::new();
+    let destination = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let limit: u64 = 25_000_000;
+    let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
+        &context,
+        &root_authority,
+        &bounded_authority,
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeLimit(StakeLimit { amount: limit }),
+        ],
+        id,
+    )
+    .expect("Failed to set up bounded role wallet");
+
+    create_initialized_stake_account(&context, &stake_account, &swig_wallet_address, 200_000_000)
+        .expect("Failed to create stake account");
+
+    // One lamport over the cap must fail.
+    let (over_result, over_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        limit + 1,
+    );
+    assert!(
+        over_result.is_err(),
+        "limit + 1 must be rejected, but it succeeded"
+    );
+    assert_eq!(over_delta, 0, "rejected withdrawal must move no lamports");
+
+    // Exactly the cap must succeed.
+    let (exact_result, exact_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        limit,
+    );
+    assert!(
+        exact_result.is_ok(),
+        "withdrawal of exactly the limit should succeed, got: {:?}",
+        exact_result.err()
+    );
+    assert_eq!(exact_delta, limit, "exact-limit delta mismatch");
+}
+
+/// `StakeRecurringLimit` caps spend per window and refills once the window
+/// elapses.
 #[test]
 fn test_stake_with_recurring_limit_v2() {
     let context = TestContext::new();
-    let owner = Keypair::new();
-    let delegate = Keypair::new();
     let stake_account = Keypair::new();
-    let swig_authority = Keypair::new();
-
-    // Airdrop funds
-    for keypair in [&owner, &delegate, &swig_authority] {
-        for _ in 0..5 {
-            match context
-                .client
-                .request_airdrop(&keypair.pubkey(), 10_000_000_000)
-            {
-                Ok(signature) => {
-                    if context.client.confirm_transaction(&signature).is_ok() {
-                        break;
-                    }
-                },
-                Err(_) => thread::sleep(Duration::from_millis(500)),
-            }
-        }
-    }
-
+    let destination = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
     let id = rand::random::<[u8; 32]>();
 
-    // Create Swig account with StakeRecurringLimit permission
-    let swig_wallet_address = create_swig_ed25519_v2(
+    let window: u64 = 20;
+    let recurring: u64 = 50_000_000;
+    let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
         &context,
-        &swig_authority,
-        vec![ClientAction::StakeRecurringLimit(StakeRecurringLimit {
-            recurring_amount: 300_000_000,
-            window: 10, // 10 slots window
-            last_reset: 0,
-            current_amount: 300_000_000,
-        })],
+        &root_authority,
+        &bounded_authority,
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeRecurringLimit(StakeRecurringLimit {
+                recurring_amount: recurring,
+                window,
+                last_reset: 0,
+                current_amount: recurring,
+            }),
+        ],
         id,
     )
-    .expect("Failed to create swig account");
+    .expect("Failed to set up bounded role wallet");
 
-    let program_id = SolanaPubkey::from_str("swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB").unwrap();
-    let (swig_account, _) =
-        SolanaPubkey::find_program_address(&swig_account_seeds(&id), &program_id);
+    create_initialized_stake_account(&context, &stake_account, &swig_wallet_address, 300_000_000)
+        .expect("Failed to create stake account");
 
-    // Create stake account
-    let rent = context
-        .client
-        .get_minimum_balance_for_rent_exemption(200)
-        .unwrap();
-    let create_tx = Transaction::new_signed_with_payer(
-        &[solana_system_interface::instruction::create_account(
-            &context.payer.pubkey(),
-            &stake_account.pubkey(),
-            rent,
-            200,
-            &STAKE_PROGRAM_ID,
-        )],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &stake_account],
-        context.client.get_latest_blockhash().unwrap(),
-    );
-    context
-        .client
-        .send_and_confirm_transaction(&create_tx)
-        .unwrap();
-
-    // Initialize stake account
-    let authorized = Authorized {
-        staker: swig_wallet_address,
-        withdrawer: owner.pubkey(),
-    };
-
-    let initialize_ix = stake_initialize(&stake_account.pubkey(), &authorized, &Lockup::default());
-
-    let initialize_tx = Transaction::new_signed_with_payer(
-        &[initialize_ix],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.client.get_latest_blockhash().unwrap(),
-    );
-    context
-        .client
-        .send_and_confirm_transaction(&initialize_tx)
-        .unwrap();
-
-    // Test first delegation within limit
-    let delegate_ix_1 = delegate_stake(
-        &stake_account.pubkey(),
-        &swig_wallet_address,
-        &delegate.pubkey(),
-    );
-
-    let signature_1 = sign_with_swig_v2(
+    // Above the per-window allowance.
+    let (over_result, over_delta) = withdraw_through_swig(
         &context,
         &swig_account,
         &swig_wallet_address,
-        &swig_authority,
-        delegate_ix_1,
-    )
-    .expect("Failed to sign with swig v2");
-
-    println!("First stake delegation successful: {}", signature_1);
-
-    // Wait for recurring limit reset
-    thread::sleep(Duration::from_secs(12));
-
-    // Test second delegation after reset
-    let delegate_ix_2 = delegate_stake(
+        &bounded_authority,
         &stake_account.pubkey(),
-        &swig_wallet_address,
-        &delegate.pubkey(),
+        &destination.pubkey(),
+        recurring + 10_000_000,
     );
+    assert!(
+        over_result.is_err(),
+        "withdrawal above the recurring allowance must be rejected"
+    );
+    assert_eq!(over_delta, 0, "rejected withdrawal must move no lamports");
 
-    let signature_2 = sign_with_swig_v2(
+    // Consume most of the window's allowance.
+    let (first_result, first_delta) = withdraw_through_swig(
         &context,
         &swig_account,
         &swig_wallet_address,
-        &swig_authority,
-        delegate_ix_2,
-    )
-    .expect("Failed to sign with swig v2");
-
-    println!(
-        "Second stake delegation after reset successful: {}",
-        signature_2
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        30_000_000,
     );
+    assert!(
+        first_result.is_ok(),
+        "first within-window withdrawal should succeed, got: {:?}",
+        first_result.err()
+    );
+    assert_eq!(first_delta, 30_000_000, "first withdrawal delta mismatch");
+
+    // Only 20_000_000 remains this window.
+    let (second_result, second_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        30_000_000,
+    );
+    assert!(
+        second_result.is_err(),
+        "second withdrawal should exhaust the window allowance and be rejected"
+    );
+    assert_eq!(second_delta, 0, "rejected withdrawal must move no lamports");
+
+    // After the window elapses the allowance refills.
+    wait_for_slots(&context, window + 5);
+    let (reset_result, reset_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        30_000_000,
+    );
+    assert!(
+        reset_result.is_ok(),
+        "withdrawal after the window resets should succeed, got: {:?}",
+        reset_result.err()
+    );
+    assert_eq!(reset_delta, 30_000_000, "post-reset delta mismatch");
 }
 
+/// Successive withdrawals accumulate against a single `StakeLimit`.
+///
+/// NOTE: this replaces a test formerly named
+/// `test_both_stake_and_unstake_affect_limit_v2`. Delegation does NOT currently
+/// count against `StakeLimit`: spend is recorded only when a stake account's
+/// lamports or delegated amount *decrease*, and delegating changes neither. The
+/// old name asserted behavior the implementation has never had.
 #[test]
-fn test_both_stake_and_unstake_affect_limit_v2() {
+fn test_cumulative_stake_withdrawals_accumulate_against_limit_v2() {
     let context = TestContext::new();
-    let owner = Keypair::new();
-    let delegate = Keypair::new();
     let stake_account = Keypair::new();
-    let swig_authority = Keypair::new();
+    let destination = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
 
-    // Airdrop funds
-    for keypair in [&owner, &delegate, &swig_authority] {
-        for _ in 0..5 {
-            match context
-                .client
-                .request_airdrop(&keypair.pubkey(), 10_000_000_000)
-            {
-                Ok(signature) => {
-                    if context.client.confirm_transaction(&signature).is_ok() {
-                        break;
-                    }
-                },
-                Err(_) => thread::sleep(Duration::from_millis(500)),
-            }
-        }
-    }
+    let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
+        &context,
+        &root_authority,
+        &bounded_authority,
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeLimit(StakeLimit {
+                amount: 50_000_000,
+            }),
+        ],
+        id,
+    )
+    .expect("Failed to set up bounded role wallet");
+
+    create_initialized_stake_account(&context, &stake_account, &swig_wallet_address, 200_000_000)
+        .expect("Failed to create stake account");
+
+    let (first_result, first_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        30_000_000,
+    );
+    assert!(
+        first_result.is_ok(),
+        "first withdrawal should succeed, got: {:?}",
+        first_result.err()
+    );
+    assert_eq!(first_delta, 30_000_000, "first withdrawal delta mismatch");
+
+    // 20_000_000 remains, so a second 30_000_000 must be refused.
+    let (second_result, second_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        30_000_000,
+    );
+    assert!(
+        second_result.is_err(),
+        "cumulative withdrawals must accumulate against StakeLimit"
+    );
+    assert_eq!(second_delta, 0, "rejected withdrawal must move no lamports");
+
+    // The remainder is still spendable.
+    let (third_result, third_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        20_000_000,
+    );
+    assert!(
+        third_result.is_ok(),
+        "withdrawal of the exact remainder should succeed, got: {:?}",
+        third_result.err()
+    );
+    assert_eq!(third_delta, 20_000_000, "remainder delta mismatch");
+}
+
+/// The limit is enforced for a stake account in the `Stake` (delegated) state
+/// and after deactivation, not just for freshly initialized accounts.
+///
+/// A withdrawal from a delegated account is refused by the stake program while
+/// the stake is active, so this delegates, deactivates, waits out the epoch,
+/// then withdraws. The principal must exceed the 1 SOL minimum delegation or
+/// the stake program rejects `DelegateStake` with error 43.
+///
+/// A within-limit withdrawal is attempted first as a control: it proves the
+/// account is genuinely withdrawable, so the subsequent rejection can only be
+/// the StakeLimit and not leftover stake activation.
+#[test]
+fn test_stake_limit_enforced_for_delegated_and_deactivated_v2() {
+    let context = TestContext::new();
+    let stake_account = Keypair::new();
+    let destination = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let vote_account = match local_vote_account(&context) {
+        Ok(v) => v,
+        Err(e) => {
+            panic!("delegation coverage requires a local vote account: {:?}", e);
+        },
+    };
+
+    let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
+        &context,
+        &root_authority,
+        &bounded_authority,
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeLimit(StakeLimit {
+                amount: 10_000_000,
+            }),
+        ],
+        id,
+    )
+    .expect("Failed to set up bounded role wallet");
+
+    // Principal must clear the 1 SOL minimum delegation.
+    let principal: u64 = 3_000_000_000;
+    create_initialized_stake_account(&context, &stake_account, &swig_wallet_address, principal)
+        .expect("Failed to create stake account");
+
+    // Delegate: moves the account into the `Stake` state.
+    let delegate_ix = delegate_stake(
+        &stake_account.pubkey(),
+        &swig_wallet_address,
+        &vote_account,
+    );
+    let delegate_result = retry_while_epoch_rewards_active(|| {
+        sign_with_swig_v2_role(
+            &context,
+            &swig_account,
+            &swig_wallet_address,
+            &bounded_authority,
+            1,
+            delegate_ix.clone(),
+        )
+    });
+    assert!(
+        delegate_result.is_ok(),
+        "delegation with Program(Stake) permission should succeed, got: {:?}",
+        delegate_result.err()
+    );
+
+    // Deactivate so the principal becomes withdrawable.
+    let deactivate_ix = deactivate_stake(&stake_account.pubkey(), &swig_wallet_address);
+    let deactivate_result = retry_while_epoch_rewards_active(|| {
+        sign_with_swig_v2_role(
+            &context,
+            &swig_account,
+            &swig_wallet_address,
+            &bounded_authority,
+            1,
+            deactivate_ix.clone(),
+        )
+    });
+    assert!(
+        deactivate_result.is_ok(),
+        "deactivation should succeed, got: {:?}",
+        deactivate_result.err()
+    );
+
+    // Deactivation only takes effect at the next epoch boundary.
+    wait_for_epoch_change(&context);
+
+    // Control: a within-limit withdrawal must succeed, proving the account is
+    // actually withdrawable. Without this, an over-limit rejection could just
+    // mean the stake was still active.
+    let (control_result, control_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        5_000_000,
+    );
+    assert!(
+        control_result.is_ok(),
+        "within-limit withdrawal from a deactivated stake account should succeed, got: {:?}",
+        control_result.err()
+    );
+    assert_eq!(control_delta, 5_000_000, "control withdrawal delta mismatch");
+
+    // Over-limit withdrawal from the same account must still be capped.
+    let (result, delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        60_000_000,
+    );
+    let err_text = format!("{:?}", result.as_ref().err());
+    assert!(
+        result.is_err(),
+        "over-limit withdrawal from a deactivated stake account must be rejected"
+    );
+    assert!(
+        err_text.contains(SWIG_LIMIT_EXCEEDED_ERROR),
+        "rejection must come from the StakeLimit ({}), not an unrelated stake error: {}",
+        SWIG_LIMIT_EXCEEDED_ERROR,
+        err_text
+    );
+    assert_eq!(delta, 0, "rejected withdrawal must move no lamports");
+}
+
+/// PoC for the reported SignV2 StakeLimit bypass.
+///
+/// SignV2 CPI-signs as the Swig *wallet* PDA (account index 1), but the stake
+/// account classifier keys `SwigStakeAccount` off `authorized_withdrawer` being
+/// the Swig *config* PDA (account index 0). A stake account whose withdrawer is
+/// the wallet PDA is therefore misclassified as `None`, the post-CPI limit
+/// branch never runs, and `StakeLimit::run()` is never reached — while the
+/// `Program(Stake)` action still authorizes the CPI.
+///
+/// This test encodes the SECURE expectation (over-limit withdraw is rejected),
+/// so it FAILS while the bug exists and PASSES once fixed.
+#[test]
+fn test_stake_withdraw_above_limit_via_wallet_pda_is_rejected_v2() {
+    let context = TestContext::new();
+    let stake_account = Keypair::new();
+    let destination = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
 
     let id = rand::random::<[u8; 32]>();
 
-    // Create Swig account with StakeLimit permission
+    // Root role (role_id 0) must hold All or ManageAuthority — a root holding
+    // only Program(Stake) + StakeLimit is rejected at creation.
     let swig_wallet_address = create_swig_ed25519_v2(
         &context,
-        &swig_authority,
-        vec![ClientAction::StakeLimit(StakeLimit {
-            amount: 1_000_000_000,
-        })],
+        &root_authority,
+        vec![ClientAction::All(All {})],
         id,
     )
     .expect("Failed to create swig account");
@@ -586,16 +1029,76 @@ fn test_both_stake_and_unstake_affect_limit_v2() {
     let (swig_account, _) =
         SolanaPubkey::find_program_address(&swig_account_seeds(&id), &program_id);
 
-    // Create stake account
+    // Bounded second role (role_id 1): stake program access + StakeLimit of
+    // 10_000_000 lamports. Deliberately NO `All`, NO `StakeAll`, NO
+    // `ManageAuthority` on this role.
+    add_swig_ed25519_authority_v2(
+        &context,
+        &swig_account,
+        &root_authority,
+        &bounded_authority.pubkey(),
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeLimit(StakeLimit {
+                amount: 10_000_000,
+            }),
+        ],
+    )
+    .expect("Failed to add bounded second authority");
+
+    // Sanity check: prove role 1's on-chain action list is exactly
+    // Program + StakeLimit (a bypass claim is meaningless otherwise).
+    let permission_name = |p: u16| -> String {
+        match p {
+            0 => "None".to_string(),
+            1 => "SolLimit".to_string(),
+            3 => "Program".to_string(),
+            7 => "All".to_string(),
+            8 => "ManageAuthority".to_string(),
+            10 => "StakeLimit".to_string(),
+            12 => "StakeAll".to_string(),
+            other => format!("Other({})", other),
+        }
+    };
+    let swig_data = context
+        .client
+        .get_account_data(&swig_account)
+        .expect("Failed to fetch swig account");
+    let swig_with_roles = SwigWithRoles::from_bytes(&swig_data).expect("Failed to parse swig");
+    let role_1 = swig_with_roles
+        .get_role(1)
+        .expect("get_role(1) failed")
+        .expect("role 1 missing");
+    let mut role_1_permissions = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < role_1.actions.len() {
+        let permission = u16::from_le_bytes(role_1.actions[cursor..cursor + 2].try_into().unwrap());
+        let boundary =
+            u32::from_le_bytes(role_1.actions[cursor + 4..cursor + 8].try_into().unwrap()) as usize;
+        role_1_permissions.push(permission);
+        println!("role 1 action: {}", permission_name(permission));
+        cursor = boundary;
+    }
+    println!("role 1 permission tags: {:?}", role_1_permissions);
+    assert_eq!(
+        role_1_permissions,
+        vec![3u16, 10u16],
+        "role 1 must hold exactly Program + StakeLimit"
+    );
+
+    // Stake account with ~100_000_000 lamports principal (plus rent)
     let rent = context
         .client
         .get_minimum_balance_for_rent_exemption(200)
         .unwrap();
+    let principal: u64 = 100_000_000;
     let create_tx = Transaction::new_signed_with_payer(
         &[solana_system_interface::instruction::create_account(
             &context.payer.pubkey(),
             &stake_account.pubkey(),
-            rent,
+            rent + principal,
             200,
             &STAKE_PROGRAM_ID,
         )],
@@ -608,14 +1111,13 @@ fn test_both_stake_and_unstake_affect_limit_v2() {
         .send_and_confirm_transaction(&create_tx)
         .unwrap();
 
-    // Initialize stake account with swig as both staker and withdrawer
+    // Authorize the swig WALLET PDA as both staker and withdrawer — the exact
+    // arrangement SignV2 signs for.
     let authorized = Authorized {
         staker: swig_wallet_address,
         withdrawer: swig_wallet_address,
     };
-
     let initialize_ix = stake_initialize(&stake_account.pubkey(), &authorized, &Lockup::default());
-
     let initialize_tx = Transaction::new_signed_with_payer(
         &[initialize_ix],
         Some(&context.payer.pubkey()),
@@ -627,50 +1129,43 @@ fn test_both_stake_and_unstake_affect_limit_v2() {
         .send_and_confirm_transaction(&initialize_tx)
         .unwrap();
 
-    // Test stake delegation
-    let delegate_ix = delegate_stake(
-        &stake_account.pubkey(),
-        &swig_wallet_address,
-        &delegate.pubkey(),
-    );
-
-    let signature_1 = sign_with_swig_v2(
-        &context,
-        &swig_account,
-        &swig_wallet_address,
-        &swig_authority,
-        delegate_ix,
-    )
-    .expect("Failed to sign stake delegation");
-
-    println!("Stake delegation successful: {}", signature_1);
-
-    // Test withdraw (this should also affect the limit)
+    // Withdraw 60_000_000 lamports = 6x the StakeLimit, leaving the source
+    // rent-exempt (rent + 40_000_000 remaining). Signed by the BOUNDED
+    // authority with role_id 1.
+    let withdraw_amount: u64 = 60_000_000;
     let withdraw_ix = withdraw(
         &stake_account.pubkey(),
         &swig_wallet_address,
-        &owner.pubkey(),
-        600_000_000,
+        &destination.pubkey(),
+        withdraw_amount,
         None,
     );
 
-    // This should fail because it would exceed the total limit when combined with
-    // the stake
-    let result = sign_with_swig_v2(
+    let dest_before = context.client.get_balance(&destination.pubkey()).unwrap_or(0);
+    let result = sign_with_swig_v2_role(
         &context,
         &swig_account,
         &swig_wallet_address,
-        &swig_authority,
+        &bounded_authority,
+        1, // role_id 1: the bounded second authority
         withdraw_ix,
     );
+    let dest_after = context.client.get_balance(&destination.pubkey()).unwrap_or(0);
+    let delta = dest_after.saturating_sub(dest_before);
 
-    // We expect this to fail due to limit exceeded
-    if result.is_ok() {
-        println!("Warning: Withdraw succeeded when it should have failed due to limit");
-    } else {
-        println!(
-            "Withdraw correctly failed due to stake limit: {:?}",
-            result.err()
-        );
-    }
+    println!("Over-limit withdraw result: {:?}", result);
+    println!(
+        "Destination balance before={} after={} delta={} lamports",
+        dest_before, dest_after, delta
+    );
+
+    // SECURE expectation: rejected by the StakeLimit. Fails today if the bypass
+    // is real; passes once the stake classifier recognizes the wallet PDA.
+    assert!(
+        result.is_err(),
+        "STAKELIMIT BYPASS: withdrew {} lamports against StakeLimit {{ amount: 10_000_000 }} \
+         (destination delta: {} lamports)",
+        withdraw_amount,
+        delta
+    );
 }

--- a/program/tests/stake_account_test_v2.rs
+++ b/program/tests/stake_account_test_v2.rs
@@ -24,9 +24,9 @@ use solana_sdk::{
 };
 use solana_stake_interface::{
     instruction::{
-        deactivate_stake, delegate_stake, initialize as stake_initialize, withdraw,
+        authorize, deactivate_stake, delegate_stake, initialize as stake_initialize, withdraw,
     },
-    state::{Authorized, Lockup},
+    state::{Authorized, Lockup, StakeAuthorize},
 };
 use swig_interface::{AuthorityConfig, ClientAction, SignV2Instruction};
 use swig_state::{
@@ -304,6 +304,10 @@ fn wait_for_slots(context: &TestContext, slots: u64) {
 /// raises when exceeded.
 const SWIG_LIMIT_EXCEEDED_ERROR: &str = "0xbc3";
 
+/// Swig's `AccountDataModifiedUnexpectedly` (43), raised when a CPI changes a
+/// protected region of a classified account.
+const SWIG_ACCOUNT_DATA_MODIFIED_ERROR: &str = "0x2b";
+
 /// Stake program `EpochRewardsActive` (16). The local validator runs 64-slot
 /// epochs, so the rewards window is frequently active and briefly rejects stake
 /// operations. Transient — retry rather than fail.
@@ -416,7 +420,9 @@ fn create_initialized_stake_account(
         &[&context.payer],
         context.client.get_latest_blockhash()?,
     );
-    context.client.send_and_confirm_transaction(&initialize_tx)?;
+    context
+        .client
+        .send_and_confirm_transaction(&initialize_tx)?;
     Ok(())
 }
 
@@ -561,9 +567,7 @@ fn test_stake_with_fixed_limit_v2() {
             ClientAction::Program(Program {
                 program_id: STAKE_PROGRAM_ID.to_bytes(),
             }),
-            ClientAction::StakeLimit(StakeLimit {
-                amount: 50_000_000,
-            }),
+            ClientAction::StakeLimit(StakeLimit { amount: 50_000_000 }),
         ],
         id,
     )
@@ -776,12 +780,6 @@ fn test_stake_with_recurring_limit_v2() {
 }
 
 /// Successive withdrawals accumulate against a single `StakeLimit`.
-///
-/// NOTE: this replaces a test formerly named
-/// `test_both_stake_and_unstake_affect_limit_v2`. Delegation does NOT currently
-/// count against `StakeLimit`: spend is recorded only when a stake account's
-/// lamports or delegated amount *decrease*, and delegating changes neither. The
-/// old name asserted behavior the implementation has never had.
 #[test]
 fn test_cumulative_stake_withdrawals_accumulate_against_limit_v2() {
     let context = TestContext::new();
@@ -799,9 +797,7 @@ fn test_cumulative_stake_withdrawals_accumulate_against_limit_v2() {
             ClientAction::Program(Program {
                 program_id: STAKE_PROGRAM_ID.to_bytes(),
             }),
-            ClientAction::StakeLimit(StakeLimit {
-                amount: 50_000_000,
-            }),
+            ClientAction::StakeLimit(StakeLimit { amount: 50_000_000 }),
         ],
         id,
     )
@@ -887,6 +883,8 @@ fn test_stake_limit_enforced_for_delegated_and_deactivated_v2() {
         },
     };
 
+    // The limit must cover the delegation itself: delegating N lamports
+    // consumes N of the limit, same as unstaking N.
     let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
         &context,
         &root_authority,
@@ -896,7 +894,7 @@ fn test_stake_limit_enforced_for_delegated_and_deactivated_v2() {
                 program_id: STAKE_PROGRAM_ID.to_bytes(),
             }),
             ClientAction::StakeLimit(StakeLimit {
-                amount: 10_000_000,
+                amount: 3_100_000_000,
             }),
         ],
         id,
@@ -909,11 +907,7 @@ fn test_stake_limit_enforced_for_delegated_and_deactivated_v2() {
         .expect("Failed to create stake account");
 
     // Delegate: moves the account into the `Stake` state.
-    let delegate_ix = delegate_stake(
-        &stake_account.pubkey(),
-        &swig_wallet_address,
-        &vote_account,
-    );
+    let delegate_ix = delegate_stake(&stake_account.pubkey(), &swig_wallet_address, &vote_account);
     let delegate_result = retry_while_epoch_rewards_active(|| {
         sign_with_swig_v2_role(
             &context,
@@ -968,9 +962,13 @@ fn test_stake_limit_enforced_for_delegated_and_deactivated_v2() {
         "within-limit withdrawal from a deactivated stake account should succeed, got: {:?}",
         control_result.err()
     );
-    assert_eq!(control_delta, 5_000_000, "control withdrawal delta mismatch");
+    assert_eq!(
+        control_delta, 5_000_000,
+        "control withdrawal delta mismatch"
+    );
 
-    // Over-limit withdrawal from the same account must still be capped.
+    // ~95_000_000 of the limit remains after the delegation and the control
+    // withdrawal, so this must be refused.
     let (result, delta) = withdraw_through_swig(
         &context,
         &swig_account,
@@ -978,7 +976,7 @@ fn test_stake_limit_enforced_for_delegated_and_deactivated_v2() {
         &bounded_authority,
         &stake_account.pubkey(),
         &destination.pubkey(),
-        60_000_000,
+        200_000_000,
     );
     let err_text = format!("{:?}", result.as_ref().err());
     assert!(
@@ -1041,9 +1039,7 @@ fn test_stake_withdraw_above_limit_via_wallet_pda_is_rejected_v2() {
             ClientAction::Program(Program {
                 program_id: STAKE_PROGRAM_ID.to_bytes(),
             }),
-            ClientAction::StakeLimit(StakeLimit {
-                amount: 10_000_000,
-            }),
+            ClientAction::StakeLimit(StakeLimit { amount: 10_000_000 }),
         ],
     )
     .expect("Failed to add bounded second authority");
@@ -1141,7 +1137,10 @@ fn test_stake_withdraw_above_limit_via_wallet_pda_is_rejected_v2() {
         None,
     );
 
-    let dest_before = context.client.get_balance(&destination.pubkey()).unwrap_or(0);
+    let dest_before = context
+        .client
+        .get_balance(&destination.pubkey())
+        .unwrap_or(0);
     let result = sign_with_swig_v2_role(
         &context,
         &swig_account,
@@ -1150,7 +1149,10 @@ fn test_stake_withdraw_above_limit_via_wallet_pda_is_rejected_v2() {
         1, // role_id 1: the bounded second authority
         withdraw_ix,
     );
-    let dest_after = context.client.get_balance(&destination.pubkey()).unwrap_or(0);
+    let dest_after = context
+        .client
+        .get_balance(&destination.pubkey())
+        .unwrap_or(0);
     let delta = dest_after.saturating_sub(dest_before);
 
     println!("Over-limit withdraw result: {:?}", result);
@@ -1168,4 +1170,316 @@ fn test_stake_withdraw_above_limit_via_wallet_pda_is_rejected_v2() {
         withdraw_amount,
         delta
     );
+}
+
+/// A delegation larger than the remaining `StakeLimit` is rejected.
+///
+/// `StakeLimit` is documented to apply to staking and unstaking alike, so a
+/// bounded role must not be able to lock up the wallet's SOL by delegating
+/// past its cap.
+#[test]
+fn test_stake_delegation_above_limit_is_rejected_v2() {
+    let context = TestContext::new();
+    let stake_account = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let vote_account = local_vote_account(&context).expect("local vote account required");
+
+    let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
+        &context,
+        &root_authority,
+        &bounded_authority,
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeLimit(StakeLimit { amount: 10_000_000 }),
+        ],
+        id,
+    )
+    .expect("Failed to set up bounded role wallet");
+
+    // 3 SOL clears the minimum delegation and dwarfs the 10_000_000 cap.
+    create_initialized_stake_account(
+        &context,
+        &stake_account,
+        &swig_wallet_address,
+        3_000_000_000,
+    )
+    .expect("Failed to create stake account");
+
+    let delegate_ix = delegate_stake(&stake_account.pubkey(), &swig_wallet_address, &vote_account);
+    let result = retry_while_epoch_rewards_active(|| {
+        sign_with_swig_v2_role(
+            &context,
+            &swig_account,
+            &swig_wallet_address,
+            &bounded_authority,
+            1,
+            delegate_ix.clone(),
+        )
+    });
+
+    let err_text = format!("{:?}", result.as_ref().err());
+    assert!(
+        result.is_err(),
+        "delegating 3 SOL under a 10_000_000 StakeLimit must be rejected"
+    );
+    assert!(
+        err_text.contains(SWIG_LIMIT_EXCEEDED_ERROR),
+        "rejection must come from the StakeLimit ({}), not an unrelated stake error: {}",
+        SWIG_LIMIT_EXCEEDED_ERROR,
+        err_text
+    );
+}
+
+/// Staking and unstaking both draw down the same `StakeLimit`.
+///
+/// Delegating N consumes N of the cap, and a later withdrawal consumes more, so
+/// the two together can exhaust a limit that either alone would fit within.
+#[test]
+fn test_both_stake_and_unstake_affect_limit_v2() {
+    let context = TestContext::new();
+    let stake_account = Keypair::new();
+    let destination = Keypair::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
+    let id = rand::random::<[u8; 32]>();
+
+    let vote_account = local_vote_account(&context).expect("local vote account required");
+
+    // Covers the 3 SOL delegation plus 50_000_000 of withdrawals.
+    let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
+        &context,
+        &root_authority,
+        &bounded_authority,
+        vec![
+            ClientAction::Program(Program {
+                program_id: STAKE_PROGRAM_ID.to_bytes(),
+            }),
+            ClientAction::StakeLimit(StakeLimit {
+                amount: 3_050_000_000,
+            }),
+        ],
+        id,
+    )
+    .expect("Failed to set up bounded role wallet");
+
+    create_initialized_stake_account(
+        &context,
+        &stake_account,
+        &swig_wallet_address,
+        3_000_000_000,
+    )
+    .expect("Failed to create stake account");
+
+    // Staking draws down the limit: 3_000_000_000 consumed, 50_000_000 left.
+    let delegate_ix = delegate_stake(&stake_account.pubkey(), &swig_wallet_address, &vote_account);
+    let delegate_result = retry_while_epoch_rewards_active(|| {
+        sign_with_swig_v2_role(
+            &context,
+            &swig_account,
+            &swig_wallet_address,
+            &bounded_authority,
+            1,
+            delegate_ix.clone(),
+        )
+    });
+    assert!(
+        delegate_result.is_ok(),
+        "delegation within the limit should succeed, got: {:?}",
+        delegate_result.err()
+    );
+
+    let deactivate_ix = deactivate_stake(&stake_account.pubkey(), &swig_wallet_address);
+    let deactivate_result = retry_while_epoch_rewards_active(|| {
+        sign_with_swig_v2_role(
+            &context,
+            &swig_account,
+            &swig_wallet_address,
+            &bounded_authority,
+            1,
+            deactivate_ix.clone(),
+        )
+    });
+    assert!(
+        deactivate_result.is_ok(),
+        "deactivation should succeed, got: {:?}",
+        deactivate_result.err()
+    );
+
+    wait_for_epoch_change(&context);
+
+    // Unstaking draws down the same limit: 30_000_000 of the 50_000_000 left.
+    let (first_result, first_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        30_000_000,
+    );
+    assert!(
+        first_result.is_ok(),
+        "withdrawal within the remaining limit should succeed, got: {:?}",
+        first_result.err()
+    );
+    assert_eq!(first_delta, 30_000_000, "first withdrawal delta mismatch");
+
+    // Only ~20_000_000 remains, so this exceeds the combined budget.
+    let (second_result, second_delta) = withdraw_through_swig(
+        &context,
+        &swig_account,
+        &swig_wallet_address,
+        &bounded_authority,
+        &stake_account.pubkey(),
+        &destination.pubkey(),
+        30_000_000,
+    );
+    let err_text = format!("{:?}", second_result.as_ref().err());
+    assert!(
+        second_result.is_err(),
+        "stake and unstake must share one budget; the combination should exceed it"
+    );
+    assert!(
+        err_text.contains(SWIG_LIMIT_EXCEEDED_ERROR),
+        "rejection must come from the StakeLimit ({}): {}",
+        SWIG_LIMIT_EXCEEDED_ERROR,
+        err_text
+    );
+    assert_eq!(second_delta, 0, "rejected withdrawal must move no lamports");
+}
+
+/// Swig's authority metadata (`12..44` staker, `44..76` withdrawer) must remain
+/// covered by the post-CPI integrity hash.
+///
+/// A bounded `Program(Stake)` role can submit a perfectly valid `Authorize`
+/// instruction — the Stake Program will happily reassign the staker or
+/// withdrawer, because the wallet PDA is the current authority and did sign.
+/// Nothing in the stake program stops it. SignV2 is the only thing standing
+/// between a delegated role and permanent takeover of the stake account, and it
+/// must detect the metadata change and roll the whole transaction back.
+///
+/// This is the test that pins the exclusion-range decision: the mutable
+/// delegation region (`0..4`, `124..200`) is excluded from the hash, but the
+/// Meta at `4..124` is not. If someone later widens the exclusion to silence a
+/// delegation failure, this test is what catches the regression.
+#[test]
+fn test_stake_authorize_change_is_rejected_and_rolled_back_v2() {
+    let context = TestContext::new();
+    let root_authority = Keypair::new();
+    let bounded_authority = Keypair::new();
+
+    // Reads the on-chain authorized staker (12..44) and withdrawer (44..76).
+    let read_authorities = |stake: &SolanaPubkey| -> (SolanaPubkey, SolanaPubkey) {
+        let data = context
+            .client
+            .get_account_data(stake)
+            .expect("failed to fetch stake account");
+        let staker = SolanaPubkey::try_from(&data[12..44]).expect("bad staker bytes");
+        let withdrawer = SolanaPubkey::try_from(&data[44..76]).expect("bad withdrawer bytes");
+        (staker, withdrawer)
+    };
+
+    for (label, authorize_kind) in [
+        ("staker (12..44)", StakeAuthorize::Staker),
+        ("withdrawer (44..76)", StakeAuthorize::Withdrawer),
+    ] {
+        let stake_account = Keypair::new();
+        let attacker = Keypair::new();
+        let id = rand::random::<[u8; 32]>();
+
+        let (swig_account, swig_wallet_address) = setup_bounded_role_wallet(
+            &context,
+            &root_authority,
+            &bounded_authority,
+            vec![
+                ClientAction::Program(Program {
+                    program_id: STAKE_PROGRAM_ID.to_bytes(),
+                }),
+                ClientAction::StakeLimit(StakeLimit { amount: 10_000_000 }),
+            ],
+            id,
+        )
+        .expect("Failed to set up bounded role wallet");
+
+        create_initialized_stake_account(
+            &context,
+            &stake_account,
+            &swig_wallet_address,
+            100_000_000,
+        )
+        .expect("Failed to create stake account");
+
+        let (staker_before, withdrawer_before) = read_authorities(&stake_account.pubkey());
+        assert_eq!(
+            staker_before, swig_wallet_address,
+            "precondition: staker should start as the wallet PDA"
+        );
+        assert_eq!(
+            withdrawer_before, swig_wallet_address,
+            "precondition: withdrawer should start as the wallet PDA"
+        );
+
+        // A valid Authorize the Stake Program itself would accept: the wallet
+        // PDA is the current authority and signs via SignV2.
+        let authorize_ix = authorize(
+            &stake_account.pubkey(),
+            &swig_wallet_address,
+            &attacker.pubkey(),
+            authorize_kind,
+            None,
+        );
+        let result = retry_while_epoch_rewards_active(|| {
+            sign_with_swig_v2_role(
+                &context,
+                &swig_account,
+                &swig_wallet_address,
+                &bounded_authority,
+                1,
+                authorize_ix.clone(),
+            )
+        });
+
+        let err_text = format!("{:?}", result.as_ref().err());
+        assert!(
+            result.is_err(),
+            "reassigning the {} via a bounded Program(Stake) role must be rejected",
+            label
+        );
+        assert!(
+            err_text.contains(SWIG_ACCOUNT_DATA_MODIFIED_ERROR),
+            "rejection must be AccountDataModifiedUnexpectedly ({}) for {}, got: {}",
+            SWIG_ACCOUNT_DATA_MODIFIED_ERROR,
+            label,
+            err_text
+        );
+
+        // The transaction rolled back: authority metadata is untouched and the
+        // attacker holds nothing.
+        let (staker_after, withdrawer_after) = read_authorities(&stake_account.pubkey());
+        assert_eq!(
+            staker_after, swig_wallet_address,
+            "staker must remain the Swig wallet PDA after the rejected {} change",
+            label
+        );
+        assert_eq!(
+            withdrawer_after, swig_wallet_address,
+            "withdrawer must remain the Swig wallet PDA after the rejected {} change",
+            label
+        );
+        assert_ne!(
+            withdrawer_after,
+            attacker.pubkey(),
+            "attacker must not hold the withdraw authority"
+        );
+        assert_ne!(
+            staker_after,
+            attacker.pubkey(),
+            "attacker must not hold the stake authority"
+        );
+    }
 }

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -71,6 +71,10 @@ pub enum AccountClassification {
         state: StakeAccountState,
         /// The staked balance
         balance: u64,
+        /// The account's lamport balance. Tracked separately from `balance`
+        /// because an undelegated stake account can be drained by a withdrawal
+        /// without its delegated stake amount ever changing.
+        lamports: u64,
         /// Amount staked/unstaked during this transaction
         spent: u64,
     },


### PR DESCRIPTION
# Correct stake account classification for stake accounts held by the Swig wallet PDA

Resolves a reported issue in how SignV2 classifies stake accounts. **This applies
only to stake accounts owned/held by the Swig wallet PDA**. That is, stake
accounts whose authorized withdrawer is the swig_wallet_address PDA. Stake
accounts held by any other authority are unaffected and their handling is
unchanged by this PR.

For that one case, the account wasn't being recognized as a Swig-held stake
account, so it never entered the post-CPI accounting path where stake limits are
applied.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anagrambuild/codesmith/swig-wallet/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787866238&installation_model_id=423339&pr_number=190&repository=anagrambuild%2Fswig-wallet&return_to=https%3A%2F%2Fgithub.com%2Fanagrambuild%2Fswig-wallet%2Fpull%2F190&signature=fd4acc73b6b3079498b3657401003351a1ee88956e9a14a7a775b6eb3280985a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->